### PR TITLE
Only check kinematics if built in debug

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
     misc-*,
     -misc-non-private-member-variables-in-classes,
+    -misc-no-recursion,
     modernize-*,
     -modernize-use-trailing-return-type,
     -modernize-use-nodiscard,
@@ -26,7 +27,8 @@ Checks: >
     -readability-braces-around-statements,
     -readability-named-parameter,
     -readability-magic-numbers,
-    -readability-isolate-declaration
+    -readability-isolate-declaration,
+    -readability-function-cognitive-complexity
 WarningsAsErrors: >
     -*,
     clang-diagnostic-*,
@@ -46,6 +48,7 @@ WarningsAsErrors: >
     -cppcoreguidelines-non-private-member-variables-in-classes,
     misc-*,
     -misc-non-private-member-variables-in-classes,
+    -misc-no-recursion,
     modernize-*,
     -modernize-use-trailing-return-type,
     -modernize-use-nodiscard,
@@ -54,7 +57,8 @@ WarningsAsErrors: >
     -readability-braces-around-statements,
     -readability-named-parameter,
     -readability-magic-numbers,
-    -readability-isolate-declaration
+    -readability-isolate-declaration,
+    -readability-function-cognitive-complexity
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none

--- a/tesseract_command_language/src/utils/utils.cpp
+++ b/tesseract_command_language/src/utils/utils.cpp
@@ -37,7 +37,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-static tesseract_planning::locateFilterFn toJointTrajectoryMoveFilter =
+static const tesseract_planning::locateFilterFn toJointTrajectoryMoveFilter =
     [](const tesseract_planning::Instruction& i,
        const tesseract_planning::CompositeInstruction& /*composite*/,
        bool parent_is_first_composite) {

--- a/tesseract_command_language/test/serialize_test.cpp
+++ b/tesseract_command_language/test/serialize_test.cpp
@@ -38,8 +38,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 using namespace tesseract_planning;
 
-bool DEBUG = false;
-
 CompositeInstruction getProgram()
 {
   CompositeInstruction program(

--- a/tesseract_command_language/test/utils_test.cpp
+++ b/tesseract_command_language/test/utils_test.cpp
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 using namespace tesseract_planning;
 
-bool DEBUG = false;
+static const bool DEBUG = false;
 
 TEST(TesseractCommandLanguageUtilsUnit, flatten)  // NOLINT
 {

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/planner_utils.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/planner_utils.h
@@ -153,10 +153,12 @@ std::shared_ptr<const ProfileType> getProfile(const std::string& ns,
   if (profile_dictionary.hasProfile<ProfileType>(ns, profile))
     return profile_dictionary.getProfile<ProfileType>(ns, profile);
 
-  CONSOLE_BRIDGE_logDebug("Profile '%s' was not found in namespace '%s'. Using default if available. Available "
+  CONSOLE_BRIDGE_logDebug("Profile '%s' was not found in namespace '%s' for type '%s'. Using default if available. "
+                          "Available "
                           "profiles:",
                           profile.c_str(),
-                          ns.c_str());
+                          ns.c_str(),
+                          typeid(ProfileType).name());
 
   if (profile_dictionary.hasProfileEntry<ProfileType>(ns))
   {

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -39,8 +39,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_environment/environment.h>
 #include <tesseract_environment/utils.h>
 
-#include <tesseract_kinematics/core/validate.h>
-
 #include <tesseract_motion_planners/descartes/descartes_motion_planner.h>
 #include <tesseract_motion_planners/descartes/profile/descartes_default_plan_profile.h>
 #include <tesseract_motion_planners/core/utils.h>
@@ -283,15 +281,6 @@ DescartesMotionPlanner<FloatType>::createProblem(const PlannerRequest& request) 
 
   prob->env_state = request.env_state;
   prob->env = request.env;
-
-  // Process instructions
-#ifndef NDEBUG
-  if (!tesseract_kinematics::checkKinematics(*(prob->manip)))
-  {
-    CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with KDL "
-                            "(TrajOpt). Did you change the URDF recently?");
-  }
-#endif
 
   std::vector<std::string> joint_names = prob->manip->getJointNames();
 

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -285,9 +285,13 @@ DescartesMotionPlanner<FloatType>::createProblem(const PlannerRequest& request) 
   prob->env = request.env;
 
   // Process instructions
+#ifndef NDEBUG
   if (!tesseract_kinematics::checkKinematics(*(prob->manip)))
+  {
     CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with KDL "
                             "(TrajOpt). Did you change the URDF recently?");
+  }
+#endif
 
   std::vector<std::string> joint_names = prob->manip->getJointNames();
 

--- a/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
@@ -34,8 +34,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_environment/utils.h>
 
-#include <tesseract_kinematics/core/validate.h>
-
 #include <tesseract_motion_planners/planner_utils.h>
 
 #include <tesseract_motion_planners/ompl/ompl_motion_planner_status_category.h>
@@ -362,13 +360,6 @@ std::vector<OMPLProblem::Ptr> OMPLMotionPlanner::createProblems(const PlannerReq
       throw std::runtime_error(error_msg);
     }
 
-#ifndef NDEBUG
-    if (!tesseract_kinematics::checkKinematics(*kin_group))
-    {
-      CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with Forward "
-                              "Kinematics. Did you change the URDF recently?");
-    }
-#endif
     manip = kin_group;
   }
   catch (...)

--- a/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
@@ -362,12 +362,13 @@ std::vector<OMPLProblem::Ptr> OMPLMotionPlanner::createProblems(const PlannerReq
       throw std::runtime_error(error_msg);
     }
 
-    // Process instructions
+#ifndef NDEBUG
     if (!tesseract_kinematics::checkKinematics(*kin_group))
     {
       CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with Forward "
                               "Kinematics. Did you change the URDF recently?");
     }
+#endif
     manip = kin_group;
   }
   catch (...)

--- a/tesseract_motion_planners/trajopt/src/trajopt_motion_planner.cpp
+++ b/tesseract_motion_planners/trajopt/src/trajopt_motion_planner.cpp
@@ -45,8 +45,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/utils/utils.h>
 
-#include <tesseract_kinematics/core/validate.h>
-
 using namespace trajopt;
 
 namespace tesseract_planning
@@ -258,13 +256,6 @@ TrajOptMotionPlanner::createProblem(const PlannerRequest& request) const
       throw std::runtime_error(error_msg);
     }
 
-#ifndef NDEBUG
-    if (!tesseract_kinematics::checkKinematics(*kin_group))
-    {
-      CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with Forward "
-                              "Kinematics. Did you change the URDF recently?");
-    }
-#endif
     pci->kin = kin_group;
   }
   catch (...)

--- a/tesseract_motion_planners/trajopt/src/trajopt_motion_planner.cpp
+++ b/tesseract_motion_planners/trajopt/src/trajopt_motion_planner.cpp
@@ -258,12 +258,13 @@ TrajOptMotionPlanner::createProblem(const PlannerRequest& request) const
       throw std::runtime_error(error_msg);
     }
 
-    // Process instructions
+#ifndef NDEBUG
     if (!tesseract_kinematics::checkKinematics(*kin_group))
     {
       CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with Forward "
                               "Kinematics. Did you change the URDF recently?");
     }
+#endif
     pci->kin = kin_group;
   }
   catch (...)

--- a/tesseract_motion_planners/trajopt_ifopt/src/trajopt_ifopt_motion_planner.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/trajopt_ifopt_motion_planner.cpp
@@ -272,12 +272,14 @@ std::shared_ptr<TrajOptIfoptProblem> TrajOptIfoptMotionPlanner::createProblem(co
       throw std::runtime_error(error_msg);
     }
 
-    // Process instructions
+#ifndef NDEBUG
     if (!tesseract_kinematics::checkKinematics(*kin_group))
     {
       CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with Forward "
                               "Kinematics. Did you change the URDF recently?");
     }
+#endif
+
     problem->manip = kin_group;
   }
   catch (...)

--- a/tesseract_motion_planners/trajopt_ifopt/src/trajopt_ifopt_motion_planner.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/trajopt_ifopt_motion_planner.cpp
@@ -42,8 +42,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/utils/utils.h>
 
-#include <tesseract_kinematics/core/validate.h>
-
 using namespace trajopt_ifopt;
 
 namespace tesseract_planning
@@ -271,14 +269,6 @@ std::shared_ptr<TrajOptIfoptProblem> TrajOptIfoptMotionPlanner::createProblem(co
       CONSOLE_BRIDGE_logError("%s", error_msg.c_str());
       throw std::runtime_error(error_msg);
     }
-
-#ifndef NDEBUG
-    if (!tesseract_kinematics::checkKinematics(*kin_group))
-    {
-      CONSOLE_BRIDGE_logError("Check Kinematics failed. This means that Inverse Kinematics does not agree with Forward "
-                              "Kinematics. Did you change the URDF recently?");
-    }
-#endif
 
     problem->manip = kin_group;
   }

--- a/tesseract_process_managers/include/tesseract_process_managers/core/default_task_namespaces.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/default_task_namespaces.h
@@ -26,6 +26,11 @@
 #ifndef TESSERACT_PROCESS_MANAGERS_DEFAULT_TASK_NAMESPACES_H
 #define TESSERACT_PROCESS_MANAGERS_DEFAULT_TASK_NAMESPACES_H
 
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <string>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
 #include <tesseract_motion_planners/default_planner_namespaces.h>
 
 namespace tesseract_planning::profile_ns

--- a/tesseract_process_managers/src/taskflow_generators/raster_global_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/raster_global_taskflow.cpp
@@ -92,7 +92,7 @@ TaskflowContainer RasterGlobalTaskflow::generateTaskflow(TaskInput input,
     TaskInput raster_input = input[idx];
 
     // Set the start instruction
-    auto& pre_raster_composite = pre_raster_input.getInstruction()->as<CompositeInstruction>();
+    const auto& pre_raster_composite = pre_raster_input.getInstruction()->as<CompositeInstruction>();
     PlanInstruction lpi = *getLastPlanInstruction(pre_raster_composite);
     lpi.setPlanType(PlanInstructionType::START);
     raster_input.setStartInstruction(lpi);

--- a/tesseract_process_managers/src/taskflow_generators/raster_global_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/raster_global_taskflow.cpp
@@ -88,9 +88,15 @@ TaskflowContainer RasterGlobalTaskflow::generateTaskflow(TaskInput input,
   std::size_t raster_idx = 0;
   for (std::size_t idx = 1; idx < input.size() - 1; idx += 2)
   {
+    TaskInput pre_raster_input = input[idx - 1];
     TaskInput raster_input = input[idx];
-    raster_input.setStartInstruction(std::vector<std::size_t>({ idx - 1 }));
-    raster_input.setEndInstruction(std::vector<std::size_t>({ idx + 1 }));
+
+    // Set the start instruction
+    auto& pre_raster_composite = pre_raster_input.getInstruction()->as<CompositeInstruction>();
+    PlanInstruction lpi = *getLastPlanInstruction(pre_raster_composite);
+    lpi.setPlanType(PlanInstructionType::START);
+    raster_input.setStartInstruction(lpi);
+
     TaskflowContainer sub_container = raster_taskflow_generator_->generateTaskflow(
         raster_input,
         [=]() { successTask(input, name_, raster_input.getInstruction()->getDescription(), done_cb); },

--- a/tesseract_process_managers/src/taskflow_generators/raster_only_global_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/raster_only_global_taskflow.cpp
@@ -94,7 +94,7 @@ TaskflowContainer RasterOnlyGlobalTaskflow::generateTaskflow(TaskInput input,
     else
     {
       TaskInput pre_raster_input = input[idx - 1];
-      auto& pre_raster_composite = pre_raster_input.getInstruction()->as<CompositeInstruction>();
+      const auto& pre_raster_composite = pre_raster_input.getInstruction()->as<CompositeInstruction>();
       PlanInstruction lpi = *getLastPlanInstruction(pre_raster_composite);
       lpi.setPlanType(PlanInstructionType::START);
       raster_input.setStartInstruction(lpi);

--- a/tesseract_process_managers/src/taskflow_generators/raster_only_global_taskflow.cpp
+++ b/tesseract_process_managers/src/taskflow_generators/raster_only_global_taskflow.cpp
@@ -88,12 +88,17 @@ TaskflowContainer RasterOnlyGlobalTaskflow::generateTaskflow(TaskInput input,
   {
     TaskInput raster_input = input[idx];
     if (idx == 0)
+    {
       raster_input.setStartInstruction(input_instruction->as<CompositeInstruction>().getStartInstruction());
+    }
     else
-      raster_input.setStartInstruction(std::vector<std::size_t>({ idx - 1 }));
-
-    if (idx < (input.size() - 1))
-      raster_input.setEndInstruction(std::vector<std::size_t>({ idx + 1 }));
+    {
+      TaskInput pre_raster_input = input[idx - 1];
+      auto& pre_raster_composite = pre_raster_input.getInstruction()->as<CompositeInstruction>();
+      PlanInstruction lpi = *getLastPlanInstruction(pre_raster_composite);
+      lpi.setPlanType(PlanInstructionType::START);
+      raster_input.setStartInstruction(lpi);
+    }
 
     TaskflowContainer sub_container = raster_taskflow_generator_->generateTaskflow(
         raster_input,

--- a/tesseract_time_parameterization/src/instructions_trajectory.cpp
+++ b/tesseract_time_parameterization/src/instructions_trajectory.cpp
@@ -31,7 +31,7 @@
 
 namespace tesseract_planning
 {
-static flattenFilterFn programFlattenMoveInstructionFilter =
+static const flattenFilterFn programFlattenMoveInstructionFilter =
     [](const Instruction& i, const CompositeInstruction& /*composite*/, bool parent_is_first_composite) {
       if (isMoveInstruction(i))
       {

--- a/tesseract_time_parameterization/src/time_optimal_trajectory_generation.cpp
+++ b/tesseract_time_parameterization/src/time_optimal_trajectory_generation.cpp
@@ -53,7 +53,7 @@ constexpr double EPS = 0.000001;
 
 namespace tesseract_planning
 {
-static flattenFilterFn programFlattenMoveInstructionFilter =
+static const flattenFilterFn programFlattenMoveInstructionFilter =
     [](const Instruction& i, const CompositeInstruction& /*composite*/, bool parent_is_first_composite) {
       if (isMoveInstruction(i))
       {


### PR DESCRIPTION
This also includes a fix for the process planners that perform a global plan first. It would hard code the raster start and end position to the results of the global plan even if they were cartesian waypoints. This fixes it such that the start and end position are based on the input instruction so if it is a cartesian waypoint it is still able to improve the results during the raster planning.