### PR TITLE
Add path profile to plan and move instruction and modify simple plan profile interface

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/core/instruction.h>
 #include <tesseract_command_language/core/waypoint.h>
 #include <tesseract_command_language/null_waypoint.h>
+#include <tesseract_command_language/plan_instruction.h>
 #include <tesseract_command_language/constants.h>
 #include <tesseract_command_language/profile_dictionary.h>
 #include <tesseract_command_language/types.h>
@@ -53,10 +54,42 @@ class MoveInstruction
 {
 public:
   MoveInstruction() = default;  // Required for boost serialization do not use
+
+  /**
+   * @brief Plan Instruction Constructor
+   * @details This constructor automatically assigns the transition profile based on the type of motion.
+   * If the motion is LINEAR/CIRCULAR it assigns the transition_profile to the defined profile.
+   * If the motion is FREESPACE/START it is left empty.
+   * @param waypoint The waypoint associated with the instruction
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param profile The waypoint profile.
+   * @param manipulator_info Then manipulator information
+   */
   MoveInstruction(Waypoint waypoint,
                   MoveInstructionType type,
                   std::string profile = DEFAULT_PROFILE_KEY,
                   ManipulatorInfo manipulator_info = ManipulatorInfo());
+
+  /**
+   * @brief Move Instruction Constructor
+   * @param waypoint The waypoint associated with the instruction
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param profile The waypoint profile.
+   * @param path_profile The waypoint path profile.
+   * @param manipulator_info Then manipulator information
+   */
+  MoveInstruction(Waypoint waypoint,
+                  MoveInstructionType type,
+                  std::string profile,
+                  std::string path_profile,
+                  ManipulatorInfo manipulator_info = ManipulatorInfo());
+
+  /**
+   * @brief Create a move instruction using properties of the plan_instruction
+   * @param waypoint The waypoint associated with the instruction
+   * @param plan_instruction The plan instruction to copy data from
+   */
+  MoveInstruction(Waypoint waypoint, const PlanInstruction& plan_instruction);
 
   void setWaypoint(Waypoint waypoint);
   Waypoint& getWaypoint();
@@ -68,6 +101,9 @@ public:
 
   void setProfile(const std::string& profile);
   const std::string& getProfile() const;
+
+  void setPathProfile(const std::string& profile);
+  const std::string& getPathProfile() const;
 
   /** @brief Dictionary of profiles that will override named profiles for a specific task*/
   ProfileDictionary::Ptr profile_overrides;
@@ -99,6 +135,9 @@ private:
 
   /** @brief The profile used for this move instruction */
   std::string profile_{ DEFAULT_PROFILE_KEY };
+
+  /** @brief The profile used for the path to this move instruction */
+  std::string path_profile_;
 
   /** @brief The assigned waypoint (Cartesian or Joint) */
   Waypoint waypoint_{ NullWaypoint() };

--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -50,6 +50,16 @@ enum class MoveInstructionType : int
   START = 3 /**< This indicates it is a start instruction. */
 };
 
+/**
+ * @brief The move instruction is used when defining the results of a motion planning request
+ * @details
+ * This instruction contains two profiles 'profile' and 'path_profile' which are similar to industrial robots
+ * termination type and Motion Options.
+ *   - profile (Termination Type): is used to define a set of costs/constraints associated only with the waypoint
+ * assigned to this instruction
+ *   - path_profile (Motion Options): is used to define a set of costs/constraints associated only with the path taken
+ * to the waypoint assigned to this instruction
+ */
 class MoveInstruction
 {
 public:
@@ -57,12 +67,12 @@ public:
 
   /**
    * @brief Move Instruction Constructor
-   * @details This constructor automatically assigns the path profile based on the type of motion.
-   * If the motion is LINEAR/CIRCULAR it assigns the path_profile to the defined profile.
-   * If the motion is FREESPACE/START it is left empty.
+   * @details This constructor automatically assigns the path profile which is only associated to the path taken to the
+   * waypoint. If the motion is LINEAR/CIRCULAR it assigns the profile to the defined profile. If the motion is
+   * FREESPACE/START it is left empty.
    * @param waypoint The waypoint associated with the instruction
    * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
-   * @param profile The waypoint profile.
+   * @param profile The waypoint profile, which is only associated to the waypoint and not the path taken.
    * @param manipulator_info Then manipulator information
    */
   MoveInstruction(Waypoint waypoint,
@@ -74,8 +84,8 @@ public:
    * @brief Move Instruction Constructor
    * @param waypoint The waypoint associated with the instruction
    * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
-   * @param profile The waypoint profile.
-   * @param path_profile The waypoint path profile.
+   * @param profile The waypoint profile, which is only associated to the waypoint and not the path taken.
+   * @param path_profile The waypoint path profile which is only associated to the path taken to the waypoint.
    * @param manipulator_info Then manipulator information
    */
   MoveInstruction(Waypoint waypoint,

--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -56,12 +56,12 @@ public:
   MoveInstruction() = default;  // Required for boost serialization do not use
 
   /**
-   * @brief Plan Instruction Constructor
-   * @details This constructor automatically assigns the transition profile based on the type of motion.
-   * If the motion is LINEAR/CIRCULAR it assigns the transition_profile to the defined profile.
+   * @brief Move Instruction Constructor
+   * @details This constructor automatically assigns the path profile based on the type of motion.
+   * If the motion is LINEAR/CIRCULAR it assigns the path_profile to the defined profile.
    * If the motion is FREESPACE/START it is left empty.
    * @param waypoint The waypoint associated with the instruction
-   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
    * @param profile The waypoint profile.
    * @param manipulator_info Then manipulator information
    */
@@ -73,7 +73,7 @@ public:
   /**
    * @brief Move Instruction Constructor
    * @param waypoint The waypoint associated with the instruction
-   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
    * @param profile The waypoint profile.
    * @param path_profile The waypoint path profile.
    * @param manipulator_info Then manipulator information

--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -131,7 +131,7 @@ public:
 
 private:
   MoveInstructionType move_type_{ MoveInstructionType::START };
-  std::string description_;
+  std::string description_{ "Tesseract Move Instruction" };
 
   /** @brief The profile used for this move instruction */
   std::string profile_{ DEFAULT_PROFILE_KEY };

--- a/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
@@ -62,11 +62,11 @@ public:
 
   /**
    * @brief Plan Instruction Constructor
-   * @details This constructor automatically assigns the transition profile based on the type of motion.
-   * If the motion is LINEAR/CIRCULAR it assigns the transition_profile to the defined profile.
+   * @details This constructor automatically assigns the path profile based on the type of motion.
+   * If the motion is LINEAR/CIRCULAR it assigns the profile to the defined profile.
    * If the motion is FREESPACE/START it is left empty.
    * @param waypoint The waypoint associated with the instruction
-   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
    * @param profile The waypoint profile.
    * @param manipulator_info Then manipulator information
    */
@@ -78,7 +78,7 @@ public:
   /**
    * @brief Plan Instruction Constructor
    * @param waypoint The waypoint associated with the instruction
-   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
    * @param profile The waypoint profile.
    * @param path_profile The waypoint path profile.
    * @param manipulator_info Then manipulator information

--- a/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
@@ -52,8 +52,12 @@ enum class PlanInstructionType : int
 /**
  * @brief The plan instruction is used when generating motion planning requests
  * @details
- * The profile is used to define a set of costs/constraints on the waypoint
- * The path profile is used to define a set of costs/constraints on the transition waypoints to this waypoint
+ * This instruction contains two profiles 'profile' and 'path_profile' which are similar to industrial robots
+ * termination type and Motion Options.
+ *   - profile (Termination Type): is used to define a set of costs/constraints associated only with the waypoint
+ * assigned to this instruction
+ *   - path_profile (Motion Options): is used to define a set of costs/constraints associated only with the path taken
+ * to the waypoint assigned to this instruction
  */
 class PlanInstruction
 {
@@ -62,12 +66,12 @@ public:
 
   /**
    * @brief Plan Instruction Constructor
-   * @details This constructor automatically assigns the path profile based on the type of motion.
-   * If the motion is LINEAR/CIRCULAR it assigns the profile to the defined profile.
-   * If the motion is FREESPACE/START it is left empty.
+   * @details This constructor automatically assigns the path profile which is only associated to the path taken to the
+   * waypoint. If the motion is LINEAR/CIRCULAR it assigns the profile to the defined profile. If the motion is
+   * FREESPACE/START it is left empty.
    * @param waypoint The waypoint associated with the instruction
    * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
-   * @param profile The waypoint profile.
+   * @param profile The waypoint profile, which is only associated to the waypoint and not the path taken.
    * @param manipulator_info Then manipulator information
    */
   PlanInstruction(Waypoint waypoint,
@@ -79,8 +83,8 @@ public:
    * @brief Plan Instruction Constructor
    * @param waypoint The waypoint associated with the instruction
    * @param type The type of instruction (LINEAR, FREESPACE, CIRCULAR, START)
-   * @param profile The waypoint profile.
-   * @param path_profile The waypoint path profile.
+   * @param profile The waypoint profile, which is only associated to the waypoint and not the path taken.
+   * @param path_profile The waypoint path profile which is only associated to the path taken to the waypoint.
    * @param manipulator_info Then manipulator information
    */
   PlanInstruction(Waypoint waypoint,

--- a/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
@@ -49,13 +49,44 @@ enum class PlanInstructionType : int
   START = 3
 };
 
+/**
+ * @brief The plan instruction is used when generating motion planning requests
+ * @details
+ * The profile is used to define a set of costs/constraints on the waypoint
+ * The path profile is used to define a set of costs/constraints on the transition waypoints to this waypoint
+ */
 class PlanInstruction
 {
 public:
   PlanInstruction() = default;  // Required for boost serialization do not use
+
+  /**
+   * @brief Plan Instruction Constructor
+   * @details This constructor automatically assigns the transition profile based on the type of motion.
+   * If the motion is LINEAR/CIRCULAR it assigns the transition_profile to the defined profile.
+   * If the motion is FREESPACE/START it is left empty.
+   * @param waypoint The waypoint associated with the instruction
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param profile The waypoint profile.
+   * @param manipulator_info Then manipulator information
+   */
   PlanInstruction(Waypoint waypoint,
                   PlanInstructionType type,
                   std::string profile = DEFAULT_PROFILE_KEY,
+                  ManipulatorInfo manipulator_info = ManipulatorInfo());
+
+  /**
+   * @brief Plan Instruction Constructor
+   * @param waypoint The waypoint associated with the instruction
+   * @param type The type of instruction (LINEAR, FREESPACE, CIRGULAR, START)
+   * @param profile The waypoint profile.
+   * @param path_profile The waypoint path profile.
+   * @param manipulator_info Then manipulator information
+   */
+  PlanInstruction(Waypoint waypoint,
+                  PlanInstructionType type,
+                  std::string profile,
+                  std::string path_profile,
                   ManipulatorInfo manipulator_info = ManipulatorInfo());
 
   void setWaypoint(Waypoint waypoint);
@@ -68,6 +99,9 @@ public:
 
   void setProfile(const std::string& profile);
   const std::string& getProfile() const;
+
+  void setPathProfile(const std::string& profile);
+  const std::string& getPathProfile() const;
 
   /** @brief Dictionary of profiles that will override named profiles for a specific task*/
   ProfileDictionary::Ptr profile_overrides;
@@ -101,6 +135,9 @@ private:
 
   /** @brief The profile used for this plan instruction */
   std::string profile_{ DEFAULT_PROFILE_KEY };
+
+  /** @brief The profile used for the path to this plan instruction */
+  std::string path_profile_;
 
   /** @brief Contains information about the manipulator associated with this instruction*/
   ManipulatorInfo manipulator_info_;

--- a/tesseract_command_language/src/move_instruction.cpp
+++ b/tesseract_command_language/src/move_instruction.cpp
@@ -45,6 +45,9 @@ MoveInstruction::MoveInstruction(Waypoint waypoint,
   , waypoint_(std::move(waypoint))
   , manipulator_info_(std::move(manipulator_info))
 {
+  if (move_type_ == MoveInstructionType::LINEAR || move_type_ == MoveInstructionType::CIRCULAR)
+    path_profile_ = profile_;
+
   if (!isStateWaypoint(waypoint_))
     CONSOLE_BRIDGE_logWarn("MoveInstruction usually expects to be provided a State Waypoint!");
 }
@@ -60,11 +63,16 @@ MoveInstruction::MoveInstruction(Waypoint waypoint,
   , waypoint_(std::move(waypoint))
   , manipulator_info_(std::move(manipulator_info))
 {
+  if (!isStateWaypoint(waypoint_))
+    CONSOLE_BRIDGE_logWarn("MoveInstruction usually expects to be provided a State Waypoint!");
 }
 
 MoveInstruction::MoveInstruction(Waypoint waypoint, const PlanInstruction& plan_instruction)
   : waypoint_(std::move(waypoint))
 {
+  if (!isStateWaypoint(waypoint_))
+    CONSOLE_BRIDGE_logWarn("MoveInstruction usually expects to be provided a State Waypoint!");
+
   switch (plan_instruction.getPlanType())
   {
     case PlanInstructionType::LINEAR:

--- a/tesseract_command_language/src/move_instruction.cpp
+++ b/tesseract_command_language/src/move_instruction.cpp
@@ -123,10 +123,7 @@ void MoveInstruction::setManipulatorInfo(ManipulatorInfo info) { manipulator_inf
 const ManipulatorInfo& MoveInstruction::getManipulatorInfo() const { return manipulator_info_; }
 ManipulatorInfo& MoveInstruction::getManipulatorInfo() { return manipulator_info_; }
 
-void MoveInstruction::setProfile(const std::string& profile)
-{
-  profile_ = (profile.empty()) ? DEFAULT_PROFILE_KEY : profile;
-}
+void MoveInstruction::setProfile(const std::string& profile) { profile_ = profile; }
 const std::string& MoveInstruction::getProfile() const { return profile_; }
 
 void MoveInstruction::setPathProfile(const std::string& profile) { path_profile_ = profile; }

--- a/tesseract_command_language/src/plan_instruction.cpp
+++ b/tesseract_command_language/src/plan_instruction.cpp
@@ -43,6 +43,21 @@ PlanInstruction::PlanInstruction(Waypoint waypoint,
   , profile_(std::move(profile))
   , manipulator_info_(std::move(manipulator_info))
 {
+  if (plan_type_ == PlanInstructionType::LINEAR || plan_type_ == PlanInstructionType::CIRCULAR)
+    path_profile_ = profile_;
+}
+
+PlanInstruction::PlanInstruction(Waypoint waypoint,
+                                 PlanInstructionType type,
+                                 std::string profile,
+                                 std::string path_profile,
+                                 ManipulatorInfo manipulator_info)
+  : plan_type_(type)
+  , waypoint_(std::move(waypoint))
+  , profile_(std::move(profile))
+  , path_profile_(std::move(path_profile))
+  , manipulator_info_(std::move(manipulator_info))
+{
 }
 
 void PlanInstruction::setWaypoint(Waypoint waypoint) { waypoint_ = std::move(waypoint); }
@@ -58,6 +73,9 @@ void PlanInstruction::setProfile(const std::string& profile)
   profile_ = (profile.empty()) ? DEFAULT_PROFILE_KEY : profile;
 }
 const std::string& PlanInstruction::getProfile() const { return profile_; }
+
+void PlanInstruction::setPathProfile(const std::string& profile) { path_profile_ = profile; }
+const std::string& PlanInstruction::getPathProfile() const { return path_profile_; }
 
 const std::string& PlanInstruction::getDescription() const { return description_; }
 
@@ -88,7 +106,8 @@ bool PlanInstruction::operator==(const PlanInstruction& rhs) const
   equal &= (static_cast<int>(plan_type_) == static_cast<int>(rhs.plan_type_));
   equal &= (waypoint_ == rhs.waypoint_);
   equal &= (manipulator_info_ == rhs.manipulator_info_);
-  equal &= (profile_ == rhs.profile_);  // NO LINT
+  equal &= (profile_ == rhs.profile_);            // NO LINT
+  equal &= (path_profile_ == rhs.path_profile_);  // NO LINT
   return equal;
 }
 
@@ -100,6 +119,7 @@ void PlanInstruction::serialize(Archive& ar, const unsigned int /*version*/)
   ar& boost::serialization::make_nvp("plan_type", plan_type_);
   ar& boost::serialization::make_nvp("description", description_);
   ar& boost::serialization::make_nvp("profile", profile_);
+  ar& boost::serialization::make_nvp("path_profile", path_profile_);
   ar& boost::serialization::make_nvp("waypoint", waypoint_);
   ar& boost::serialization::make_nvp("manipulator_info", manipulator_info_);
 }

--- a/tesseract_command_language/test/CMakeLists.txt
+++ b/tesseract_command_language/test/CMakeLists.txt
@@ -67,6 +67,48 @@ add_gtest_discover_tests(${PROJECT_NAME}_joint_waypoint_unit)
 add_dependencies(run_tests ${PROJECT_NAME}_joint_waypoint_unit)
 add_dependencies(${PROJECT_NAME}_joint_waypoint_unit ${PROJECT_NAME})
 
+# PlanInstruction Tests
+add_executable(${PROJECT_NAME}_plan_instruction_unit plan_instruction_unit.cpp)
+target_link_libraries(
+  ${PROJECT_NAME}_plan_instruction_unit
+  PRIVATE GTest::GTest
+          GTest::Main
+          Eigen3::Eigen
+          ${PROJECT_NAME})
+target_compile_options(${PROJECT_NAME}_plan_instruction_unit PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
+                                                                     ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_clang_tidy(${PROJECT_NAME}_plan_instruction_unit ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_plan_instruction_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}_plan_instruction_unit
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+add_gtest_discover_tests(${PROJECT_NAME}_plan_instruction_unit)
+add_dependencies(run_tests ${PROJECT_NAME}_plan_instruction_unit)
+add_dependencies(${PROJECT_NAME}_plan_instruction_unit ${PROJECT_NAME})
+
+# MoveInstruction Tests
+add_executable(${PROJECT_NAME}_move_instruction_unit move_instruction_unit.cpp)
+target_link_libraries(
+  ${PROJECT_NAME}_move_instruction_unit
+  PRIVATE GTest::GTest
+          GTest::Main
+          Eigen3::Eigen
+          ${PROJECT_NAME})
+target_compile_options(${PROJECT_NAME}_move_instruction_unit PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
+                                                                     ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_clang_tidy(${PROJECT_NAME}_move_instruction_unit ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_move_instruction_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}_move_instruction_unit
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+add_gtest_discover_tests(${PROJECT_NAME}_move_instruction_unit)
+add_dependencies(run_tests ${PROJECT_NAME}_move_instruction_unit)
+add_dependencies(${PROJECT_NAME}_move_instruction_unit ${PROJECT_NAME})
+
 # Serialize Tests
 add_executable(${PROJECT_NAME}_serialize_unit serialize_test.cpp)
 target_link_libraries(${PROJECT_NAME}_serialize_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME})

--- a/tesseract_command_language/test/move_instruction_unit.cpp
+++ b/tesseract_command_language/test/move_instruction_unit.cpp
@@ -1,0 +1,191 @@
+/**
+ * @file move_instruction_unit.cpp
+ * @brief Contains unit tests for MoveInstruction
+ *
+ * @author Levi Armstrong
+ * @date February 15, 2021
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2022, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <fstream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_command_language/core/instruction.h>
+#include <tesseract_command_language/core/serialization.h>
+#include <tesseract_command_language/move_instruction.h>
+#include <tesseract_command_language/state_waypoint.h>
+#include <tesseract_command_language/null_instruction.h>
+
+using namespace tesseract_planning;
+
+TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
+{
+  Eigen::VectorXd jv = Eigen::VectorXd::Ones(6);
+  std::vector<std::string> jn = { "j1", "j2", "j3", "j4", "j5", "j6" };
+  StateWaypoint swp(jn, jv);
+
+  // Minimum arguments
+  {
+    MoveInstruction instr(swp, MoveInstructionType::START);
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::START);
+    EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    MoveInstruction instr(swp, MoveInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    MoveInstruction instr(swp, MoveInstructionType::LINEAR);
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::LINEAR);
+    EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_EQ(instr.getPathProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  // With plan profile
+  {
+    MoveInstruction instr(swp, MoveInstructionType::START, "TEST_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::START);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    MoveInstruction instr(swp, MoveInstructionType::FREESPACE, "TEST_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    MoveInstruction instr(swp, MoveInstructionType::LINEAR, "TEST_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::LINEAR);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  // With plan and path profile
+  {
+    MoveInstruction instr(swp, MoveInstructionType::START, "TEST_PROFILE", "TEST_PATH_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::START);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    MoveInstruction instr(swp, MoveInstructionType::FREESPACE, "TEST_PROFILE", "TEST_PATH_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    MoveInstruction instr(swp, MoveInstructionType::LINEAR, "TEST_PROFILE", "TEST_PATH_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), swp);
+    EXPECT_EQ(instr.getMoveType(), MoveInstructionType::LINEAR);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+}
+
+TEST(TesseractCommandLanguageMoveInstructionUnit, setters)  // NOLINT
+{
+  Eigen::VectorXd jv = Eigen::VectorXd::Ones(6);
+  std::vector<std::string> jn = { "j1", "j2", "j3", "j4", "j5", "j6" };
+  StateWaypoint swp(jn, jv);
+
+  MoveInstruction instr(swp, MoveInstructionType::START);
+  EXPECT_EQ(instr.getWaypoint(), swp);
+  EXPECT_EQ(instr.getMoveType(), MoveInstructionType::START);
+  EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+  EXPECT_TRUE(instr.getPathProfile().empty());
+  EXPECT_FALSE(instr.getDescription().empty());
+
+  StateWaypoint test_swp(jn, 5 * jv);
+  instr.setWaypoint(test_swp);
+  EXPECT_EQ(instr.getWaypoint(), test_swp);
+
+  instr.setMoveType(MoveInstructionType::LINEAR);
+  EXPECT_EQ(instr.getMoveType(), MoveInstructionType::LINEAR);
+
+  instr.setProfile("TEST_PROFILE");
+  EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+
+  instr.setPathProfile("TEST_PATH_PROFILE");
+  EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+
+  instr.setDescription("This is a test.");
+  EXPECT_EQ(instr.getDescription(), "This is a test.");
+}
+
+TEST(TesseractCommandLanguageMoveInstructionUnit, boostSerialization)  // NOLINT
+{
+  Eigen::VectorXd jv = Eigen::VectorXd::Ones(6);
+  std::vector<std::string> jn = { "j1", "j2", "j3", "j4", "j5", "j6" };
+  StateWaypoint swp(jn, jv);
+
+  MoveInstruction instr(swp, MoveInstructionType::START);
+  instr.setMoveType(MoveInstructionType::LINEAR);
+  instr.setProfile("TEST_PROFILE");
+  instr.setPathProfile("TEST_PATH_PROFILE");
+  instr.setDescription("This is a test.");
+
+  Serialization::toArchiveFileXML<Instruction>(instr, "/tmp/move_instruction_boost.xml");
+
+  auto ninstr = Serialization::fromArchiveFileXML<Instruction>("/tmp/move_instruction_boost.xml").as<MoveInstruction>();
+
+  EXPECT_TRUE(instr == ninstr);
+  EXPECT_EQ(ninstr.getWaypoint(), swp);
+  EXPECT_EQ(ninstr.getMoveType(), MoveInstructionType::LINEAR);
+  EXPECT_EQ(ninstr.getProfile(), "TEST_PROFILE");
+  EXPECT_EQ(ninstr.getPathProfile(), "TEST_PATH_PROFILE");
+  EXPECT_EQ(ninstr.getDescription(), "This is a test.");
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_command_language/test/plan_instruction_unit.cpp
+++ b/tesseract_command_language/test/plan_instruction_unit.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file plan_instruction_unit.cpp
+ * @brief Contains unit tests for PlanInstruction
+ *
+ * @author Levi Armstrong
+ * @date February 15, 2021
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2022, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <fstream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_command_language/core/instruction.h>
+#include <tesseract_command_language/core/serialization.h>
+#include <tesseract_command_language/plan_instruction.h>
+#include <tesseract_command_language/joint_waypoint.h>
+#include <tesseract_command_language/cartesian_waypoint.h>
+#include <tesseract_command_language/null_instruction.h>
+
+using namespace tesseract_planning;
+
+TEST(TesseractCommandLanguagePlanInstructionUnit, constructor)  // NOLINT
+{
+  Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  CartesianWaypoint wp(pose);
+
+  // Minimum arguments
+  {
+    PlanInstruction instr(wp, PlanInstructionType::START);
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::START);
+    EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    PlanInstruction instr(wp, PlanInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    PlanInstruction instr(wp, PlanInstructionType::LINEAR);
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::LINEAR);
+    EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_EQ(instr.getPathProfile(), DEFAULT_PROFILE_KEY);
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  // With plan profile
+  {
+    PlanInstruction instr(wp, PlanInstructionType::START, "TEST_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::START);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    PlanInstruction instr(wp, PlanInstructionType::FREESPACE, "TEST_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_TRUE(instr.getPathProfile().empty());
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    PlanInstruction instr(wp, PlanInstructionType::LINEAR, "TEST_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::LINEAR);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  // With plan and path profile
+  {
+    PlanInstruction instr(wp, PlanInstructionType::START, "TEST_PROFILE", "TEST_PATH_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::START);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    PlanInstruction instr(wp, PlanInstructionType::FREESPACE, "TEST_PROFILE", "TEST_PATH_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::FREESPACE);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+
+  {
+    PlanInstruction instr(wp, PlanInstructionType::LINEAR, "TEST_PROFILE", "TEST_PATH_PROFILE");
+    EXPECT_EQ(instr.getWaypoint(), wp);
+    EXPECT_EQ(instr.getPlanType(), PlanInstructionType::LINEAR);
+    EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+    EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+    EXPECT_FALSE(instr.getDescription().empty());
+  }
+}
+
+TEST(TesseractCommandLanguagePlanInstructionUnit, setters)  // NOLINT
+{
+  Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  CartesianWaypoint cwp(pose);
+
+  PlanInstruction instr(cwp, PlanInstructionType::START);
+  EXPECT_EQ(instr.getWaypoint(), cwp);
+  EXPECT_EQ(instr.getPlanType(), PlanInstructionType::START);
+  EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+  EXPECT_TRUE(instr.getPathProfile().empty());
+  EXPECT_FALSE(instr.getDescription().empty());
+
+  Eigen::VectorXd jv = Eigen::VectorXd::Ones(6);
+  std::vector<std::string> jn = { "j1", "j2", "j3", "j4", "j5", "j6" };
+  JointWaypoint jwp(jn, jv);
+  instr.setWaypoint(jwp);
+  EXPECT_EQ(instr.getWaypoint(), jwp);
+
+  instr.setPlanType(PlanInstructionType::LINEAR);
+  EXPECT_EQ(instr.getPlanType(), PlanInstructionType::LINEAR);
+
+  instr.setProfile("TEST_PROFILE");
+  EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
+
+  instr.setPathProfile("TEST_PATH_PROFILE");
+  EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
+
+  instr.setDescription("This is a test.");
+  EXPECT_EQ(instr.getDescription(), "This is a test.");
+}
+
+TEST(TesseractCommandLanguagePlanInstructionUnit, boostSerialization)  // NOLINT
+{
+  Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+  pose.translation() = Eigen::Vector3d(1, 2, 3);
+  CartesianWaypoint cwp(pose);
+
+  PlanInstruction instr(cwp, PlanInstructionType::START);
+  instr.setPlanType(PlanInstructionType::LINEAR);
+  instr.setProfile("TEST_PROFILE");
+  instr.setPathProfile("TEST_PATH_PROFILE");
+  instr.setDescription("This is a test.");
+
+  Serialization::toArchiveFileXML<Instruction>(instr, "/tmp/plan_instruction_boost.xml");
+
+  auto ninstr = Serialization::fromArchiveFileXML<Instruction>("/tmp/plan_instruction_boost.xml").as<PlanInstruction>();
+
+  EXPECT_TRUE(instr == ninstr);
+  EXPECT_EQ(ninstr.getWaypoint(), cwp);
+  EXPECT_EQ(ninstr.getPlanType(), PlanInstructionType::LINEAR);
+  EXPECT_EQ(ninstr.getProfile(), "TEST_PROFILE");
+  EXPECT_EQ(ninstr.getPathProfile(), "TEST_PATH_PROFILE");
+  EXPECT_EQ(ninstr.getDescription(), "This is a test.");
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_command_language/test/serialize_test.cpp
+++ b/tesseract_command_language/test/serialize_test.cpp
@@ -66,11 +66,11 @@ CompositeInstruction getProgram()
 
   // Define raster move instruction
   PlanInstruction plan_c0(wp2, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c1(wp3, PlanInstructionType::LINEAR, "RASTER");
+  PlanInstruction plan_c1(wp3, PlanInstructionType::LINEAR, "RASTER", "RASTER");
   PlanInstruction plan_c2(wp4, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c3(wp5, PlanInstructionType::LINEAR, "RASTER");
+  PlanInstruction plan_c3(wp5, PlanInstructionType::LINEAR, "RASTER", "RASTER");
   PlanInstruction plan_c4(wp6, PlanInstructionType::LINEAR, "RASTER");
-  PlanInstruction plan_c5(wp7, PlanInstructionType::LINEAR, "RASTER");
+  PlanInstruction plan_c5(wp7, PlanInstructionType::LINEAR, "RASTER", "RASTER");
 
   PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
   plan_f0.setDescription("from_start_plan");

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_plan_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_plan_profile.h
@@ -55,7 +55,9 @@ public:
   SimplePlannerFixedSizeAssignPlanProfile(int freespace_steps = 10, int linear_steps = 10);
 
   CompositeInstruction generate(const PlanInstruction& prev_instruction,
+                                const MoveInstruction& prev_seed,
                                 const PlanInstruction& base_instruction,
+                                const Instruction& next_instruction,
                                 const PlannerRequest& request,
                                 const ManipulatorInfo& global_manip_info) const override;
 

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_plan_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_plan_profile.h
@@ -54,7 +54,9 @@ public:
   SimplePlannerFixedSizePlanProfile(int freespace_steps = 10, int linear_steps = 10);
 
   CompositeInstruction generate(const PlanInstruction& prev_instruction,
+                                const MoveInstruction& prev_seed,
                                 const PlanInstruction& base_instruction,
+                                const Instruction& next_instruction,
                                 const PlannerRequest& request,
                                 const ManipulatorInfo& global_manip_info) const override;
 

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_no_ik_plan_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_no_ik_plan_profile.h
@@ -63,7 +63,9 @@ public:
                                   int max_steps = std::numeric_limits<int>::max());
 
   CompositeInstruction generate(const PlanInstruction& prev_instruction,
+                                const MoveInstruction& prev_seed,
                                 const PlanInstruction& base_instruction,
+                                const Instruction& next_instruction,
                                 const PlannerRequest& request,
                                 const ManipulatorInfo& global_manip_info) const override;
 

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_plan_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_plan_profile.h
@@ -61,7 +61,9 @@ public:
                               int min_steps = 1);
 
   CompositeInstruction generate(const PlanInstruction& prev_instruction,
+                                const MoveInstruction& prev_seed,
                                 const PlanInstruction& base_instruction,
+                                const Instruction& next_instruction,
                                 const PlannerRequest& request,
                                 const ManipulatorInfo& global_manip_info) const override;
 

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
@@ -67,10 +67,33 @@ public:
    * @param global_manip_info The global manipulator information
    * @return A composite instruction representing the seed for the base_instruction
    */
+  virtual DEPRECATED() CompositeInstruction generate(const PlanInstruction& /*prev_instruction*/,
+                                                     const PlanInstruction& /*base_instruction*/,
+                                                     const PlannerRequest& /*request*/,
+                                                     const ManipulatorInfo& /*global_manip_info*/) const
+  {
+    throw std::runtime_error("SimplePlannerPlanProfile, this must be implemented in the derived class");
+  }
+
+  /**
+   * @brief Generate a seed for the provided base_instruction
+   * @param prev_instruction The previous instruction
+   * @param prev_seed The previous seed
+   * @param base_instruction The base/current instruction to generate the seed for
+   * @param next_instruction The next instruction. This will be a null instruction for the final instruction
+   * @param request The planning request
+   * @param global_manip_info The global manipulator information
+   * @return A composite instruction representing the seed for the base_instruction
+   */
   virtual CompositeInstruction generate(const PlanInstruction& prev_instruction,
+                                        const MoveInstruction& /*prev_seed*/,
                                         const PlanInstruction& base_instruction,
+                                        const Instruction& /*next_instruction*/,
                                         const PlannerRequest& request,
-                                        const ManipulatorInfo& global_manip_info) const = 0;
+                                        const ManipulatorInfo& global_manip_info) const
+  {
+    return generate(prev_instruction, base_instruction, request, global_manip_info);
+  }
 };
 
 class SimplePlannerCompositeProfile

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
@@ -92,7 +92,9 @@ public:
                                         const PlannerRequest& request,
                                         const ManipulatorInfo& global_manip_info) const
   {
+    TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
     return generate(prev_instruction, base_instruction, request, global_manip_info);
+    TESSERACT_COMMON_IGNORE_WARNINGS_POP
   }
 };
 

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_utils.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_utils.h
@@ -111,13 +111,6 @@ struct KinematicGroupInstructionInfo
 };
 
 /**
- * @brief Get the associated move instruction type for the give plan instruction type
- * @param base_instruction The plan instruction
- * @returnThe associated move instruction type for the give plan instruction type
- */
-MoveInstructionType getMoveInstructionType(const PlanInstruction& base_instruction);
-
-/**
  * @brief This takes the provided seed state for the base_instruction and create a corresponding composite instruction
  * @param joint_names The joint names associated with the states
  * @param states The joint states to populate the composite instruction with

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/simple_motion_planner.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/simple_motion_planner.h
@@ -97,6 +97,7 @@ protected:
 
   CompositeInstruction processCompositeInstruction(const CompositeInstruction& instructions,
                                                    PlanInstruction& prev_instruction,
+                                                   MoveInstruction& prev_seed,
                                                    const PlannerRequest& request) const;
 };
 

--- a/tesseract_motion_planners/core/src/simple/profile/simple_planner_fixed_size_assign_plan_profile.cpp
+++ b/tesseract_motion_planners/core/src/simple/profile/simple_planner_fixed_size_assign_plan_profile.cpp
@@ -35,7 +35,9 @@ SimplePlannerFixedSizeAssignPlanProfile::SimplePlannerFixedSizeAssignPlanProfile
 }
 
 CompositeInstruction SimplePlannerFixedSizeAssignPlanProfile::generate(const PlanInstruction& prev_instruction,
+                                                                       const MoveInstruction& /*prev_seed*/,
                                                                        const PlanInstruction& base_instruction,
+                                                                       const Instruction& /*next_instruction*/,
                                                                        const PlannerRequest& request,
                                                                        const ManipulatorInfo& global_manip_info) const
 {

--- a/tesseract_motion_planners/core/src/simple/profile/simple_planner_fixed_size_plan_profile.cpp
+++ b/tesseract_motion_planners/core/src/simple/profile/simple_planner_fixed_size_plan_profile.cpp
@@ -35,7 +35,9 @@ SimplePlannerFixedSizePlanProfile::SimplePlannerFixedSizePlanProfile(int freespa
 }
 
 CompositeInstruction SimplePlannerFixedSizePlanProfile::generate(const PlanInstruction& prev_instruction,
+                                                                 const MoveInstruction& /*prev_seed*/,
                                                                  const PlanInstruction& base_instruction,
+                                                                 const Instruction& /*next_instruction*/,
                                                                  const PlannerRequest& request,
                                                                  const ManipulatorInfo& global_manip_info) const
 {

--- a/tesseract_motion_planners/core/src/simple/profile/simple_planner_lvs_no_ik_plan_profile.cpp
+++ b/tesseract_motion_planners/core/src/simple/profile/simple_planner_lvs_no_ik_plan_profile.cpp
@@ -43,7 +43,9 @@ SimplePlannerLVSNoIKPlanProfile::SimplePlannerLVSNoIKPlanProfile(double state_lo
 }
 
 CompositeInstruction SimplePlannerLVSNoIKPlanProfile::generate(const PlanInstruction& prev_instruction,
+                                                               const MoveInstruction& /*prev_seed*/,
                                                                const PlanInstruction& base_instruction,
+                                                               const Instruction& /*next_instruction*/,
                                                                const PlannerRequest& request,
                                                                const ManipulatorInfo& global_manip_info) const
 {

--- a/tesseract_motion_planners/core/src/simple/profile/simple_planner_lvs_plan_profile.cpp
+++ b/tesseract_motion_planners/core/src/simple/profile/simple_planner_lvs_plan_profile.cpp
@@ -41,7 +41,9 @@ SimplePlannerLVSPlanProfile::SimplePlannerLVSPlanProfile(double state_longest_va
 }
 
 CompositeInstruction SimplePlannerLVSPlanProfile::generate(const PlanInstruction& prev_instruction,
+                                                           const MoveInstruction& /*prev_seed*/,
                                                            const PlanInstruction& base_instruction,
+                                                           const Instruction& /*next_instruction*/,
                                                            const PlannerRequest& request,
                                                            const ManipulatorInfo& global_manip_info) const
 {

--- a/tesseract_motion_planners/test/simple_planner_fixed_size_assign_position.cpp
+++ b/tesseract_motion_planners/test/simple_planner_fixed_size_assign_position.cpp
@@ -92,21 +92,33 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeAssignPositionUnit, JointCartesian
   request.env = env_;
   request.env_state = env_->getState();
   JointWaypoint wp1(joint_names_, Eigen::VectorXd::Zero(7));
-  CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
+  CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizeAssignPlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
+
     const auto& mi = c.as<MoveInstruction>();
     EXPECT_TRUE(wp1.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(mi.getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
   }
+  const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_TRUE(wp1.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
 }
 
 TEST_F(TesseractPlanningSimplePlannerFixedSizeAssignPositionUnit, CartesianJoint_AssignJointPosition)  // NOLINT
@@ -115,21 +127,33 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeAssignPositionUnit, CartesianJoint
   request.env = env_;
   request.env_state = env_->getState();
   CartesianWaypoint wp1 = Eigen::Isometry3d::Identity();
-  JointWaypoint wp2(joint_names_, Eigen::VectorXd::Zero(7));
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
+  JointWaypoint wp2(joint_names_, Eigen::VectorXd::Zero(7));
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizeAssignPlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
+
     const auto& mi = c.as<MoveInstruction>();
     EXPECT_TRUE(wp2.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(mi.getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
   }
+  const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_TRUE(wp2.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
 }
 
 TEST_F(TesseractPlanningSimplePlannerFixedSizeAssignPositionUnit, CartesianCartesian_AssignJointPosition)  // NOLINT
@@ -138,23 +162,35 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeAssignPositionUnit, CartesianCarte
   request.env = env_;
   request.env_state = env_->getState();
   CartesianWaypoint wp1 = Eigen::Isometry3d::Identity();
-  CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
+  CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizeAssignPlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   auto fwd_kin = env_->getJointGroup(manip_info_.manipulator);
   Eigen::VectorXd position = request.env_state.getJointValues(fwd_kin->getJointNames());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
+
     const auto& mi = c.as<MoveInstruction>();
     EXPECT_TRUE(position.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(mi.getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
   }
+  const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_TRUE(position.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
 }
 
 int main(int argc, char** argv)

--- a/tesseract_motion_planners/test/simple_planner_fixed_size_interpolation.cpp
+++ b/tesseract_motion_planners/test/simple_planner_fixed_size_interpolation.cpp
@@ -94,20 +94,29 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, JointJoint_Join
   request.env = env_;
   request.env_state = env_->getState();
   JointWaypoint wp1(joint_names_, Eigen::VectorXd::Zero(7));
-  JointWaypoint wp2(joint_names_, Eigen::VectorXd::Ones(7));
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
+  JointWaypoint wp2(joint_names_, Eigen::VectorXd::Ones(7));
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizePlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getPathProfile(), instr2.getPathProfile());
   }
   const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
   EXPECT_TRUE(wp2.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
 }
 
@@ -117,21 +126,31 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, JointCart_Joint
   request.env = env_;
   request.env_state = env_->getState();
   JointWaypoint wp1(joint_names_, Eigen::VectorXd::Zero(7));
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
+  PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
   CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
   wp2.waypoint.translation() = Eigen::Vector3d(0.25, 0, 1);
-  PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizePlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getPathProfile(), instr2.getPathProfile());
   }
   const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
+
   const Eigen::VectorXd& last_position = mi.getWaypoint().as<StateWaypoint>().position;
   auto manip = env_->getJointGroup(manip_info_.manipulator);
   Eigen::Isometry3d final_pose = manip->calcFwdKin(last_position).at(manip_info_.tcp_frame);
@@ -145,20 +164,29 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, CartJoint_Joint
   request.env_state = env_->getState();
   CartesianWaypoint wp1 = Eigen::Isometry3d::Identity();
   wp1.waypoint.translation() = Eigen::Vector3d(0.25, 0, 1);
-  JointWaypoint wp2(joint_names_, Eigen::VectorXd::Zero(7));
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
   PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
+  JointWaypoint wp2(joint_names_, Eigen::VectorXd::Zero(7));
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizePlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getPathProfile(), instr2.getPathProfile());
   }
   const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
   EXPECT_TRUE(wp2.isApprox(mi.getWaypoint().as<StateWaypoint>().position, 1e-5));
 }
 
@@ -169,21 +197,30 @@ TEST_F(TesseractPlanningSimplePlannerFixedSizeInterpolationUnit, CartCart_JointI
   request.env_state = env_->getState();
   CartesianWaypoint wp1 = Eigen::Isometry3d::Identity();
   wp1.waypoint.translation() = Eigen::Vector3d(0.25, -0.1, 1);
+  JointWaypoint wp1_seed(joint_names_, request.env_state.getJointValues(joint_names_));
+  PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
+  MoveInstruction instr1_seed(wp1_seed, instr1);
+
   CartesianWaypoint wp2 = Eigen::Isometry3d::Identity();
   wp2.waypoint.translation() = Eigen::Vector3d(0.25, 0.1, 1);
-  PlanInstruction instr1(wp1, PlanInstructionType::START, "TEST_PROFILE", manip_info_);
   PlanInstruction instr2(wp2, PlanInstructionType::FREESPACE, "TEST_PROFILE", manip_info_);
 
+  NullInstruction instr3;
+
   SimplePlannerFixedSizePlanProfile profile(10, 10);
-  auto composite = profile.generate(instr1, instr2, request, ManipulatorInfo());
+  auto composite = profile.generate(instr1, instr1_seed, instr2, instr3, request, ManipulatorInfo());
   EXPECT_EQ(composite.size(), 10);
-  for (const auto& c : composite)
+  for (std::size_t i = 0; i < composite.size() - 1; ++i)
   {
+    const auto& c = composite.at(i);
     EXPECT_TRUE(isMoveInstruction(c));
     EXPECT_TRUE(isStateWaypoint(c.as<MoveInstruction>().getWaypoint()));
-    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getProfile(), instr2.getPathProfile());
+    EXPECT_EQ(c.as<MoveInstruction>().getPathProfile(), instr2.getPathProfile());
   }
   const auto& mi = composite.back().as<MoveInstruction>();
+  EXPECT_EQ(mi.getProfile(), instr2.getProfile());
+  EXPECT_EQ(mi.getPathProfile(), instr2.getPathProfile());
   const Eigen::VectorXd& last_position = mi.getWaypoint().as<StateWaypoint>().position;
   auto manip = env_->getJointGroup(manip_info_.manipulator);
   Eigen::Isometry3d final_pose = manip->calcFwdKin(last_position).at(manip_info_.tcp_frame);

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_default_plan_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_default_plan_profile.cpp
@@ -180,6 +180,9 @@ void TrajOptDefaultPlanProfile::apply(trajopt::ProblemConstructionInfo& pci,
     pci.cnt_infos.push_back(ti);
   else
     pci.cost_infos.push_back(ti);
+
+  // Add constraints from error functions if available.
+  addConstraintErrorFunctions(pci, index);
 }
 
 void TrajOptDefaultPlanProfile::addConstraintErrorFunctions(trajopt::ProblemConstructionInfo& pci, int index) const


### PR DESCRIPTION
This adds a path profile for both move and plan instruction to allows using different costs/constraints for the path to the waypoint versus the waypoint itself. 

Updates the simple planners interface to provide next instruction.