### PR TITLE
Fix thread safety issue with TaskInfoContainer

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
@@ -51,6 +51,8 @@ enum class CompositeInstructionOrder
 class CompositeInstruction
 {
 public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   CompositeInstruction(std::string profile = DEFAULT_PROFILE_KEY,
                        CompositeInstructionOrder order = CompositeInstructionOrder::ORDERED,
                        ManipulatorInfo manipulator_info = ManipulatorInfo());

--- a/tesseract_process_managers/examples/freespace_manager_example.cpp
+++ b/tesseract_process_managers/examples/freespace_manager_example.cpp
@@ -94,7 +94,7 @@ int main()
   std::cout << "Execution Complete" << std::endl;
 
   // Print summary statistics
-  std::map<std::size_t, TaskInfo::ConstPtr> info_map = response.interface->getTaskInfoMap();
+  std::map<std::size_t, TaskInfo::UPtr> info_map = response.interface->getTaskInfoMap();
   TaskInfoProfiler profiler;
   profiler.load(info_map);
   profiler.print();

--- a/tesseract_process_managers/examples/raster_manager_example.cpp
+++ b/tesseract_process_managers/examples/raster_manager_example.cpp
@@ -95,7 +95,7 @@ int main()
   std::cout << "Execution Complete" << std::endl;
 
   // Print summary statistics
-  std::map<std::size_t, TaskInfo::ConstPtr> info_map = response.interface->getTaskInfoMap();
+  std::map<std::size_t, TaskInfo::UPtr> info_map = response.interface->getTaskInfoMap();
   TaskInfoProfiler profiler;
   profiler.load(info_map);
   profiler.print();

--- a/tesseract_process_managers/include/tesseract_process_managers/core/task_info.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/task_info.h
@@ -51,6 +51,8 @@ class TaskInfo
 public:
   using Ptr = std::shared_ptr<TaskInfo>;
   using ConstPtr = std::shared_ptr<const TaskInfo>;
+  using UPtr = std::unique_ptr<TaskInfo>;
+  using ConstUPtr = std::unique_ptr<const TaskInfo>;
 
   TaskInfo() = default;  // Required for serialization
   TaskInfo(std::size_t unique_id, std::string name = "");
@@ -87,6 +89,8 @@ public:
   bool operator==(const TaskInfo& rhs) const;
   bool operator!=(const TaskInfo& rhs) const;
 
+  virtual TaskInfo::UPtr clone() const;
+
 private:
   friend class boost::serialization::access;
   template <class Archive>
@@ -99,16 +103,16 @@ struct TaskInfoContainer
   using Ptr = std::shared_ptr<TaskInfoContainer>;
   using ConstPtr = std::shared_ptr<const TaskInfoContainer>;
 
-  void addTaskInfo(TaskInfo::ConstPtr task_info);
+  void addTaskInfo(TaskInfo::UPtr task_info);
 
-  TaskInfo::ConstPtr operator[](std::size_t index) const;
+  TaskInfo::UPtr operator[](std::size_t index) const;
 
   /** @brief Get a copy of the task_info_map_ in case it gets resized*/
-  std::map<std::size_t, TaskInfo::ConstPtr> getTaskInfoMap() const;
+  std::map<std::size_t, TaskInfo::UPtr> getTaskInfoMap() const;
 
 private:
   mutable std::shared_mutex mutex_;
-  std::map<std::size_t, TaskInfo::ConstPtr> task_info_map_;
+  std::map<std::size_t, TaskInfo::UPtr> task_info_map_;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/core/task_input.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/task_input.h
@@ -168,9 +168,9 @@ struct TaskInput
   void setEndInstruction(std::vector<std::size_t> end);
   Instruction getEndInstruction() const;
 
-  void addTaskInfo(const TaskInfo::ConstPtr& task_info);
-  TaskInfo::ConstPtr getTaskInfo(const std::size_t& index) const;
-  std::map<std::size_t, TaskInfo::ConstPtr> getTaskInfoMap() const;
+  void addTaskInfo(TaskInfo::UPtr task_info);
+  TaskInfo::UPtr getTaskInfo(const std::size_t& index) const;
+  std::map<std::size_t, TaskInfo::UPtr> getTaskInfoMap() const;
 
   /** @brief If true the task will save the inputs and outputs to the TaskInfo*/
   bool save_io{ false };

--- a/tesseract_process_managers/include/tesseract_process_managers/core/taskflow_interface.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/taskflow_interface.h
@@ -42,7 +42,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 /**
- * @brief This is a thread safe class used for aborting a process along with checking if a process was succesful
+ * @brief This is a thread safe class used for aborting a process along with checking if a process was successful
  * @details If a process failed then the process has been abort by some child process
  */
 class TaskflowInterface
@@ -70,13 +70,13 @@ public:
    * @param index Unique ID assigned the task from taskflow
    * @return The TaskInfo associated with this task
    */
-  TaskInfo::ConstPtr getTaskInfo(const std::size_t& index) const;
+  TaskInfo::UPtr getTaskInfo(const std::size_t& index) const;
 
   /**
    * @brief Get the entire stored map of TaskInfos
    * @return The map of TaskInfos stored by unique ID
    */
-  std::map<std::size_t, TaskInfo::ConstPtr> getTaskInfoMap() const;
+  std::map<std::size_t, TaskInfo::UPtr> getTaskInfoMap() const;
 
   /**
    * @brief Not meant to be used by users. Exposes TaskInfoContainer so that the

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/check_input_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/check_input_task_generator.h
@@ -62,6 +62,8 @@ public:
   using ConstPtr = std::shared_ptr<const CheckInputTaskInfo>;
 
   CheckInputTaskInfo(std::size_t unique_id, std::string name = profile_ns::CHECK_INPUT_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/continuous_contact_check_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/continuous_contact_check_task_generator.h
@@ -63,6 +63,8 @@ public:
                                  std::string name = profile_ns::CONTINUOUS_CONTACT_CHECK_DEFAULT_NAMESPACE);
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 #endif  // TESSERACT_PROCESS_MANAGERS_CONTINUOUS_CONTACT_CHECK_TASK_GENERATOR_H

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/discrete_contact_check_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/discrete_contact_check_task_generator.h
@@ -63,6 +63,8 @@ public:
                                std::string name = profile_ns::DISCRETE_CONTACT_CHECK_DEFAULT_NAMESPACE);
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;
+
+  TaskInfo::UPtr clone() const override;
 };
 
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_bounds_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_bounds_task_generator.h
@@ -62,6 +62,8 @@ public:
   FixStateBoundsTaskInfo(std::size_t unique_id, std::string name = profile_ns::FIX_STATE_BOUNDS_DEFAULT_NAMESPACE);
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 #endif  // TESSERACT_PROCESS_MANAGERS_FIX_STATE_BOUNDS_TASK_GENERATOR_H

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_collision_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/fix_state_collision_task_generator.h
@@ -66,6 +66,8 @@ public:
                             std::string name = profile_ns::FIX_STATE_COLLISION_DEFAULT_NAMESPACE);
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;
+
+  TaskInfo::UPtr clone() const override;
 };
 
 /**

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/has_seed_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/has_seed_task_generator.h
@@ -56,6 +56,8 @@ public:
   using ConstPtr = std::shared_ptr<const HasSeedTaskInfo>;
 
   HasSeedTaskInfo(std::size_t unique_id, std::string name = profile_ns::HAS_SEED_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/iterative_spline_parameterization_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/iterative_spline_parameterization_task_generator.h
@@ -70,6 +70,8 @@ public:
   IterativeSplineParameterizationTaskInfo(
       std::size_t unique_id,
       std::string name = profile_ns::ITERATIVE_SPLINE_PARAMETERIZATION_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/motion_planner_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/motion_planner_task_generator.h
@@ -60,6 +60,8 @@ public:
   using ConstPtr = std::shared_ptr<const MotionPlannerTaskInfo>;
 
   MotionPlannerTaskInfo(std::size_t unique_id, std::string name);
+
+  TaskInfo::UPtr clone() const override;
 };
 
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/profile_switch_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/profile_switch_task_generator.h
@@ -64,6 +64,8 @@ public:
   using ConstPtr = std::shared_ptr<const ProfileSwitchTaskInfo>;
 
   ProfileSwitchTaskInfo(std::size_t unique_id, std::string name = profile_ns::PROFILE_SWITCH_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/seed_min_length_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/seed_min_length_task_generator.h
@@ -68,6 +68,8 @@ public:
   using ConstPtr = std::shared_ptr<const SeedMinLengthTaskInfo>;
 
   SeedMinLengthTaskInfo(std::size_t unique_id, std::string name = profile_ns::SEED_MIN_LENGTH_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/time_optimal_parameterization_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/time_optimal_parameterization_task_generator.h
@@ -82,6 +82,8 @@ public:
   TimeOptimalTrajectoryGenerationTaskInfo(
       std::size_t unique_id,
       std::string name = profile_ns::TIME_OPTIMAL_PARAMETERIZATION_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/task_generators/upsample_trajectory_task_generator.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/task_generators/upsample_trajectory_task_generator.h
@@ -73,6 +73,8 @@ public:
 
   UpsampleTrajectoryTaskInfo(std::size_t unique_id,
                              std::string name = profile_ns::UPSAMPLE_TRAJECTORY_DEFAULT_NAMESPACE);
+
+  TaskInfo::UPtr clone() const override;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_process_managers/include/tesseract_process_managers/utils/task_info_statistics.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/utils/task_info_statistics.h
@@ -73,7 +73,7 @@ public:
    * load(response.interface->getTaskInfoMap());
    * @param task_info_map Key: unique_id (unused), Value: TaskInfo to be inserted
    */
-  void load(const std::map<std::size_t, TaskInfo::ConstPtr>& task_info_map);
+  void load(const std::map<std::size_t, TaskInfo::UPtr>& task_info_map);
 
   /** @brief Clears any loaded data */
   void clear();

--- a/tesseract_process_managers/src/core/task_input.cpp
+++ b/tesseract_process_managers/src/core/task_input.cpp
@@ -268,17 +268,17 @@ Instruction TaskInput::getEndInstruction() const
   return *ci;
 }
 
-void TaskInput::addTaskInfo(const TaskInfo::ConstPtr& task_info)
+void TaskInput::addTaskInfo(TaskInfo::UPtr task_info)
 {
-  interface_->getTaskInfoContainer()->addTaskInfo(task_info);
+  interface_->getTaskInfoContainer()->addTaskInfo(std::move(task_info));
 }
 
-TaskInfo::ConstPtr TaskInput::getTaskInfo(const std::size_t& index) const
+TaskInfo::UPtr TaskInput::getTaskInfo(const std::size_t& index) const
 {
   return (*interface_->getTaskInfoContainer())[index];
 }
 
-std::map<std::size_t, TaskInfo::ConstPtr> TaskInput::getTaskInfoMap() const
+std::map<std::size_t, TaskInfo::UPtr> TaskInput::getTaskInfoMap() const
 {
   return interface_->getTaskInfoContainer()->getTaskInfoMap();
 }

--- a/tesseract_process_managers/src/core/taskflow_interface.cpp
+++ b/tesseract_process_managers/src/core/taskflow_interface.cpp
@@ -35,14 +35,14 @@ bool TaskflowInterface::isSuccessful() const { return !abort_; }
 
 void TaskflowInterface::abort() { abort_ = true; }
 
-TaskInfo::ConstPtr TaskflowInterface::getTaskInfo(const std::size_t& index) const
+TaskInfo::UPtr TaskflowInterface::getTaskInfo(const std::size_t& index) const
 {
   if (task_infos_)
     return (*task_infos_)[index];
   return nullptr;
 }
 
-std::map<std::size_t, TaskInfo::ConstPtr> TaskflowInterface::getTaskInfoMap() const
+std::map<std::size_t, TaskInfo::UPtr> TaskflowInterface::getTaskInfoMap() const
 {
   return task_infos_->getTaskInfoMap();
 }

--- a/tesseract_process_managers/src/task_generators/check_input_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/check_input_task_generator.cpp
@@ -60,4 +60,6 @@ void CheckInputTaskGenerator::process(TaskInput input, std::size_t unique_id) co
 CheckInputTaskInfo::CheckInputTaskInfo(std::size_t unique_id, std::string name) : TaskInfo(unique_id, std::move(name))
 {
 }
+
+TaskInfo::UPtr CheckInputTaskInfo::clone() const { return std::make_unique<CheckInputTaskInfo>(*this); }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/continuous_contact_check_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/continuous_contact_check_task_generator.cpp
@@ -49,9 +49,8 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<ContinuousContactCheckTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<ContinuousContactCheckTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -66,6 +65,7 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -99,6 +99,7 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
     info->contact_results = contacts;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -106,6 +107,7 @@ int ContinuousContactCheckTaskGenerator::conditionalProcess(TaskInput input, std
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -117,5 +119,10 @@ void ContinuousContactCheckTaskGenerator::process(TaskInput input, std::size_t u
 ContinuousContactCheckTaskInfo::ContinuousContactCheckTaskInfo(std::size_t unique_id, std::string name)
   : TaskInfo(unique_id, std::move(name))
 {
+}
+
+TaskInfo::UPtr ContinuousContactCheckTaskInfo::clone() const
+{
+  return std::make_unique<ContinuousContactCheckTaskInfo>(*this);
 }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/discrete_contact_check_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/discrete_contact_check_task_generator.cpp
@@ -48,9 +48,8 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<DiscreteContactCheckTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<DiscreteContactCheckTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -65,6 +64,7 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -98,6 +98,7 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
     info->contact_results = contacts;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -105,6 +106,7 @@ int DiscreteContactCheckTaskGenerator::conditionalProcess(TaskInput input, std::
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -116,5 +118,10 @@ void DiscreteContactCheckTaskGenerator::process(TaskInput input, std::size_t uni
 DiscreteContactCheckTaskInfo::DiscreteContactCheckTaskInfo(std::size_t unique_id, std::string name)
   : TaskInfo(unique_id, std::move(name))
 {
+}
+
+TaskInfo::UPtr DiscreteContactCheckTaskInfo::clone() const
+{
+  return std::make_unique<DiscreteContactCheckTaskInfo>(*this);
 }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/fix_state_bounds_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/fix_state_bounds_task_generator.cpp
@@ -47,9 +47,8 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<FixStateBoundsTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<FixStateBoundsTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -64,6 +63,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -84,6 +84,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
     info->return_value = 1;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 1;
   }
 
@@ -105,6 +106,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -125,6 +127,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -140,6 +143,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
         info->return_value = 1;
         saveOutputs(*info, input);
         info->elapsed_time = timer.elapsedSeconds();
+        input.addTaskInfo(std::move(info));
         return 1;
       }
 
@@ -162,6 +166,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
         {
           saveOutputs(*info, input);
           info->elapsed_time = timer.elapsedSeconds();
+          input.addTaskInfo(std::move(info));
           return 0;
         }
       }
@@ -171,6 +176,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
       info->return_value = 1;
       saveOutputs(*info, input);
       info->elapsed_time = timer.elapsedSeconds();
+      input.addTaskInfo(std::move(info));
       return 1;
   }
 
@@ -178,6 +184,7 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -190,4 +197,6 @@ FixStateBoundsTaskInfo::FixStateBoundsTaskInfo(std::size_t unique_id, std::strin
   : TaskInfo(unique_id, std::move(name))
 {
 }
+
+TaskInfo::UPtr FixStateBoundsTaskInfo::clone() const { return std::make_unique<FixStateBoundsTaskInfo>(*this); }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/fix_state_collision_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/fix_state_collision_task_generator.cpp
@@ -288,9 +288,8 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<FixStateCollisionTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<FixStateCollisionTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -305,6 +304,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -335,6 +335,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -357,6 +358,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -371,6 +373,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
       {
         CONSOLE_BRIDGE_logWarn("FixStateCollisionTaskGenerator found no PlanInstructions to process");
         info->return_value = 1;
+        input.addTaskInfo(std::move(info));
         return 1;
       }
 
@@ -378,6 +381,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
       {
         CONSOLE_BRIDGE_logWarn("FixStateCollisionTaskGenerator found intermediate PlanInstructions to process");
         info->return_value = 1;
+        input.addTaskInfo(std::move(info));
         return 1;
       }
 
@@ -407,6 +411,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -421,6 +426,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
       {
         CONSOLE_BRIDGE_logWarn("FixStateCollisionTaskGenerator found no PlanInstructions to process");
         info->return_value = 1;
+        input.addTaskInfo(std::move(info));
         return 1;
       }
 
@@ -450,6 +456,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -464,6 +471,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
       {
         CONSOLE_BRIDGE_logWarn("FixStateCollisionTaskGenerator found no PlanInstructions to process");
         info->return_value = 1;
+        input.addTaskInfo(std::move(info));
         return 1;
       }
 
@@ -493,6 +501,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -507,6 +516,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
       {
         CONSOLE_BRIDGE_logWarn("FixStateCollisionTaskGenerator found no PlanInstructions to process");
         info->return_value = 1;
+        input.addTaskInfo(std::move(info));
         return 1;
       }
 
@@ -536,6 +546,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
           {
             saveOutputs(*info, input);
             info->elapsed_time = timer.elapsedSeconds();
+            input.addTaskInfo(std::move(info));
             return 0;
           }
         }
@@ -546,6 +557,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
       info->return_value = 1;
       saveOutputs(*info, input);
       info->elapsed_time = timer.elapsedSeconds();
+      input.addTaskInfo(std::move(info));
       return 1;
   }
 
@@ -553,6 +565,7 @@ int FixStateCollisionTaskGenerator::conditionalProcess(TaskInput input, std::siz
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -565,5 +578,7 @@ FixStateCollisionTaskInfo::FixStateCollisionTaskInfo(std::size_t unique_id, std:
   : TaskInfo(unique_id, std::move(name))
 {
 }
+
+TaskInfo::UPtr FixStateCollisionTaskInfo::clone() const { return std::make_unique<FixStateCollisionTaskInfo>(*this); }
 
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/has_seed_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/has_seed_task_generator.cpp
@@ -48,4 +48,6 @@ void HasSeedTaskGenerator::process(TaskInput input, std::size_t unique_id) const
 }
 
 HasSeedTaskInfo::HasSeedTaskInfo(std::size_t unique_id, std::string name) : TaskInfo(unique_id, std::move(name)) {}
+
+TaskInfo::UPtr HasSeedTaskInfo::clone() const { return std::make_unique<HasSeedTaskInfo>(*this); }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/iterative_spline_parameterization_task_generator.cpp
@@ -53,9 +53,8 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<IterativeSplineParameterizationTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<IterativeSplineParameterizationTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -69,6 +68,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
     CONSOLE_BRIDGE_logError("Input results to iterative spline parameterization must be a composite instruction");
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -92,6 +92,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
     info->return_value = 1;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 1;
   }
 
@@ -132,6 +133,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
                              input_results->getDescription().c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -139,6 +141,7 @@ int IterativeSplineParameterizationTaskGenerator::conditionalProcess(TaskInput i
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -151,5 +154,10 @@ IterativeSplineParameterizationTaskInfo::IterativeSplineParameterizationTaskInfo
                                                                                  std::string name)
   : TaskInfo(unique_id, std::move(name))
 {
+}
+
+TaskInfo::UPtr IterativeSplineParameterizationTaskInfo::clone() const
+{
+  return std::make_unique<IterativeSplineParameterizationTaskInfo>(*this);
 }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/motion_planner_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/motion_planner_task_generator.cpp
@@ -48,9 +48,8 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<MotionPlannerTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<MotionPlannerTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -64,6 +63,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -74,6 +74,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
     CONSOLE_BRIDGE_logError("%s", info->message.c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -177,6 +178,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
     info->return_value = 1;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 1;
   }
 
@@ -187,6 +189,7 @@ int MotionPlannerTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   info->message = status.message();
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 0;
 }
 
@@ -199,4 +202,6 @@ MotionPlannerTaskInfo::MotionPlannerTaskInfo(std::size_t unique_id, std::string 
   : TaskInfo(unique_id, std::move(name))
 {
 }
+
+TaskInfo::UPtr MotionPlannerTaskInfo::clone() const { return std::make_unique<MotionPlannerTaskInfo>(*this); }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/seed_min_length_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/seed_min_length_task_generator.cpp
@@ -47,9 +47,8 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<SeedMinLengthTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<SeedMinLengthTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -61,6 +60,7 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
     CONSOLE_BRIDGE_logError("Input seed to SeedMinLengthTaskGenerator must be a composite instruction");
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -79,6 +79,7 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
     info->return_value = 1;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 1;
   }
 
@@ -97,6 +98,7 @@ int SeedMinLengthTaskGenerator::conditionalProcess(TaskInput input, std::size_t 
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -157,4 +159,6 @@ SeedMinLengthTaskInfo::SeedMinLengthTaskInfo(std::size_t unique_id, std::string 
   : TaskInfo(unique_id, std::move(name))
 {
 }
+
+TaskInfo::UPtr SeedMinLengthTaskInfo::clone() const { return std::make_unique<SeedMinLengthTaskInfo>(*this); }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/time_optimal_parameterization_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/time_optimal_parameterization_task_generator.cpp
@@ -55,9 +55,8 @@ int TimeOptimalParameterizationTaskGenerator::conditionalProcess(TaskInput input
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<TimeOptimalTrajectoryGenerationTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<TimeOptimalTrajectoryGenerationTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -71,6 +70,7 @@ int TimeOptimalParameterizationTaskGenerator::conditionalProcess(TaskInput input
     CONSOLE_BRIDGE_logError("Input results to TOTG must be a composite instruction");
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -94,6 +94,7 @@ int TimeOptimalParameterizationTaskGenerator::conditionalProcess(TaskInput input
     info->return_value = 1;
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 1;
   }
 
@@ -145,6 +146,7 @@ int TimeOptimalParameterizationTaskGenerator::conditionalProcess(TaskInput input
     CONSOLE_BRIDGE_logInform("Failed to perform TOTG for process input: %s!", input_results->getDescription().c_str());
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -178,6 +180,7 @@ int TimeOptimalParameterizationTaskGenerator::conditionalProcess(TaskInput input
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -258,5 +261,10 @@ TimeOptimalTrajectoryGenerationTaskInfo::TimeOptimalTrajectoryGenerationTaskInfo
                                                                                  std::string name)
   : TaskInfo(unique_id, std::move(name))
 {
+}
+
+TaskInfo::UPtr TimeOptimalTrajectoryGenerationTaskInfo::clone() const
+{
+  return std::make_unique<TimeOptimalTrajectoryGenerationTaskInfo>(*this);
 }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/task_generators/upsample_trajectory_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/upsample_trajectory_task_generator.cpp
@@ -45,9 +45,8 @@ int UpsampleTrajectoryTaskGenerator::conditionalProcess(TaskInput input, std::si
   if (input.isAborted())
     return 0;
 
-  auto info = std::make_shared<UpsampleTrajectoryTaskInfo>(unique_id, name_);
+  auto info = std::make_unique<UpsampleTrajectoryTaskInfo>(unique_id, name_);
   info->return_value = 0;
-  input.addTaskInfo(info);
   tesseract_common::Timer timer;
   timer.start();
   saveInputs(*info, input);
@@ -59,6 +58,7 @@ int UpsampleTrajectoryTaskGenerator::conditionalProcess(TaskInput input, std::si
     CONSOLE_BRIDGE_logError("Input seed to UpsampleTrajectoryTaskGenerator must be a composite instruction");
     saveOutputs(*info, input);
     info->elapsed_time = timer.elapsedSeconds();
+    input.addTaskInfo(std::move(info));
     return 0;
   }
 
@@ -82,6 +82,7 @@ int UpsampleTrajectoryTaskGenerator::conditionalProcess(TaskInput input, std::si
   info->return_value = 1;
   saveOutputs(*info, input);
   info->elapsed_time = timer.elapsedSeconds();
+  input.addTaskInfo(std::move(info));
   return 1;
 }
 
@@ -153,4 +154,6 @@ UpsampleTrajectoryTaskInfo::UpsampleTrajectoryTaskInfo(std::size_t unique_id, st
   : TaskInfo(unique_id, std::move(name))
 {
 }
+
+TaskInfo::UPtr UpsampleTrajectoryTaskInfo::clone() const { return std::make_unique<UpsampleTrajectoryTaskInfo>(*this); }
 }  // namespace tesseract_planning

--- a/tesseract_process_managers/src/utils/task_info_statistics.cpp
+++ b/tesseract_process_managers/src/utils/task_info_statistics.cpp
@@ -88,7 +88,7 @@ void TaskInfoProfiler::load(const std::vector<std::vector<TaskInfo>>& task_info_
   }
 }
 
-void TaskInfoProfiler::load(const std::map<std::size_t, TaskInfo::ConstPtr>& task_info_map)
+void TaskInfoProfiler::load(const std::map<std::size_t, TaskInfo::UPtr>& task_info_map)
 {
   for (const auto& kv : task_info_map)
   {
@@ -101,7 +101,7 @@ void TaskInfoProfiler::clear() { stats_map.clear(); }
 void TaskInfoProfiler::print(std::ostream& os) const
 {
   using std::setw;
-  const std::vector<std::string> column_names = { "Task Name",    "Occurances",    "Min Time (s)",  "Max Time (s)",
+  const std::vector<std::string> column_names = { "Task Name",    "Occurrences",   "Min Time (s)",  "Max Time (s)",
                                                   "Avg Time (s)", "Return values", "Return value %" };
   const int column_width = 20;
 
@@ -126,7 +126,7 @@ void TaskInfoProfiler::print(std::ostream& os) const
 
     // Name
     os << setw(column_width * 2) << kv.first.substr(0, column_width * 2) << "|";
-    // Occurances
+    // Occurrences
     os << setw(column_width) << kv.second.occurances << "|";
     // Time
     os << setw(column_width) << kv.second.min_time << "|" << setw(column_width) << kv.second.max_time << "|"


### PR DESCRIPTION
The TaskInfoContainer stored the TaskInfo's as const shared pointers creating a thread safety issue because even though the TaskInfoContainer was thread safe the TaskInfo's are not. Switching to unique pointers ensured that after it was added to the container nothing else could change a TaskInfo preventing a potential race condition.