### PR TITLE
Fix motion planner freespace example opw_kinematics include build error

### DIFF
--- a/tesseract_motion_planners/examples/chain_example.cpp
+++ b/tesseract_motion_planners/examples/chain_example.cpp
@@ -102,6 +102,8 @@ int main(int /*argc*/, char** /*argv*/)
     }
 
     ManipulatorInfo manip;
+    manip.tcp_frame = "tool0";
+    manip.working_frame = "base_link";
     manip.manipulator = "manipulator";
     manip.manipulator_ik_solver = "OPWInvKin";
 

--- a/tesseract_motion_planners/examples/freespace_example.cpp
+++ b/tesseract_motion_planners/examples/freespace_example.cpp
@@ -26,12 +26,10 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
-#include <opw_kinematics/opw_parameters.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/types.h>
 
-#include <tesseract_kinematics/opw/opw_inv_kin.h>
 #include <tesseract_kinematics/core/utils.h>
 
 #include <tesseract_environment/environment.h>

--- a/tesseract_motion_planners/examples/freespace_example.cpp
+++ b/tesseract_motion_planners/examples/freespace_example.cpp
@@ -100,6 +100,7 @@ int main(int /*argc*/, char** /*argv*/)
 
     ManipulatorInfo manip;
     manip.tcp_frame = "tool0";
+    manip.working_frame = "base_link";
     manip.manipulator = "manipulator";
     manip.manipulator_ik_solver = "OPWInvKin";
 

--- a/tesseract_motion_planners/examples/raster_example.cpp
+++ b/tesseract_motion_planners/examples/raster_example.cpp
@@ -103,6 +103,7 @@ int main(int /*argc*/, char** /*argv*/)
 
     ManipulatorInfo manip;
     manip.tcp_frame = "tool0";
+    manip.working_frame = "base_link";
     manip.manipulator = "manipulator";
     manip.manipulator_ik_solver = "OPWInvKin";
 


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

Hi maintainers, I get this error when building both tesseract and tesseract_planning `master` branch with `foxy` on `focal`.

```
<path-to>/tesseract_ws/src/tesseract_planning/tesseract_motion_planners/examples/freespace_example.cpp:29:10: fatal error: opw_kinematics/opw_parameters.h: No such file or directory
   29 | #include <opw_kinematics/opw_parameters.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [examples/CMakeFiles/tesseract_motion_planners_freespace_example.dir/build.make:63: examples/CMakeFiles/tesseract_motion_planners_freespace_example.dir/freespace_example.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:510: examples/CMakeFiles/tesseract_motion_planners_freespace_example.dir/all] Error 2
```
I managed to fix it by including the `tesseract_kinematics_opw` target. I am not sure if I should just remove the `#include` line instead.