### PR TITLE
Add seed parameter to cartesian waypoint

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
@@ -34,6 +34,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/core/waypoint.h>
 #include <tesseract_command_language/waypoint_type.h>
+#include <tesseract_command_language/joint_waypoint.h>
+#include <tesseract_command_language/null_waypoint.h>
 #include <tesseract_common/utils.h>
 
 namespace tesseract_planning
@@ -169,8 +171,18 @@ public:
   Eigen::VectorXd upper_tolerance;
 
   /**
-   * @brief Returns true if waypoint is toleranced
-   * @return True if waypoint is toleranced
+   * @brief Allow storing a seed associated with this cartesian waypoint
+   * @details Using the waypoint type erasure type to allow user defined types.
+   * The most common type that would be used it the joint waypoint for the following
+   *   - providing a seed to the IK solver
+   *   - providing a seed to the IK solver with modified limits using the tolerances
+   *   - providing a state to be used in a simple planner for interpolation to avoid running IK
+   */
+  Waypoint seed{ NullWaypoint() };
+
+  /**
+   * @brief Returns true if waypoint has tolerances
+   * @return True if waypoint has tolerances
    */
   bool isToleranced() const
   {
@@ -197,6 +209,7 @@ public:
     equal &= waypoint.isApprox(rhs.waypoint);
     equal &= tesseract_common::almostEqualRelativeAndAbs(lower_tolerance, rhs.lower_tolerance, max_diff);
     equal &= tesseract_common::almostEqualRelativeAndAbs(upper_tolerance, rhs.upper_tolerance, max_diff);
+    equal &= (seed == rhs.seed);
     return equal;
   }
   bool operator!=(const CartesianWaypoint& rhs) const { return !operator==(rhs); }

--- a/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
@@ -34,7 +34,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/core/waypoint.h>
 #include <tesseract_command_language/waypoint_type.h>
-#include <tesseract_command_language/joint_waypoint.h>
 #include <tesseract_command_language/null_waypoint.h>
 #include <tesseract_common/utils.h>
 
@@ -171,12 +170,11 @@ public:
   Eigen::VectorXd upper_tolerance;
 
   /**
-   * @brief Allow storing a seed associated with this cartesian waypoint
-   * @details Using the waypoint type erasure type to allow user defined types.
-   * The most common type that would be used it the joint waypoint for the following
-   *   - providing a seed to the IK solver
+   * @brief Waypoint seed associated with this Cartesian waypoint
+   * @details The waypoint seed can be used for purposes like:
+   *   - providing a joint state seed to an IK solver
    *   - providing a seed to the IK solver with modified limits using the tolerances
-   *   - providing a state to be used in a simple planner for interpolation to avoid running IK
+   *   - providing a joint state to be used by a motion planner for interpolation to avoid performing IK
    */
   Waypoint seed{ NullWaypoint() };
 

--- a/tesseract_command_language/src/cartesian_waypoint.cpp
+++ b/tesseract_command_language/src/cartesian_waypoint.cpp
@@ -12,6 +12,7 @@ void tesseract_planning::CartesianWaypoint::serialize(Archive& ar, const unsigne
   ar& BOOST_SERIALIZATION_NVP(waypoint);
   ar& BOOST_SERIALIZATION_NVP(upper_tolerance);
   ar& BOOST_SERIALIZATION_NVP(lower_tolerance);
+  ar& BOOST_SERIALIZATION_NVP(seed);
 }
 
 #include <boost/archive/xml_oarchive.hpp>

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
@@ -67,10 +67,11 @@ public:
    * @param global_manip_info The global manipulator information
    * @return A composite instruction representing the seed for the base_instruction
    */
-  virtual DEPRECATED() CompositeInstruction generate(const PlanInstruction& /*prev_instruction*/,
-                                                     const PlanInstruction& /*base_instruction*/,
-                                                     const PlannerRequest& /*request*/,
-                                                     const ManipulatorInfo& /*global_manip_info*/) const
+  virtual DEPRECATED("Use other generate method.") CompositeInstruction
+      generate(const PlanInstruction& /*prev_instruction*/,
+               const PlanInstruction& /*base_instruction*/,
+               const PlannerRequest& /*request*/,
+               const ManipulatorInfo& /*global_manip_info*/) const
   {
     throw std::runtime_error("SimplePlannerPlanProfile, this must be implemented in the derived class");
   }


### PR DESCRIPTION
Allow storing a seed inside the CartesianWaypoint
Using the waypoint type erasure type to allow user defined types.
 - The most common type that would be used it the joint waypoint for the following
     - providing a seed to the ik solver
     - providing a seed to the ik solver with modified limits using the tolerances
     - providing a state to be used in a simple planner for interpolation to avoid running ik
