### PR TITLE
Make process planning server threadsafe and support multiple executors

### DIFF
--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_request.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_request.h
@@ -39,9 +39,15 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
+/** @brief The name of the primary executor (thread pool) */
+static const std::string PRIMARY_EXECUTOR_NAME = "primary";
+
 class ProcessPlanningRequest
 {
 public:
+  /** @brief The name of the executor to use */
+  std::string executor{ PRIMARY_EXECUTOR_NAME };
+
   /** @brief The name of the Process Pipeline (aka. Taskflow) to use */
   std::string name;
 

--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_request.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_request.h
@@ -46,7 +46,7 @@ class ProcessPlanningRequest
 {
 public:
   /** @brief The name of the executor to use */
-  std::string executor{ PRIMARY_EXECUTOR_NAME };
+  std::string executor_name{ PRIMARY_EXECUTOR_NAME };
 
   /** @brief The name of the Process Pipeline (aka. Taskflow) to use */
   std::string name;

--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
@@ -30,6 +30,8 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <string>
+#include <vector>
+#include <shared_mutex>
 #include <taskflow/taskflow.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
@@ -50,6 +52,7 @@ namespace tesseract_planning
 /**
  * @brief A process planning server that support asynchronous execution of process planning requests
  * @details It allows the developer to register Process pipelines (aka. Taskflow Generators) so they may be request
+ * @note This class is thread safe
  */
 class ProcessPlanningServer
 {
@@ -86,6 +89,27 @@ public:
   ProcessPlanningServer(ProcessPlanningServer&&) = default;
   ProcessPlanningServer& operator=(ProcessPlanningServer&&) = default;
 #endif  // SWIG
+
+  /**
+   * @brief Add a executors (thread pool) under the provided name
+   * @brief This creates a taskflow executor with the provided number of threads
+   * @param name The name of the thread pool
+   * @param n The number of threads
+   */
+  void addExecutor(const std::string& name, size_t n);
+
+  /**
+   * @brief Check if executors (thread pool) exists with the provided name
+   * @param name The name to search
+   * @return True if it exists, otherwise false
+   */
+  bool hasExecutor(const std::string& name) const;
+
+  /**
+   * @brief Get the available executors (thread pool) names
+   * @return A vector of names
+   */
+  std::vector<std::string> getAvailableExecutors() const;
 
 #ifndef SWIG
   /**
@@ -126,10 +150,11 @@ public:
 
   /**
    * @brief This is a utility function to run arbitrary taskflows
-   * @param taskflow the taskflow to execute
+   * @param taskflow The taskflow to execute
+   * @param name The name of the executor to use
    * @return A future to monitor progress
    */
-  tf::Future<void> run(tf::Taskflow& taskflow) const;
+  tf::Future<void> run(tf::Taskflow& taskflow, const std::string& name = PRIMARY_EXECUTOR_NAME) const;
 #endif  // SWIG
 
 #ifdef SWIG
@@ -142,14 +167,23 @@ public:
   }
 #endif  // SWIG
 
-  /** @brief Wait for all process currently being executed to finish before returning */
-  void waitForAll();
+  /**
+   * @brief Wait for all process currently being executed to finish before returning
+   * @param name The name of the executor to wait on
+   */
+  void waitForAll(const std::string& name = PRIMARY_EXECUTOR_NAME) const;
 
-  /** @brief This add a Taskflow profiling observer to the executor */
-  void enableTaskflowProfiling();
+  /**
+   * @brief This add a Taskflow profiling observer to the executor
+   * @param name The name of the executor to enable profiling for
+   */
+  void enableTaskflowProfiling(const std::string& name = PRIMARY_EXECUTOR_NAME);
 
-  /** @brief This remove the Taskflow profiling observer from the executor if one exists */
-  void disableTaskflowProfiling();
+  /**
+   * @brief This remove the Taskflow profiling observer from the executor if one exists
+   * @param name The name of the executor to disable profiling for
+   */
+  void disableTaskflowProfiling(const std::string& name = PRIMARY_EXECUTOR_NAME);
 
   /**
    * @brief Get the profile dictionary associated with the planning server
@@ -163,12 +197,36 @@ public:
    */
   ProfileDictionary::ConstPtr getProfiles() const;
 
-protected:
-  EnvironmentCache::ConstPtr cache_;
-  mutable std::shared_ptr<tf::Executor> executor_;
-  std::shared_ptr<tf::TFProfObserver> profile_observer_;
+  /**
+   * @brief Queries the number of worker threads (can be zero)
+   * @param name The name of the executor to get worker count for
+   */
+  long getWorkerCount(const std::string& name = PRIMARY_EXECUTOR_NAME) const;
 
+  /**
+   * @brief Queries the number of running tasks at the time of this call
+   * When a taskflow is submitted to an executor, a topology is created to store
+   * runtime metadata of the running taskflow.
+   * @param name The name of the executor to get task count for
+   */
+  long getTaskCount(const std::string& name = PRIMARY_EXECUTOR_NAME) const;
+
+protected:
+  mutable std::shared_mutex mutex_;
+
+  /** @brief An environment cache which is thread safe */
+  EnvironmentCache::ConstPtr cache_;
+
+  /** @brief A map of executors which are thread safe */
+  std::unordered_map<std::string, std::shared_ptr<tf::Executor>> executors_;
+
+  /** @brief A map of profile observers */
+  std::unordered_map<std::string, std::shared_ptr<tf::TFProfObserver>> profile_observers_;
+
+  /** @brief A map of process planners */
   std::unordered_map<std::string, TaskflowGenerator::UPtr> process_planners_;
+
+  /** @brief The profile dictionary which is thread safe */
   ProfileDictionary::Ptr profiles_{ std::make_shared<ProfileDictionary>() };
 };
 

--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
@@ -84,15 +84,22 @@ public:
 
   virtual ~ProcessPlanningServer() = default;
 #ifndef SWIG
-  ProcessPlanningServer(const ProcessPlanningServer&) = default;
-  ProcessPlanningServer& operator=(const ProcessPlanningServer&) = default;
-  ProcessPlanningServer(ProcessPlanningServer&&) = default;
-  ProcessPlanningServer& operator=(ProcessPlanningServer&&) = default;
+  ProcessPlanningServer(const ProcessPlanningServer&) = delete;
+  ProcessPlanningServer& operator=(const ProcessPlanningServer&) = delete;
+  ProcessPlanningServer(ProcessPlanningServer&&) = delete;
+  ProcessPlanningServer& operator=(ProcessPlanningServer&&) = delete;
 #endif  // SWIG
 
   /**
    * @brief Add a executors (thread pool) under the provided name
-   * @brief This creates a taskflow executor with the provided number of threads
+   * @param name The name of the thread pool
+   * @param executor The executor to add
+   */
+  void addExecutor(const std::string& name, std::shared_ptr<tf::Executor> executor);
+
+  /**
+   * @brief Add a executors (thread pool) under the provided name
+   * @details This creates a taskflow executor with the provided number of threads
    * @param name The name of the thread pool
    * @param n The number of threads
    */

--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_server.h
@@ -95,7 +95,7 @@ public:
    * @param name The name of the thread pool
    * @param executor The executor to add
    */
-  void addExecutor(const std::string& name, std::shared_ptr<tf::Executor> executor);
+  void addExecutor(const std::string& name, const std::shared_ptr<tf::Executor>& executor);
 
   /**
    * @brief Add a executors (thread pool) under the provided name

--- a/tesseract_process_managers/src/core/process_planning_future.cpp
+++ b/tesseract_process_managers/src/core/process_planning_future.cpp
@@ -67,7 +67,7 @@ bool ProcessPlanningFuture::operator==(const tesseract_planning::ProcessPlanning
 {
   bool equal = true;
   equal &= process_future.valid() == rhs.process_future.valid();
-  equal &= (problem && rhs.problem && *problem == *rhs.problem) || (!problem && !rhs.problem);
+  equal &= tesseract_common::pointersEqual(problem, rhs.problem);
   equal &= tesseract_common::pointersEqual(interface, rhs.interface);
 
   return equal;

--- a/tesseract_process_managers/src/core/process_planning_request.cpp
+++ b/tesseract_process_managers/src/core/process_planning_request.cpp
@@ -40,7 +40,7 @@ bool tesseract_planning::ProcessPlanningRequest::operator==(const tesseract_plan
   using namespace tesseract_common;
   using namespace tesseract_environment;
   bool equal = true;
-  equal &= executor == rhs.executor;
+  equal &= executor_name == rhs.executor_name;
   equal &= name == rhs.name;
   equal &= instructions == rhs.instructions;
   equal &= seed == rhs.seed;
@@ -62,7 +62,7 @@ template <class Archive>
 void tesseract_planning::ProcessPlanningRequest::serialize(Archive& ar, const unsigned int version)
 {
   if (version == 1)
-    ar& BOOST_SERIALIZATION_NVP(executor);
+    ar& BOOST_SERIALIZATION_NVP(executor_name);
 
   ar& BOOST_SERIALIZATION_NVP(name);
   ar& BOOST_SERIALIZATION_NVP(instructions);

--- a/tesseract_process_managers/src/core/process_planning_request.cpp
+++ b/tesseract_process_managers/src/core/process_planning_request.cpp
@@ -40,6 +40,7 @@ bool tesseract_planning::ProcessPlanningRequest::operator==(const tesseract_plan
   using namespace tesseract_common;
   using namespace tesseract_environment;
   bool equal = true;
+  equal &= executor == rhs.executor;
   equal &= name == rhs.name;
   equal &= instructions == rhs.instructions;
   equal &= seed == rhs.seed;
@@ -58,8 +59,11 @@ bool tesseract_planning::ProcessPlanningRequest::operator!=(const tesseract_plan
 }
 
 template <class Archive>
-void tesseract_planning::ProcessPlanningRequest::serialize(Archive& ar, const unsigned int /*version*/)
+void tesseract_planning::ProcessPlanningRequest::serialize(Archive& ar, const unsigned int version)
 {
+  if (version == 1)
+    ar& BOOST_SERIALIZATION_NVP(executor);
+
   ar& BOOST_SERIALIZATION_NVP(name);
   ar& BOOST_SERIALIZATION_NVP(instructions);
   ar& BOOST_SERIALIZATION_NVP(seed);
@@ -70,6 +74,8 @@ void tesseract_planning::ProcessPlanningRequest::serialize(Archive& ar, const un
   ar& BOOST_SERIALIZATION_NVP(plan_profile_remapping);
   ar& BOOST_SERIALIZATION_NVP(composite_profile_remapping);
 }
+
+BOOST_CLASS_VERSION(tesseract_planning::ProcessPlanningRequest, 1)  // Adding executor
 
 #include <tesseract_common/serialization.h>
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::ProcessPlanningRequest)

--- a/tesseract_process_managers/src/core/process_planning_server.cpp
+++ b/tesseract_process_managers/src/core/process_planning_server.cpp
@@ -58,6 +58,13 @@ ProcessPlanningServer::ProcessPlanningServer(tesseract_environment::Environment:
   addExecutor(PRIMARY_EXECUTOR_NAME, n);
 }
 
+void ProcessPlanningServer::addExecutor(const std::string& name, std::shared_ptr<tf::Executor> executor)
+{
+  std::unique_lock lock(mutex_);
+  executors_[name] = executor;
+  executor->make_observer<DebugObserver>("ProcessPlanningObserver");
+}
+
 void ProcessPlanningServer::addExecutor(const std::string& name, size_t n)
 {
   std::unique_lock lock(mutex_);
@@ -215,7 +222,7 @@ ProcessPlanningFuture ProcessPlanningServer::run(const ProcessPlanningRequest& r
   std::shared_ptr<tf::Executor> executor;
   {
     std::shared_lock lock(mutex_);
-    executor = executors_.at(request.executor);
+    executor = executors_.at(request.executor_name);
   }
   tf::Future<void> fu = executor->run(*(response.problem->taskflow_container.taskflow));
   response.process_future = fu.share();

--- a/tesseract_process_managers/src/core/process_planning_server.cpp
+++ b/tesseract_process_managers/src/core/process_planning_server.cpp
@@ -58,7 +58,7 @@ ProcessPlanningServer::ProcessPlanningServer(tesseract_environment::Environment:
   addExecutor(PRIMARY_EXECUTOR_NAME, n);
 }
 
-void ProcessPlanningServer::addExecutor(const std::string& name, std::shared_ptr<tf::Executor> executor)
+void ProcessPlanningServer::addExecutor(const std::string& name, const std::shared_ptr<tf::Executor>& executor)
 {
   std::unique_lock lock(mutex_);
   executors_[name] = executor;


### PR DESCRIPTION
This now allows for user defined executors which is selected as part of the process planning request. This essentially allows you to define different thread pools instead of just have a single one.