### PR TITLE
Make ProcessPlanningServer::run const

### DIFF
--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
@@ -122,14 +122,14 @@ public:
    * @param request The process planning request to execute
    * @return A process planning future to get results and monitor the execution along with the ability to abort
    */
-  ProcessPlanningFuture run(const ProcessPlanningRequest& request);
+  ProcessPlanningFuture run(const ProcessPlanningRequest& request) const;
 
   /**
    * @brief This is a utility function to run arbitrary taskflows
    * @param taskflow the taskflow to execute
    * @return A future to monitor progress
    */
-  tf::Future<void> run(tf::Taskflow& taskflow);
+  tf::Future<void> run(tf::Taskflow& taskflow) const;
 #endif  // SWIG
 
 #ifdef SWIG
@@ -165,7 +165,7 @@ public:
 
 protected:
   EnvironmentCache::ConstPtr cache_;
-  std::shared_ptr<tf::Executor> executor_;
+  mutable std::shared_ptr<tf::Executor> executor_;
   std::shared_ptr<tf::TFProfObserver> profile_observer_;
 
   std::unordered_map<std::string, TaskflowGenerator::UPtr> process_planners_;

--- a/tesseract_process_managers/src/core/process_planning_server.cpp
+++ b/tesseract_process_managers/src/core/process_planning_server.cpp
@@ -109,7 +109,7 @@ std::vector<std::string> ProcessPlanningServer::getAvailableProcessPlanners() co
   return planners;
 }
 
-ProcessPlanningFuture ProcessPlanningServer::run(const ProcessPlanningRequest& request)
+ProcessPlanningFuture ProcessPlanningServer::run(const ProcessPlanningRequest& request) const
 {
   CONSOLE_BRIDGE_logInform("Tesseract Planning Server Received Request!");
   ProcessPlanningFuture response;
@@ -183,7 +183,7 @@ ProcessPlanningFuture ProcessPlanningServer::run(const ProcessPlanningRequest& r
   return response;
 }
 
-tf::Future<void> ProcessPlanningServer::run(tf::Taskflow& taskflow) { return executor_->run(taskflow); }
+tf::Future<void> ProcessPlanningServer::run(tf::Taskflow& taskflow) const { return executor_->run(taskflow); }
 
 void ProcessPlanningServer::waitForAll() { executor_->wait_for_all(); }
 


### PR DESCRIPTION
The only thing keeping run from being const is that executor_->run is non-const even though it appears to be threadsafe. 