### PR TITLE
Add TESSERACT_ENABLE_EXAMPLES compile option

### DIFF
--- a/tesseract_motion_planners/CMakeLists.txt
+++ b/tesseract_motion_planners/CMakeLists.txt
@@ -74,7 +74,9 @@ if(TESSERACT_BUILD_TRAJOPT_IFOPT)
 endif()
 
 # Examples
+if(TESSERACT_ENABLE_EXAMPLES)
 add_subdirectory(examples)
+endif()
 
 # Tests
 if(TESSERACT_ENABLE_TESTING)

--- a/tesseract_motion_planners/CMakeLists.txt
+++ b/tesseract_motion_planners/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 # Examples
 if(TESSERACT_ENABLE_EXAMPLES)
-add_subdirectory(examples)
+  add_subdirectory(examples)
 endif()
 
 # Tests

--- a/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract_process_managers/CMakeLists.txt
@@ -133,7 +133,7 @@ target_include_directories(${PROJECT_NAME}_utils PUBLIC "$<BUILD_INTERFACE:${CMA
 list(APPEND Targets ${PROJECT_NAME}_utils)
 
 if(TESSERACT_ENABLE_EXAMPLES)
-add_subdirectory(examples)
+  add_subdirectory(examples)
 endif()
 
 configure_package(NAMESPACE tesseract TARGETS ${Targets})

--- a/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract_process_managers/CMakeLists.txt
@@ -132,7 +132,9 @@ target_include_directories(${PROJECT_NAME}_utils PUBLIC "$<BUILD_INTERFACE:${CMA
                                                         "$<INSTALL_INTERFACE:include>")
 list(APPEND Targets ${PROJECT_NAME}_utils)
 
+if(TESSERACT_ENABLE_EXAMPLES)
 add_subdirectory(examples)
+endif()
 
 configure_package(NAMESPACE tesseract TARGETS ${Targets})
 


### PR DESCRIPTION
This pull request adds the TESSERACT_ENABLE_EXAMPLES cmake option to disable examples being built. Requires https://github.com/tesseract-robotics/tesseract/pull/719