### PR TITLE
Fix logic in FixStateBounds for case ALL

### DIFF
--- a/tesseract_command_language/test/utils_test.cpp
+++ b/tesseract_command_language/test/utils_test.cpp
@@ -340,6 +340,12 @@ TEST(TesseractCommandLanguageUtilsUnit, isWithinJointLimits)  // NOLINT
     Waypoint tmp(jp);
     EXPECT_FALSE(isWithinJointLimits(tmp, limits));
   }
+  // Cartesian Waypoint
+  {
+    CartesianWaypoint jp;
+    Waypoint tmp(jp);
+    EXPECT_TRUE(isWithinJointLimits(tmp, limits));
+  }
 }
 
 TEST(TesseractCommandLanguageUtilsUnit, clampToJointLimits)  // NOLINT

--- a/tesseract_process_managers/src/task_generators/fix_state_bounds_task_generator.cpp
+++ b/tesseract_process_managers/src/task_generators/fix_state_bounds_task_generator.cpp
@@ -147,13 +147,13 @@ int FixStateBoundsTaskGenerator::conditionalProcess(TaskInput input, std::size_t
         return 1;
       }
 
-      bool outside_limits = false;
+      bool inside_limits = true;
       for (const auto& instruction : flattened)
       {
-        outside_limits |=
+        inside_limits &=
             isWithinJointLimits(instruction.get().as<PlanInstruction>().getWaypoint(), limits.joint_limits);
       }
-      if (!outside_limits)
+      if (inside_limits)
         break;
 
       CONSOLE_BRIDGE_logInform("FixStateBoundsTaskGenerator is modifying the const input instructions");


### PR DESCRIPTION
This fixes a logic mistake in FixStateBounds that was causing it to always clamp the limits 