### PR TITLE
Add isValidCast to instruction and waypoint type erasure

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
@@ -45,6 +45,7 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   CartesianWaypoint() = default;
+  virtual ~CartesianWaypoint() = default;
 
   void print(const std::string& prefix = "") const
   {
@@ -53,6 +54,8 @@ public:
               << this->translation().z() << std::endl;  // NOLINT
     // TODO: Add rotation
   }
+
+  virtual bool isValidCast(std::type_index id) const { return (id == std::type_index(typeid(CartesianWaypoint))); }
 
   /////////////////////
   // Eigen Container //

--- a/tesseract_command_language/include/tesseract_command_language/core/instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/core/instruction.h
@@ -76,9 +76,11 @@ namespace detail_instruction
 CREATE_MEMBER_CHECK(getDescription);
 CREATE_MEMBER_CHECK(setDescription);
 CREATE_MEMBER_CHECK(print);
+// CREATE_MEMBER_CHECK(isValidCast);
 CREATE_MEMBER_FUNC_SIGNATURE_NOARGS_CHECK(getDescription, const std::string&);
 CREATE_MEMBER_FUNC_SIGNATURE_CHECK(setDescription, void, const std::string&);
 CREATE_MEMBER_FUNC_SIGNATURE_CHECK(print, void, std::string);
+// CREATE_MEMBER_FUNC_SIGNATURE_CHECK(isValidCast, bool, std::type_index);
 
 struct InstructionInnerBase
 {
@@ -95,6 +97,8 @@ struct InstructionInnerBase
   virtual void setDescription(const std::string& description) = 0;
 
   virtual void print(const std::string& prefix) const = 0;
+
+  //  virtual bool isValidCast(std::type_index id) const = 0;
 
   virtual bool operator==(const InstructionInnerBase& rhs) const = 0;
 
@@ -127,11 +131,13 @@ struct InstructionInner final : InstructionInnerBase
     static_assert(has_member_getDescription<T>::value, "Class does not have member function 'getDescription'");
     static_assert(has_member_setDescription<T>::value, "Class does not have member function 'setDescription'");
     static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
+    static_assert(has_member_isValidCast<T>::value, "Class does not have member function 'isValidCast'");
     static_assert(has_member_func_signature_getDescription<T>::value,
                   "Class 'getDescription' function has incorrect signature");
     static_assert(has_member_func_signature_setDescription<T>::value,
                   "Class 'setDescription' function has incorrect signature");
     static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
+    static_assert(has_member_func_signature_isValidCast<T>::value, "Class 'isValidCast' function has incorrect signature");
   }
   ~InstructionInner() override = default;
   InstructionInner(const InstructionInner&) = delete;
@@ -145,11 +151,13 @@ struct InstructionInner final : InstructionInnerBase
     static_assert(has_member_getDescription<T>::value, "Class does not have member function 'getDescription'");
     static_assert(has_member_setDescription<T>::value, "Class does not have member function 'setDescription'");
     static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
+    static_assert(has_member_isValidCast<T>::value, "Class does not have member function 'isValidCast'");
     static_assert(has_member_func_signature_getDescription<T>::value,
                   "Class 'getDescription' function has incorrect signature");
     static_assert(has_member_func_signature_setDescription<T>::value,
                   "Class 'setDescription' function has incorrect signature");
     static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
+    static_assert(has_member_func_signature_isValidCast<T>::value, "Class 'isValidCast' function has incorrect signature");
   }
 
   explicit InstructionInner(T&& instruction) : instruction_(std::move(instruction))
@@ -157,11 +165,13 @@ struct InstructionInner final : InstructionInnerBase
     static_assert(has_member_getDescription<T>::value, "Class does not have member function 'getDescription'");
     static_assert(has_member_setDescription<T>::value, "Class does not have member function 'setDescription'");
     static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
+    static_assert(has_member_isValidCast<T>::value, "Class does not have member function 'isValidCast'");
     static_assert(has_member_func_signature_getDescription<T>::value,
                   "Class 'getDescription' function has incorrect signature");
     static_assert(has_member_func_signature_setDescription<T>::value,
                   "Class 'setDescription' function has incorrect signature");
     static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
+    static_assert(has_member_func_signature_isValidCast<T>::value, "Class 'isValidCast' function has incorrect signature");
   }
 
   std::unique_ptr<InstructionInnerBase> clone() const final { return std::make_unique<InstructionInner>(instruction_); }
@@ -177,6 +187,8 @@ struct InstructionInner final : InstructionInnerBase
   void setDescription(const std::string& description) final { instruction_.setDescription(description); }
 
   void print(const std::string& prefix) const final { instruction_.print(prefix); }
+
+  bool isValidCast(std::type_index id) const final { instruction_.isValidCast(id); };
 
   bool operator==(const InstructionInnerBase& rhs) const final
   {
@@ -273,6 +285,8 @@ public:
   void setDescription(const std::string& description);
 
   void print(const std::string& prefix = "") const;
+
+  bool isValidCast(std::type_index id) const;
 
   bool operator==(const Instruction& rhs) const;
 

--- a/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
@@ -44,8 +44,11 @@ public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   JointWaypoint() = default;
+  virtual ~JointWaypoint() = default;
 
   void print(const std::string& prefix = "") const;
+
+  virtual bool isValidCast(std::type_index id) const;
 
 #ifndef SWIG
 

--- a/tesseract_command_language/include/tesseract_command_language/null_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/null_waypoint.h
@@ -39,7 +39,11 @@ namespace tesseract_planning
 class NullWaypoint
 {
 public:
+  virtual ~NullWaypoint() = default;
+
   void print(const std::string& prefix = "") const;
+
+  virtual bool isValidCast(std::type_index id) const;
 
   bool operator==(const NullWaypoint& rhs) const;
   bool operator!=(const NullWaypoint& rhs) const;

--- a/tesseract_command_language/include/tesseract_command_language/state_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/state_waypoint.h
@@ -47,8 +47,11 @@ class StateWaypoint : public tesseract_common::JointState
 public:
   StateWaypoint() = default;
   StateWaypoint(std::vector<std::string> joint_names, const Eigen::Ref<const Eigen::VectorXd>& position);
+  virtual ~StateWaypoint() = default;
 
   void print(const std::string& prefix = "") const;
+
+  virtual bool isValidCast(std::type_index id) const;
 
   bool operator==(const StateWaypoint& rhs) const;
   bool operator!=(const StateWaypoint& rhs) const;

--- a/tesseract_command_language/src/core/instruction.cpp
+++ b/tesseract_command_language/src/core/instruction.cpp
@@ -47,6 +47,8 @@ void tesseract_planning::Instruction::setDescription(const std::string& descript
 
 void tesseract_planning::Instruction::print(const std::string& prefix) const { instruction_->print(prefix); }
 
+// bool tesseract_planning::Instruction::isValidCast(std::type_index id) const { return instruction_->isValidCast(id); }
+
 bool tesseract_planning::Instruction::operator==(const Instruction& rhs) const
 {
   return instruction_->operator==(*rhs.instruction_);

--- a/tesseract_command_language/src/core/waypoint.cpp
+++ b/tesseract_command_language/src/core/waypoint.cpp
@@ -37,6 +37,8 @@ std::type_index tesseract_planning::Waypoint::getType() const { return waypoint_
 
 void tesseract_planning::Waypoint::print(const std::string& prefix) const { waypoint_->print(prefix); }
 
+bool tesseract_planning::Waypoint::isValidCast(std::type_index id) const { return waypoint_->isValidCast(id); }
+
 bool tesseract_planning::Waypoint::operator==(const Waypoint& rhs) const
 {
   return waypoint_->operator==(*rhs.waypoint_);

--- a/tesseract_command_language/src/joint_waypoint.cpp
+++ b/tesseract_command_language/src/joint_waypoint.cpp
@@ -17,6 +17,8 @@ void JointWaypoint::print(const std::string& prefix) const
   std::cout << prefix << "Joint WP: " << this->transpose() << std::endl;  // NOLINT
 }
 
+bool JointWaypoint::isValidCast(std::type_index id) const { return (id == std::type_index(typeid(JointWaypoint))); }
+
 bool JointWaypoint::isToleranced() const
 {
   // Check if they are empty

--- a/tesseract_command_language/src/null_waypoint.cpp
+++ b/tesseract_command_language/src/null_waypoint.cpp
@@ -35,6 +35,8 @@ namespace tesseract_planning
 {
 void NullWaypoint::print(const std::string& prefix) const { std::cout << prefix << "Null WP"; }  // NOLINT
 
+bool NullWaypoint::isValidCast(std::type_index id) const { return (id == std::type_index(typeid(NullWaypoint))); }
+
 bool NullWaypoint::operator==(const NullWaypoint& /*rhs*/) const { return true; }
 bool NullWaypoint::operator!=(const NullWaypoint& /*rhs*/) const { return false; }
 

--- a/tesseract_command_language/src/state_waypoint.cpp
+++ b/tesseract_command_language/src/state_waypoint.cpp
@@ -42,6 +42,8 @@ void StateWaypoint::print(const std::string& prefix) const
   std::cout << prefix << "State WP: Pos=" << position.transpose() << std::endl;  // NOLINT
 }
 
+bool StateWaypoint::isValidCast(std::type_index id) const { return (id == std::type_index(typeid(StateWaypoint))); }
+
 bool StateWaypoint::operator==(const StateWaypoint& rhs) const
 {
   static auto max_diff = static_cast<double>(std::numeric_limits<float>::epsilon());

--- a/tesseract_command_language/src/state_waypoint.cpp
+++ b/tesseract_command_language/src/state_waypoint.cpp
@@ -42,7 +42,13 @@ void StateWaypoint::print(const std::string& prefix) const
   std::cout << prefix << "State WP: Pos=" << position.transpose() << std::endl;  // NOLINT
 }
 
-bool StateWaypoint::isValidCast(std::type_index id) const { return (id == std::type_index(typeid(StateWaypoint))); }
+bool StateWaypoint::isValidCast(std::type_index id) const
+{
+  if (id == std::type_index(typeid(StateWaypoint)))
+    return true;
+
+  return (id == std::type_index(typeid(tesseract_common::JointState)));
+}
 
 bool StateWaypoint::operator==(const StateWaypoint& rhs) const
 {

--- a/tesseract_command_language/src/utils/utils.cpp
+++ b/tesseract_command_language/src/utils/utils.cpp
@@ -64,8 +64,8 @@ tesseract_common::JointTrajectory toJointTrajectory(const CompositeInstruction& 
   for (auto& i : flattened_program)
   {
     const auto& mi = i.get().as<tesseract_planning::MoveInstruction>();
-    const auto& swp = mi.getWaypoint().as<tesseract_planning::StateWaypoint>();
-    tesseract_common::JointState joint_state(swp);
+    const auto& js = mi.getWaypoint().as<tesseract_common::JointState>();
+    tesseract_common::JointState joint_state(js);
     current_time = joint_state.time;
 
     // It is possible for sub composites to start back from zero, this accounts for it

--- a/tesseract_command_language/src/waypoint_type.cpp
+++ b/tesseract_command_language/src/waypoint_type.cpp
@@ -39,19 +39,13 @@ namespace tesseract_planning
 {
 bool isCartesianWaypoint(const Waypoint& waypoint)
 {
-  return (waypoint.getType() == std::type_index(typeid(CartesianWaypoint)));
+  return waypoint.isValidCast(std::type_index(typeid(CartesianWaypoint)));
 }
 
-bool isJointWaypoint(const Waypoint& waypoint)
-{
-  return (waypoint.getType() == std::type_index(typeid(JointWaypoint)));
-}
+bool isJointWaypoint(const Waypoint& waypoint) { return waypoint.isValidCast(std::type_index(typeid(JointWaypoint))); }
 
-bool isStateWaypoint(const Waypoint& waypoint)
-{
-  return (waypoint.getType() == std::type_index(typeid(StateWaypoint)));
-}
+bool isStateWaypoint(const Waypoint& waypoint) { return waypoint.isValidCast(std::type_index(typeid(StateWaypoint))); }
 
-bool isNullWaypoint(const Waypoint& waypoint) { return (waypoint.getType() == std::type_index(typeid(NullWaypoint))); }
+bool isNullWaypoint(const Waypoint& waypoint) { return waypoint.isValidCast(std::type_index(typeid(NullWaypoint))); }
 
 }  // namespace tesseract_planning

--- a/tesseract_command_language/test/cartesian_waypoint_unit.cpp
+++ b/tesseract_command_language/test/cartesian_waypoint_unit.cpp
@@ -38,6 +38,31 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 using namespace tesseract_planning;
 
+class DerivedCartesianWaypoint : public CartesianWaypoint
+{
+public:
+  double user_data{ 0 };
+  using CartesianWaypoint::CartesianWaypoint;
+
+  bool isValidCast(std::type_index id) const override
+  {
+    if (id == std::type_index(typeid(DerivedCartesianWaypoint)))
+      return true;
+
+    return CartesianWaypoint::isValidCast(id);
+  }
+};
+
+TEST(TesseractCommandLanguageCartesianWaypointUnit, derived)  // NOLINT
+{
+  Waypoint wp = DerivedCartesianWaypoint(Eigen::Isometry3d::Identity());
+  EXPECT_TRUE(isCartesianWaypoint(wp));
+  auto& cwp = wp.as<CartesianWaypoint>();
+  EXPECT_TRUE(isCartesianWaypoint(cwp));
+  auto& dcwp = wp.as<DerivedCartesianWaypoint>();
+  EXPECT_TRUE(isCartesianWaypoint(dcwp));
+}
+
 TEST(TesseractCommandLanguageCartesianWaypointUnit, isToleranced)  // NOLINT
 {
   Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();


### PR DESCRIPTION
@marip8  and @mpowelson This will enable to use derived types for waypoint types ans instruction types. I have the waypoint finished along with a unit test which was failing before the change and now passes. I am working on instructions now. Let me know what you think.