### PR TITLE
Update toJointTrajectory to support plan instructions

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/utils/utils.h
+++ b/tesseract_command_language/include/tesseract_command_language/utils/utils.h
@@ -44,6 +44,8 @@ namespace tesseract_planning
 {
 /**
  * @brief Convert composite instruction to a joint trajectory
+ * @details This searches for both move and plan instruction to support converting both input and results to planning
+ * requests. If it contains a Cartesian waypoint it is skipped.
  * @param composite_instructions The composite instruction to convert
  * @return A joint trajectory
  */


### PR DESCRIPTION
Previously this function only supported composites with all move instruction, but to support visualizing the input instruction it was updated to handle plan instructions. Currently it skips any plan instruction with a cartesian waypoint.