### PR TITLE
Revised Planner Profile Interfaces

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/profile_dictionary.h
+++ b/tesseract_command_language/include/tesseract_command_language/profile_dictionary.h
@@ -29,6 +29,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <any>
+#include <boost/serialization/serialization.hpp>
 #include <iostream>
 #include <typeindex>
 #include <unordered_map>
@@ -36,15 +37,20 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <shared_mutex>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_command_language/composite_instruction.h>
-#include <tesseract_environment/environment.h>
-
 #ifdef SWIG
 %shared_ptr(tesseract_planning::ProfileDictionary)
 #endif  // SWIG
 
+namespace tesseract_environment
+{
+class Environment;
+}
+
 namespace tesseract_planning
 {
+class Instruction;
+class CompositeInstruction;
+
 /**
  * @brief Struct to produce a planner-specific planning profile to apply to a single waypoint.
  * @details Examples of waypoint profiles might include costs/constraints for a waypoint or a waypoint sampler
@@ -63,7 +69,7 @@ public:
 
   virtual ~WaypointProfile() = default;
 
-  virtual std::any create(const Instruction& instruction, tesseract_environment::Environment::ConstPtr env) const = 0;
+  virtual std::any create(const Instruction& instruction, const tesseract_environment::Environment& env) const = 0;
 
 private:
   friend class boost::serialization::access;
@@ -92,7 +98,7 @@ public:
 
   virtual ~CompositeProfile() = default;
   virtual std::any create(const CompositeInstruction& instruction,
-                          tesseract_environment::Environment::ConstPtr env) const = 0;
+                          const tesseract_environment::Environment& env) const = 0;
 
 private:
   friend class boost::serialization::access;

--- a/tesseract_motion_planners/test/profile_dictionary_tests.cpp
+++ b/tesseract_motion_planners/test/profile_dictionary_tests.cpp
@@ -28,6 +28,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_command_language/composite_instruction.h>
+#include <tesseract_environment/environment.h>
 #include <tesseract_command_language/profile_dictionary.h>
 
 struct ProfileBase


### PR DESCRIPTION
This PR provides new interfaces for motion planner waypoint, composite, and planner level profiles. Each profile produces a type-erased, planner-specific data object from a relevant input (an instruction for the waypoint profile, a composite instruction for the composite profile). The individual planners can look up profiles in the profile dictionary by a combination of namespace and name, and can cast them to the required type. Since the objects returned by the profiles are `std::any` type-erasers, any issues with incorrect casts will result in an exception that can be handled.

The addition of new planner profile interfaces supports an on-going larger refactor and simplification of the various motion planners class (started in #138). Additionally, the new profiles will be easier to store and retrieve in the profile dictionary since they will no longer be stored by class `typeid`.

This PR adds three new maps in the profile dictionary to hold these waypoints. Currently these maps are public members of the profile dictionary for convenience and to minimize API breakage. As motion planners are refactored to use these profile interfaces, the planners will retrieve profiles from these maps. Ultimately, the map storing profiles by `typeid` will be removed, the three maps holding the new profiles will be made private, and the existing profile dictionary API will be revised to access the new profile maps.