### PR TITLE
Instruction Start State Update

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/utils/get_instruction_utils.h
+++ b/tesseract_command_language/include/tesseract_command_language/utils/get_instruction_utils.h
@@ -35,6 +35,7 @@ namespace tesseract_planning
 {
 /**
  * @brief Get the first Instruction in a Composite Instruction that is identified by the filter
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @param locate_filter The filter to indicate if an instruction should be considered
  * @param process_child_composites Indicate if child Composite Instructions should be searched
@@ -46,6 +47,7 @@ const Instruction* getFirstInstruction(const CompositeInstruction& composite_ins
 
 /**
  * @brief Get the first Instruction in a Composite Instruction that is identified by the filter
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @param locate_filter The filter to indicate if an instruction should be considered
  * @param process_child_composites Indicate if child Composite Instructions should be searched
@@ -57,6 +59,7 @@ Instruction* getFirstInstruction(CompositeInstruction& composite_instruction,
 
 /**
  * @brief Get the last Instruction in a Composite Instruction that is identified by the filter
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @param locate_filter The filter to indicate if an instruction should be considered
  * @param process_child_composites Indicate if child Composite Instructions should be searched
@@ -68,6 +71,7 @@ const Instruction* getLastInstruction(const CompositeInstruction& composite_inst
 
 /**
  * @brief Get the last Instruction in a Composite Instruction that is identified by the filter
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @param locate_filter The filter to indicate if an instruction should be considered
  * @param process_child_composites Indicate if child Composite Instructions should be searched
@@ -79,7 +83,7 @@ Instruction* getLastInstruction(CompositeInstruction& composite_instruction,
 
 /**
  * @brief Get the first Move Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The first Move Instruction (Non-Const)
  */
@@ -94,7 +98,7 @@ inline MoveInstruction* getFirstMoveInstruction(CompositeInstruction& composite_
 
 /**
  * @brief Get the first Move Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The first Move Instruction (Const)
  */
@@ -109,7 +113,7 @@ inline const MoveInstruction* getFirstMoveInstruction(const CompositeInstruction
 
 /**
  * @brief Get the first Plan Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The first Plan Instruction (Non-Const)
  */
@@ -124,7 +128,7 @@ inline PlanInstruction* getFirstPlanInstruction(CompositeInstruction& composite_
 
 /**
  * @brief Get the first Plan Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The first Plan Instruction (Const)
  */
@@ -139,7 +143,7 @@ inline const PlanInstruction* getFirstPlanInstruction(const CompositeInstruction
 
 /**
  * @brief Get the last Move Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The last Move Instruction (Non-Const)
  */
@@ -154,7 +158,7 @@ inline MoveInstruction* getLastMoveInstruction(CompositeInstruction& composite_i
 
 /**
  * @brief Get the last Move Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The last Move Instruction (Const)
  */
@@ -169,7 +173,7 @@ inline const MoveInstruction* getLastMoveInstruction(const CompositeInstruction&
 
 /**
  * @brief Get the last Plan Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The last Plan Instruction (Non-Const)
  */
@@ -184,7 +188,7 @@ inline PlanInstruction* getLastPlanInstruction(CompositeInstruction& composite_i
 
 /**
  * @brief Get the last Plan Instruction in a Composite Instruction
- * This does not consider the start instruction in child composite instruction
+ * @detials This does not consider the start instruction of nested composite instructions
  * @param composite_instruction Composite Instruction to search
  * @return The last Plan Instruction (Const)
  */
@@ -199,6 +203,7 @@ inline const PlanInstruction* getLastPlanInstruction(const CompositeInstruction&
 
 /**
  * @brief Get number of Instruction in a Composite Instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction The Composite Instruction to process
  * @param locate_filter The filter to indicate if an instruction should be considered
  * @param process_child_composites Indicate if child Composite Instructions should be searched
@@ -210,7 +215,7 @@ long getInstructionCount(const CompositeInstruction& composite_instruction,
 
 /**
  * @brief Get number of Move Instruction in a Composite Instruction
- * This does not consider the start instruction in the child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction The Composite Instruction to process
  * @return The number of Move Instructions
  */
@@ -221,7 +226,7 @@ inline long getMoveInstructionCount(const CompositeInstruction& composite_instru
 
 /**
  * @brief Get number of Plan Instruction in a Composite Instruction
- * This does not consider the start instruction in the child composite instruction
+ * @details This does not consider the start instruction of nested composite instructions
  * @param composite_instruction The Composite Instruction to process
  * @return The number of Plan Instructions
  */

--- a/tesseract_command_language/src/utils/flatten_utils.cpp
+++ b/tesseract_command_language/src/utils/flatten_utils.cpp
@@ -49,7 +49,7 @@ void flattenHelper(std::vector<std::reference_wrapper<Instruction>>& flattened,
                    const flattenFilterFn& filter,
                    bool first_composite)
 {
-  if (composite.hasStartInstruction())
+  if (composite.hasStartInstruction() && first_composite)
     if (!filter || filter(composite.getStartInstruction(), composite, first_composite))
       flattened.emplace_back(composite.getStartInstruction());
 
@@ -92,7 +92,7 @@ void flattenHelper(std::vector<std::reference_wrapper<const Instruction>>& flatt
                    const flattenFilterFn& filter,
                    bool first_composite)
 {
-  if (composite.hasStartInstruction())
+  if (composite.hasStartInstruction() && first_composite)
     if (!filter || filter(composite.getStartInstruction(), composite, first_composite))
       flattened.emplace_back(composite.getStartInstruction());
 
@@ -143,7 +143,7 @@ void flattenToPatternHelper(std::vector<std::reference_wrapper<Instruction>>& fl
     return;
   }
 
-  if (composite.hasStartInstruction())
+  if (composite.hasStartInstruction() && first_composite)
     if (!filter || filter(composite.getStartInstruction(), composite, first_composite))
       flattened.emplace_back(composite.getStartInstruction());
 
@@ -196,7 +196,7 @@ void flattenToPatternHelper(std::vector<std::reference_wrapper<const Instruction
     return;
   }
 
-  if (composite.hasStartInstruction())
+  if (composite.hasStartInstruction() && first_composite)
     if (!filter || filter(composite.getStartInstruction(), composite, first_composite))
       flattened.emplace_back(composite.getStartInstruction());
 

--- a/tesseract_command_language/src/utils/get_instruction_utils.cpp
+++ b/tesseract_command_language/src/utils/get_instruction_utils.cpp
@@ -42,7 +42,7 @@ const Instruction* getFirstInstructionHelper(const CompositeInstruction& composi
                                              bool process_child_composites,
                                              bool first_composite)
 {
-  if (composite_instruction.hasStartInstruction())
+  if (composite_instruction.hasStartInstruction() && first_composite)
     if (!locate_filter ||
         locate_filter(composite_instruction.getStartInstruction(), composite_instruction, first_composite))
       return &(composite_instruction.getStartInstruction());
@@ -78,7 +78,7 @@ Instruction* getFirstInstructionHelper(CompositeInstruction& composite_instructi
                                        bool process_child_composites,
                                        bool first_composite)
 {
-  if (composite_instruction.hasStartInstruction())
+  if (composite_instruction.hasStartInstruction() && first_composite)
     if (!locate_filter ||
         locate_filter(composite_instruction.getStartInstruction(), composite_instruction, first_composite))
       return &(composite_instruction.getStartInstruction());
@@ -197,7 +197,7 @@ long getInstructionCountHelper(const CompositeInstruction& composite_instruction
                                bool first_composite)
 {
   long cnt = 0;
-  if (composite_instruction.hasStartInstruction())
+  if (composite_instruction.hasStartInstruction() && first_composite)
     if (!locate_filter ||
         locate_filter(composite_instruction.getStartInstruction(), composite_instruction, first_composite))
       ++cnt;

--- a/tesseract_motion_planners/core/src/simple/profile/simple_planner_utils.cpp
+++ b/tesseract_motion_planners/core/src/simple/profile/simple_planner_utils.cpp
@@ -163,15 +163,20 @@ CompositeInstruction getInterpolatedComposite(const std::vector<std::string>& jo
   // Get move type base on base instruction type
   MoveInstructionType move_type = getMoveInstructionType(base_instruction);
 
+  auto create_move_inst = [&](const Eigen::Index idx) -> MoveInstruction {
+    MoveInstruction inst(StateWaypoint(joint_names, states.col(idx)), move_type);
+    inst.setManipulatorInfo(base_instruction.getManipulatorInfo());
+    inst.setDescription(base_instruction.getDescription());
+    inst.setProfile(base_instruction.getProfile());
+    inst.profile_overrides = base_instruction.profile_overrides;
+    return inst;
+  };
+
   // Convert to MoveInstructions
+  composite.setStartInstruction(create_move_inst(0));
   for (long i = 1; i < states.cols(); ++i)
   {
-    MoveInstruction move_instruction(StateWaypoint(joint_names, states.col(i)), move_type);
-    move_instruction.setManipulatorInfo(base_instruction.getManipulatorInfo());
-    move_instruction.setDescription(base_instruction.getDescription());
-    move_instruction.setProfile(base_instruction.getProfile());
-    move_instruction.profile_overrides = base_instruction.profile_overrides;
-    composite.push_back(move_instruction);
+    composite.push_back(create_move_inst(i));
   }
 
   return composite;


### PR DESCRIPTION
Currently the start state of most composite instructions (especially nested composite instructions) are never changed from `NullInstructions`. The reason for this is that usually the start instruction of one composite usually duplicates the last instruction of the previous composite, such as in the case of a robot trajectory. To avoid duplicating waypoints, the start instructions of most subsequent composites are left empty. However, this can be problematic when trying to use a nested composite instruction as a seed for another instruction or when using the composite instruction on its own. It also makes the composite instruction confusing to interpret since it is missing its first waypoint.

This PR updates the instruction `flatten` functions to ignore start instructions from composites that are not the first in a container. This retains the current behavior for the assembly of trajectories from nested composite instructions. This PR also changes the simple planner utility `getInterpolatedComposite` to put the first state of the interpolation as the start instruction of the composite, such that the entire interpolation is captured in the composite instruction.

This change is required for the OMPL planner refactor in #138 