### PR TITLE
Update to use new type erasure interface

### DIFF
--- a/.github/workflows/dependencies_windows_build.rosinstall
+++ b/.github/workflows/dependencies_windows_build.rosinstall
@@ -9,7 +9,7 @@
 - git:
     local-name: tesseract
     uri: https://github.com/ros-industrial-consortium/tesseract.git
-    version: 0.9.9
+    version: 0.9.10
 - git:
     local-name: trajopt
     uri: https://github.com/ros-industrial-consortium/trajopt_ros.git

--- a/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/cartesian_waypoint.h
@@ -223,7 +223,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_waypoint_type(CartesianWaypoint)
 #else
-TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning::CartesianWaypoint);
+TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning, CartesianWaypoint);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_CARTESIAN_WAYPOINT_H

--- a/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
@@ -286,7 +286,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(CompositeInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::CompositeInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, CompositeInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_COMPOSITE_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/core/instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/core/instruction.h
@@ -29,19 +29,14 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
-#include <typeindex>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/export.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/unique_ptr.hpp>
-#include <boost/serialization/export.hpp>
-#include <boost/type_traits/is_virtual_base_of.hpp>
+#include <boost/concept_check.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
-#include <tesseract_common/serialization.h>
 #include <tesseract_command_language/core/waypoint.h>
 #include <tesseract_common/serialization.h>
-#include <tesseract_common/sfinae_utils.h>
+#include <tesseract_common/type_erasure.h>
 
 #ifdef SWIG
 %ignore std::vector<tesseract_planning::Instruction>::vector(size_type);
@@ -51,222 +46,120 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #endif  // SWIG
 
 /** @brief If shared library, this must go in the header after the class definition */
-#define TESSERACT_INSTRUCTION_EXPORT_KEY(inst)                                                                         \
-  BOOST_CLASS_EXPORT_KEY2(tesseract_planning::detail_instruction::InstructionInner<inst>, #inst)                       \
-  BOOST_CLASS_TRACKING(tesseract_planning::detail_instruction::InstructionInner<inst>,                                 \
-                       boost::serialization::track_never)
+#define TESSERACT_INSTRUCTION_EXPORT_KEY(N, C)                                                                         \
+  namespace N                                                                                                          \
+  {                                                                                                                    \
+  using C##InstanceBase =                                                                                              \
+      tesseract_common::TypeErasureInstance<C, tesseract_planning::detail_instruction::InstructionInterface>;          \
+  using C##Instance = tesseract_planning::detail_instruction::InstructionInstance<C>;                                  \
+  using C##InstanceWrapper = tesseract_common::TypeErasureInstanceWrapper<C##Instance>;                                \
+  }                                                                                                                    \
+  BOOST_CLASS_EXPORT_KEY(N::C##InstanceBase)                                                                           \
+  BOOST_CLASS_EXPORT_KEY(N::C##Instance)                                                                               \
+  BOOST_CLASS_EXPORT_KEY(N::C##InstanceWrapper)                                                                        \
+  BOOST_CLASS_TRACKING(N::C##InstanceBase, boost::serialization::track_never)                                          \
+  BOOST_CLASS_TRACKING(N::C##Instance, boost::serialization::track_never)                                              \
+  BOOST_CLASS_TRACKING(N::C##InstanceWrapper, boost::serialization::track_never)
 
 /** @brief If shared library, this must go in the cpp after the implicit instantiation of the serialize function */
 #define TESSERACT_INSTRUCTION_EXPORT_IMPLEMENT(inst)                                                                   \
-  BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::detail_instruction::InstructionInner<inst>)
+  BOOST_CLASS_EXPORT_IMPLEMENT(inst##InstanceBase)                                                                     \
+  BOOST_CLASS_EXPORT_IMPLEMENT(inst##Instance)                                                                         \
+  BOOST_CLASS_EXPORT_IMPLEMENT(inst##InstanceWrapper)
 
 /**
  * @brief This should not be used within shared libraries use the two above.
  * If not in a shared library it can go in header or cpp
  */
-#define TESSERACT_INSTRUCTION_EXPORT(inst)                                                                             \
-  TESSERACT_INSTRUCTION_EXPORT_KEY(inst)                                                                               \
-  TESSERACT_INSTRUCTION_EXPORT_IMPLEMENT(inst)
+#define TESSERACT_INSTRUCTION_EXPORT(N, C)                                                                             \
+  TESSERACT_INSTRUCTION_EXPORT_KEY(N, C)                                                                               \
+  TESSERACT_INSTRUCTION_EXPORT_IMPLEMENT(N::C)
 
 namespace tesseract_planning
 {
 #ifndef SWIG
 namespace detail_instruction
 {
-CREATE_MEMBER_CHECK(getDescription);
-CREATE_MEMBER_CHECK(setDescription);
-CREATE_MEMBER_CHECK(print);
-CREATE_MEMBER_FUNC_SIGNATURE_NOARGS_CHECK(getDescription, const std::string&);
-CREATE_MEMBER_FUNC_SIGNATURE_CHECK(setDescription, void, const std::string&);
-CREATE_MEMBER_FUNC_SIGNATURE_CHECK(print, void, std::string);
-
-struct InstructionInnerBase
+template <typename T>
+struct InstructionConcept  // NOLINT
+  : boost::Assignable<T>,
+    boost::CopyConstructible<T>,
+    boost::EqualityComparable<T>
 {
-  InstructionInnerBase() = default;
-  virtual ~InstructionInnerBase() = default;
-  InstructionInnerBase(const InstructionInnerBase&) = delete;
-  InstructionInnerBase& operator=(const InstructionInnerBase&) = delete;
-  InstructionInnerBase(InstructionInnerBase&&) = delete;
-  InstructionInnerBase& operator=(InstructionInnerBase&&) = delete;
+  BOOST_CONCEPT_USAGE(InstructionConcept)
+  {
+    T cp(c);
+    T assign = c;
+    bool eq = (c == cp);
+    bool neq = (c != cp);
+    UNUSED(assign);
+    UNUSED(eq);
+    UNUSED(neq);
 
-  // User-defined methods
+    const std::string& desc = c.getDescription();
+    UNUSED(desc);
+
+    c.setDescription("test");
+    c.print();
+    c.print("prefix_");
+  }
+
+private:
+  T c;
+};
+
+struct InstructionInterface : tesseract_common::TypeErasureInterface
+{
   virtual const std::string& getDescription() const = 0;
 
   virtual void setDescription(const std::string& description) = 0;
 
   virtual void print(const std::string& prefix) const = 0;
 
-  virtual bool operator==(const InstructionInnerBase& rhs) const = 0;
-
-  // This is not required for user defined implementation
-  virtual bool operator!=(const InstructionInnerBase& rhs) const = 0;
-
-  // This is not required for user defined implementation
-  virtual std::type_index getType() const = 0;
-
-  // This is not required for user defined implementation
-  virtual void* recover() = 0;
-
-  // This is not required for user defined implementation
-  virtual const void* recover() const = 0;
-
-  // This is not required for user defined implementation
-  virtual std::unique_ptr<InstructionInnerBase> clone() const = 0;
-
 private:
   friend class boost::serialization::access;
+  friend struct tesseract_common::Serialization;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 };
 
 template <typename T>
-struct InstructionInner final : InstructionInnerBase
+struct InstructionInstance : tesseract_common::TypeErasureInstance<T, InstructionInterface>  // NOLINT
 {
-  InstructionInner()
-  {
-    static_assert(has_member_getDescription<T>::value, "Class does not have member function 'getDescription'");
-    static_assert(has_member_setDescription<T>::value, "Class does not have member function 'setDescription'");
-    static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
-    static_assert(has_member_func_signature_getDescription<T>::value,
-                  "Class 'getDescription' function has incorrect signature");
-    static_assert(has_member_func_signature_setDescription<T>::value,
-                  "Class 'setDescription' function has incorrect signature");
-    static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
-  }
-  ~InstructionInner() override = default;
-  InstructionInner(const InstructionInner&) = delete;
-  InstructionInner(InstructionInner&&) = delete;
-  InstructionInner& operator=(const InstructionInner&) = delete;
-  InstructionInner& operator=(InstructionInner&&) = delete;
+  using BaseType = tesseract_common::TypeErasureInstance<T, InstructionInterface>;
+  InstructionInstance() = default;
+  InstructionInstance(const T& x) : BaseType(x) {}
+  InstructionInstance(InstructionInstance&& x) noexcept : BaseType(std::move(x)) {}
 
-  // Constructors from T (copy and move variants).
-  explicit InstructionInner(T instruction) : instruction_(std::move(instruction))
-  {
-    static_assert(has_member_getDescription<T>::value, "Class does not have member function 'getDescription'");
-    static_assert(has_member_setDescription<T>::value, "Class does not have member function 'setDescription'");
-    static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
-    static_assert(has_member_func_signature_getDescription<T>::value,
-                  "Class 'getDescription' function has incorrect signature");
-    static_assert(has_member_func_signature_setDescription<T>::value,
-                  "Class 'setDescription' function has incorrect signature");
-    static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
-  }
+  BOOST_CONCEPT_ASSERT((InstructionConcept<T>));
 
-  explicit InstructionInner(T&& instruction) : instruction_(std::move(instruction))
-  {
-    static_assert(has_member_getDescription<T>::value, "Class does not have member function 'getDescription'");
-    static_assert(has_member_setDescription<T>::value, "Class does not have member function 'setDescription'");
-    static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
-    static_assert(has_member_func_signature_getDescription<T>::value,
-                  "Class 'getDescription' function has incorrect signature");
-    static_assert(has_member_func_signature_setDescription<T>::value,
-                  "Class 'setDescription' function has incorrect signature");
-    static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
-  }
+  const std::string& getDescription() const final { return this->get().getDescription(); }
 
-  std::unique_ptr<InstructionInnerBase> clone() const final { return std::make_unique<InstructionInner>(instruction_); }
+  void setDescription(const std::string& description) final { this->get().setDescription(description); }
 
-  void* recover() final { return &instruction_; }
-
-  const void* recover() const final { return &instruction_; }
-
-  std::type_index getType() const final { return std::type_index(typeid(T)); }
-
-  const std::string& getDescription() const final { return instruction_.getDescription(); }
-
-  void setDescription(const std::string& description) final { instruction_.setDescription(description); }
-
-  void print(const std::string& prefix) const final { instruction_.print(prefix); }
-
-  bool operator==(const InstructionInnerBase& rhs) const final
-  {
-    // Compare class types before casting the incoming object to the T type
-    if (rhs.getType() == getType())
-    {
-      const auto* instruction = static_cast<const T*>(rhs.recover());
-      return instruction_ == *instruction;
-    }
-    return false;
-  }
-
-  bool operator!=(const InstructionInnerBase& rhs) const final { return !operator==(rhs); }
+  void print(const std::string& prefix) const final { this->get().print(prefix); }
 
 private:
   friend class boost::serialization::access;
+  friend struct tesseract_common::Serialization;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/)  // NOLINT
   {
-    // If this line is removed a exception is thrown for unregistered cast need to too look into this.
-    ar& boost::serialization::make_nvp("base", boost::serialization::base_object<InstructionInnerBase>(*this));
-    ar& boost::serialization::make_nvp("impl", instruction_);
+    ar& boost::serialization::make_nvp("base", boost::serialization::base_object<BaseType>(*this));
   }
-
-  T instruction_;
 };
 
 }  // namespace detail_instruction
 #endif  // SWIG
 }  // namespace tesseract_planning
 
-namespace boost
-{
-// Taken from pagmo to address the same issue
-// NOTE: in some earlier versions of Boost (i.e., at least up to 1.67)
-// the is_virtual_base_of type trait, used by the Boost serialization library, fails
-// with a compile time error if a class is declared final. Thus, we provide a specialised
-// implementation of this type trait to work around the issue. See:
-// https://www.boost.org/doc/libs/1_52_0/libs/type_traits/doc/html/boost_typetraits/reference/is_virtual_base_of.html
-// https://stackoverflow.com/questions/18982064/boost-serialization-of-base-class-of-final-subclass-error
-// We never use virtual inheritance, thus the specialisation is always false.
-template <typename T>
-struct is_virtual_base_of<tesseract_planning::detail_instruction::InstructionInnerBase,
-                          tesseract_planning::detail_instruction::InstructionInner<T>> : false_type
-{
-};
-}  // namespace boost
-
 namespace tesseract_planning
 {
-class Instruction
+using InstructionBase = tesseract_common::TypeErasureBase<detail_instruction::InstructionInterface,
+                                                          detail_instruction::InstructionInstance>;
+struct Instruction : InstructionBase
 {
-  template <typename T>
-  using uncvref_t = std::remove_cv_t<typename std::remove_reference<T>::type>;
-
-  // Enable the generic ctor only if ``T`` is not a ForwardKinematics (after removing const/reference qualifiers)
-  // If ``T`` is of type ForwardKinematics we disable so it will use the copy or move constructors of this class.
-  template <typename T>
-  using generic_ctor_enabler = std::enable_if_t<!std::is_same<Instruction, uncvref_t<T>>::value, int>;
-
-public:
-  template <typename T, generic_ctor_enabler<T> = 0>
-  Instruction(T&& instruction)  // NOLINT
-    : instruction_(std::make_unique<detail_instruction::InstructionInner<uncvref_t<T>>>(instruction))
-  {
-  }
-
-  // Destructor
-  ~Instruction() = default;
-
-  // Copy constructor
-  Instruction(const Instruction& other);
-
-  // Move ctor.
-  Instruction(Instruction&& other) noexcept;
-
-  // Move assignment.
-  Instruction& operator=(Instruction&& other) noexcept;
-
-  // Copy assignment.
-  Instruction& operator=(const Instruction& other);
-
-  template <typename T, generic_ctor_enabler<T> = 0>
-  Instruction& operator=(T&& other)
-  {
-    (*this) = Instruction(std::forward<T>(other));
-    return (*this);
-  }
-
-  std::type_index getType() const;
+  using InstructionBase::InstructionBase;
 
   const std::string& getDescription() const;
 
@@ -274,42 +167,12 @@ public:
 
   void print(const std::string& prefix = "") const;
 
-  bool operator==(const Instruction& rhs) const;
-
-  bool operator!=(const Instruction& rhs) const;
-
-  template <typename T>
-  T& as()
-  {
-    if (getType() != typeid(T))
-      throw std::runtime_error("Instruction, tried to cast '" + std::string(getType().name()) + "' to '" +
-                               std::string(typeid(T).name()) + "'!");
-
-    auto* p = static_cast<uncvref_t<T>*>(instruction_->recover());
-    return *p;
-  }
-
-  template <typename T>
-  const T& as() const
-  {
-    if (getType() != typeid(T))
-      throw std::runtime_error("Instruction, tried to cast '" + std::string(getType().name()) + "' to '" +
-                               std::string(typeid(T).name()) + "'!");
-
-    const auto* p = static_cast<const uncvref_t<T>*>(instruction_->recover());
-    return *p;
-  }
-
 private:
   friend class boost::serialization::access;
   friend struct tesseract_common::Serialization;
 
-  Instruction();  // NOLINT
-
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/);  // NOLINT
-
-  std::unique_ptr<detail_instruction::InstructionInnerBase> instruction_;
 };
 
 }  // namespace tesseract_planning
@@ -317,7 +180,14 @@ private:
 #ifdef SWIG
 %template(Instructions) std::vector<tesseract_planning::Instruction>;
 #else
-BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::detail_instruction::InstructionInnerBase)
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::detail_instruction::InstructionInterface)
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::detail_instruction::InstructionInterface)
+BOOST_CLASS_TRACKING(tesseract_planning::detail_instruction::InstructionInterface, boost::serialization::track_never)
+
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::InstructionBase)
+BOOST_CLASS_TRACKING(tesseract_planning::InstructionBase, boost::serialization::track_never)
+
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::Instruction)
 BOOST_CLASS_TRACKING(tesseract_planning::Instruction, boost::serialization::track_never);
 #endif  // SWIG
 

--- a/tesseract_command_language/include/tesseract_command_language/core/waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/core/waypoint.h
@@ -76,8 +76,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-class Waypoint;
-
 #ifndef SWIG
 namespace detail_waypoint
 {

--- a/tesseract_command_language/include/tesseract_command_language/core/waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/core/waypoint.h
@@ -33,14 +33,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <typeindex>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/export.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/unique_ptr.hpp>
-#include <boost/serialization/export.hpp>
-#include <boost/type_traits/is_virtual_base_of.hpp>
+#include <boost/concept_check.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/serialization.h>
-#include <tesseract_common/sfinae_utils.h>
+#include <tesseract_common/type_erasure.h>
 
 #ifdef SWIG
 //%template(Waypoints) std::vector<tesseract_planning::Waypoint>;
@@ -48,21 +45,34 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #endif  // SWIG
 
 /** @brief If shared library, this must go in the header after the class definition */
-#define TESSERACT_WAYPOINT_EXPORT_KEY(wp)                                                                              \
-  BOOST_CLASS_EXPORT_KEY2(tesseract_planning::detail_waypoint::WaypointInner<wp>, #wp)                                 \
-  BOOST_CLASS_TRACKING(tesseract_planning::detail_waypoint::WaypointInner<wp>, boost::serialization::track_never)
+#define TESSERACT_WAYPOINT_EXPORT_KEY(N, C)                                                                            \
+  namespace N                                                                                                          \
+  {                                                                                                                    \
+  using C##InstanceBase =                                                                                              \
+      tesseract_common::TypeErasureInstance<C, tesseract_planning::detail_waypoint::WaypointInterface>;                \
+  using C##Instance = tesseract_planning::detail_waypoint::WaypointInstance<C>;                                        \
+  using C##InstanceWrapper = tesseract_common::TypeErasureInstanceWrapper<C##Instance>;                                \
+  }                                                                                                                    \
+  BOOST_CLASS_EXPORT_KEY(N::C##InstanceBase)                                                                           \
+  BOOST_CLASS_EXPORT_KEY(N::C##Instance)                                                                               \
+  BOOST_CLASS_EXPORT_KEY(N::C##InstanceWrapper)                                                                        \
+  BOOST_CLASS_TRACKING(N::C##InstanceBase, boost::serialization::track_never)                                          \
+  BOOST_CLASS_TRACKING(N::C##Instance, boost::serialization::track_never)                                              \
+  BOOST_CLASS_TRACKING(N::C##InstanceWrapper, boost::serialization::track_never)
 
 /** @brief If shared library, this must go in the cpp after the implicit instantiation of the serialize function */
-#define TESSERACT_WAYPOINT_EXPORT_IMPLEMENT(wp)                                                                        \
-  BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::detail_waypoint::WaypointInner<wp>)
+#define TESSERACT_WAYPOINT_EXPORT_IMPLEMENT(inst)                                                                      \
+  BOOST_CLASS_EXPORT_IMPLEMENT(inst##InstanceBase)                                                                     \
+  BOOST_CLASS_EXPORT_IMPLEMENT(inst##Instance)                                                                         \
+  BOOST_CLASS_EXPORT_IMPLEMENT(inst##InstanceWrapper)
 
 /**
  * @brief This should not be used within shared libraries use the two above.
  * If not in a shared library it can go in header or cpp
  */
-#define TESSERACT_WAYPOINT_EXPORT(wp)                                                                                  \
-  TESSERACT_WAYPOINT_EXPORT_KEY(wp)                                                                                    \
-  TESSERACT_WAYPOINT_EXPORT_IMPLEMENT(wp)
+#define TESSERACT_WAYPOINT_EXPORT(N, C)                                                                                \
+  TESSERACT_WAYPOINT_EXPORT_KEY(N, C)                                                                                  \
+  TESSERACT_WAYPOINT_EXPORT_IMPLEMENT(N::C)
 
 namespace tesseract_planning
 {
@@ -71,36 +81,33 @@ class Waypoint;
 #ifndef SWIG
 namespace detail_waypoint
 {
-CREATE_MEMBER_CHECK(print);
-CREATE_MEMBER_FUNC_SIGNATURE_CHECK(print, void, std::string);
-
-struct WaypointInnerBase
+template <typename T>
+struct WaypointConcept  // NOLINT
+  : boost::Assignable<T>,
+    boost::CopyConstructible<T>,
+    boost::EqualityComparable<T>
 {
-  WaypointInnerBase() = default;
-  virtual ~WaypointInnerBase() = default;
-  WaypointInnerBase(const WaypointInnerBase&) = delete;
-  WaypointInnerBase& operator=(const WaypointInnerBase&) = delete;
-  WaypointInnerBase(WaypointInnerBase&&) = delete;
-  WaypointInnerBase& operator=(WaypointInnerBase&&) = delete;
+  BOOST_CONCEPT_USAGE(WaypointConcept)
+  {
+    T cp(c);
+    T assign = c;
+    bool eq = (c == cp);
+    bool neq = (c != cp);
+    UNUSED(assign);
+    UNUSED(eq);
+    UNUSED(neq);
 
-  // User-defined methods
+    c.print();
+    c.print("prefix_");
+  }
+
+private:
+  T c;
+};
+
+struct WaypointInterface : tesseract_common::TypeErasureInterface
+{
   virtual void print(const std::string& prefix) const = 0;
-  virtual bool operator==(const WaypointInnerBase& rhs) const = 0;
-
-  // This is not required for user defined implementation
-  virtual bool operator!=(const WaypointInnerBase& rhs) const = 0;
-
-  // This is not required for user defined implementation
-  virtual std::type_index getType() const = 0;
-
-  // This is not required for user defined implementation
-  virtual void* recover() = 0;
-
-  // This is not required for user defined implementation
-  virtual const void* recover() const = 0;
-
-  // This is not required for user defined implementation
-  virtual std::unique_ptr<WaypointInnerBase> clone() const = 0;
 
 private:
   friend class boost::serialization::access;
@@ -109,174 +116,59 @@ private:
 };
 
 template <typename T>
-struct WaypointInner final : WaypointInnerBase
+struct WaypointInstance : tesseract_common::TypeErasureInstance<T, WaypointInterface>  // NOLINT
 {
-  WaypointInner()
-  {
-    static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
-    static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
-  }
-  ~WaypointInner() override = default;
-  WaypointInner(const WaypointInner&) = delete;
-  WaypointInner(WaypointInner&&) = delete;
-  WaypointInner& operator=(const WaypointInner&) = delete;
-  WaypointInner& operator=(WaypointInner&&) = delete;
+  using BaseType = tesseract_common::TypeErasureInstance<T, WaypointInterface>;
+  WaypointInstance() = default;
+  WaypointInstance(const T& x) : BaseType(x) {}
+  WaypointInstance(WaypointInstance&& x) noexcept : BaseType(std::move(x)) {}
 
-  // Constructors from T (copy and move variants).
-  explicit WaypointInner(T waypoint) : waypoint_(std::move(waypoint))
-  {
-    static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
-    static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
-  }
-  explicit WaypointInner(T&& waypoint) : waypoint_(std::move(waypoint))
-  {
-    static_assert(has_member_print<T>::value, "Class does not have member function 'print'");
-    static_assert(has_member_func_signature_print<T>::value, "Class 'print' function has incorrect signature");
-  }
+  BOOST_CONCEPT_ASSERT((WaypointConcept<T>));
 
-  std::unique_ptr<WaypointInnerBase> clone() const final { return std::make_unique<WaypointInner>(waypoint_); }
-
-  std::type_index getType() const final { return std::type_index(typeid(T)); }
-
-  void print(const std::string& prefix) const final { waypoint_.print(prefix); }
-
-  void* recover() final { return &waypoint_; }
-
-  const void* recover() const final { return &waypoint_; }
-
-  bool operator==(const WaypointInnerBase& rhs) const final
-  {
-    // Compare class types before casting the incoming object to the T type
-    if (rhs.getType() == getType())
-    {
-      const auto* waypoint = static_cast<const T*>(rhs.recover());
-      return waypoint_ == *waypoint;
-    }
-    return false;
-  }
-
-  bool operator!=(const WaypointInnerBase& rhs) const final { return !operator==(rhs); }
+  void print(const std::string& prefix) const final { this->get().print(prefix); }
 
 private:
   friend class boost::serialization::access;
+  friend struct tesseract_common::Serialization;
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/)  // NOLINT
   {
-    // If this line is removed a exception is thrown for unregistered cast need to too look into this.
-    ar& boost::serialization::make_nvp("base", boost::serialization::base_object<WaypointInnerBase>(*this));
-    ar& boost::serialization::make_nvp("impl", waypoint_);
+    ar& boost::serialization::make_nvp("base", boost::serialization::base_object<BaseType>(*this));
   }
-
-  T waypoint_;
 };
 }  // namespace detail_waypoint
 #endif  // SWIG
 }  // namespace tesseract_planning
 
-namespace boost
-{
-// Taken from pagmo to address the same issue
-// NOTE: in some earlier versions of Boost (i.e., at least up to 1.67)
-// the is_virtual_base_of type trait, used by the Boost serialization library, fails
-// with a compile time error if a class is declared final. Thus, we provide a specialised
-// implementation of this type trait to work around the issue. See:
-// https://www.boost.org/doc/libs/1_52_0/libs/type_traits/doc/html/boost_typetraits/reference/is_virtual_base_of.html
-// https://stackoverflow.com/questions/18982064/boost-serialization-of-base-class-of-final-subclass-error
-// We never use virtual inheritance, thus the specialisation is always false.
-template <typename T>
-struct is_virtual_base_of<tesseract_planning::detail_waypoint::WaypointInnerBase,
-                          tesseract_planning::detail_waypoint::WaypointInner<T>> : false_type
-{
-};
-}  // namespace boost
-
 namespace tesseract_planning
 {
-class Waypoint
+using WaypointBase =
+    tesseract_common::TypeErasureBase<detail_waypoint::WaypointInterface, detail_waypoint::WaypointInstance>;
+struct Waypoint : WaypointBase
 {
-  template <typename T>
-  using uncvref_t = std::remove_cv_t<typename std::remove_reference<T>::type>;
-
-  // Enable the generic ctor only if ``T`` is not a ForwardKinematics (after removing const/reference qualifiers)
-  // If ``T`` is of type ForwardKinematics we disable so it will use the copy or move constructors of this class.
-  template <typename T>
-  using generic_ctor_enabler = std::enable_if_t<!std::is_same<Waypoint, uncvref_t<T>>::value, int>;
-
-public:
-  template <typename T, generic_ctor_enabler<T> = 0>
-  Waypoint(T&& waypoint)  // NOLINT
-    : waypoint_(std::make_unique<detail_waypoint::WaypointInner<uncvref_t<T>>>(waypoint))
-  {
-  }
-
-  // Destructor
-  ~Waypoint() = default;
-
-  // Copy constructor
-  Waypoint(const Waypoint& other);
-
-  // Move ctor.
-  Waypoint(Waypoint&& other) noexcept;
-
-  // Move assignment.
-  Waypoint& operator=(Waypoint&& other) noexcept;
-
-  // Copy assignment.
-  Waypoint& operator=(const Waypoint& other);
-
-  template <typename T, generic_ctor_enabler<T> = 0>
-  Waypoint& operator=(T&& other)
-  {
-    (*this) = Waypoint(std::forward<T>(other));
-    return (*this);
-  }
-
-  std::type_index getType() const;
+  using WaypointBase::WaypointBase;
 
   void print(const std::string& prefix = "") const;
-
-  bool operator==(const Waypoint& rhs) const;
-
-  bool operator!=(const Waypoint& rhs) const;
-
-  template <typename T>
-  T& as()
-  {
-    if (getType() != typeid(T))
-      throw std::runtime_error("Waypoint, tried to cast '" + std::string(getType().name()) + "' to '" +
-                               std::string(typeid(T).name()) + "'!");
-
-    auto* p = static_cast<uncvref_t<T>*>(waypoint_->recover());
-    return *p;
-  }
-
-  template <typename T>
-  const T& as() const
-  {
-    if (getType() != typeid(T))
-      throw std::runtime_error("Waypoint, tried to cast '" + std::string(getType().name()) + "' to '" +
-                               std::string(typeid(T).name()) + "'!");
-
-    const auto* p = static_cast<const uncvref_t<T>*>(waypoint_->recover());
-    return *p;
-  }
 
 private:
   friend class boost::serialization::access;
   friend struct tesseract_common::Serialization;
 
-  Waypoint();  // NOLINT
-
   template <class Archive>
   void serialize(Archive& ar, const unsigned int /*version*/);  // NOLINT
-
-  std::unique_ptr<detail_waypoint::WaypointInnerBase> waypoint_;
 };
 
 }  // namespace tesseract_planning
 
 #ifndef SWIG
-BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::detail_waypoint::WaypointInnerBase)
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::detail_waypoint::WaypointInterface)
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::detail_waypoint::WaypointInterface)
+BOOST_CLASS_TRACKING(tesseract_planning::detail_waypoint::WaypointInterface, boost::serialization::track_never)
+
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::WaypointBase)
+BOOST_CLASS_TRACKING(tesseract_planning::WaypointBase, boost::serialization::track_never)
+
+BOOST_CLASS_EXPORT_KEY(tesseract_planning::Waypoint)
 BOOST_CLASS_TRACKING(tesseract_planning::Waypoint, boost::serialization::track_never);
 #endif  // SWIG
 

--- a/tesseract_command_language/include/tesseract_command_language/instruction_type.h
+++ b/tesseract_command_language/include/tesseract_command_language/instruction_type.h
@@ -28,7 +28,7 @@
 
 namespace tesseract_planning
 {
-class Instruction;
+struct Instruction;
 
 bool isCommentInstruction(const Instruction& instruction);
 

--- a/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
@@ -226,7 +226,7 @@ private:
 
 %tesseract_command_language_add_waypoint_type(JointWaypoint)
 #else
-TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning::JointWaypoint);
+TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning, JointWaypoint);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_JOINT_WAYPOINT_H

--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -165,7 +165,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(MoveInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::MoveInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, MoveInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_MOVE_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/null_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/null_instruction.h
@@ -62,7 +62,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(NullInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::NullInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, NullInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_NULL_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/null_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/null_waypoint.h
@@ -54,7 +54,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_waypoint_type(NullWaypoint)
 #else
-TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning::NullWaypoint);
+TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning, NullWaypoint);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_NULL_WAYPOINT_H

--- a/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/plan_instruction.h
@@ -159,7 +159,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(PlanInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::PlanInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, PlanInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_PLAN_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/set_analog_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/set_analog_instruction.h
@@ -89,7 +89,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(SetAnalogInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::SetAnalogInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, SetAnalogInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_SET_ANALOG_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/set_tool_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/set_tool_instruction.h
@@ -81,7 +81,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(SetToolInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::SetToolInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, SetToolInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_SET_TOOL_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/state_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/state_waypoint.h
@@ -63,7 +63,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_waypoint_type(StateWaypoint)
 #else
-TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning::StateWaypoint);
+TESSERACT_WAYPOINT_EXPORT_KEY(tesseract_planning, StateWaypoint);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_JOINT_WAYPOINT_H

--- a/tesseract_command_language/include/tesseract_command_language/timer_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/timer_instruction.h
@@ -125,7 +125,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(TimerInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::TimerInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, TimerInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_TIMER_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/wait_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/wait_instruction.h
@@ -132,7 +132,7 @@ private:
 #ifdef SWIG
 %tesseract_command_language_add_instruction_type(WaitInstruction)
 #else
-TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning::WaitInstruction);
+TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, WaitInstruction);
 #endif  // SWIG
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_WAIT_INSTRUCTION_H

--- a/tesseract_command_language/include/tesseract_command_language/waypoint_type.h
+++ b/tesseract_command_language/include/tesseract_command_language/waypoint_type.h
@@ -28,7 +28,7 @@
 
 namespace tesseract_planning
 {
-class Waypoint;
+struct Waypoint;
 
 bool isCartesianWaypoint(const Waypoint& waypoint);
 

--- a/tesseract_command_language/src/core/instruction.cpp
+++ b/tesseract_command_language/src/core/instruction.cpp
@@ -7,59 +7,33 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/core/instruction.h>
 
 template <class Archive>
-void tesseract_planning::detail_instruction::InstructionInnerBase::serialize(Archive& /*ar*/,
+void tesseract_planning::detail_instruction::InstructionInterface::serialize(Archive& ar,
                                                                              const unsigned int /*version*/)  // NOLINT
 {
+  ar& boost::serialization::make_nvp("base",
+                                     boost::serialization::base_object<tesseract_common::TypeErasureInterface>(*this));
 }
 
-tesseract_planning::Instruction::Instruction()  // NOLINT
-  : instruction_(nullptr)
-{
-}
-
-// Copy constructor
-tesseract_planning::Instruction::Instruction(const Instruction& other) { instruction_ = other.instruction_->clone(); }
-
-// Move ctor.
-tesseract_planning::Instruction::Instruction(Instruction&& other) noexcept { instruction_.swap(other.instruction_); }
-
-// Move assignment.
-tesseract_planning::Instruction& tesseract_planning::Instruction::operator=(Instruction&& other) noexcept
-{
-  instruction_.swap(other.instruction_);
-  return (*this);
-}
-
-tesseract_planning::Instruction& tesseract_planning::Instruction::operator=(const Instruction& other)
-{
-  (*this) = Instruction(other);
-  return (*this);
-}
-
-std::type_index tesseract_planning::Instruction::getType() const { return instruction_->getType(); }
-
-const std::string& tesseract_planning::Instruction::getDescription() const { return instruction_->getDescription(); }
+const std::string& tesseract_planning::Instruction::getDescription() const { return interface().getDescription(); }
 
 void tesseract_planning::Instruction::setDescription(const std::string& description)
 {
-  instruction_->setDescription(description);
+  interface().setDescription(description);
 }
 
-void tesseract_planning::Instruction::print(const std::string& prefix) const { instruction_->print(prefix); }
-
-bool tesseract_planning::Instruction::operator==(const Instruction& rhs) const
-{
-  return instruction_->operator==(*rhs.instruction_);
-}
-
-bool tesseract_planning::Instruction::operator!=(const Instruction& rhs) const { return !operator==(rhs); }
+void tesseract_planning::Instruction::print(const std::string& prefix) const { interface().print(prefix); }
 
 template <class Archive>
 void tesseract_planning::Instruction::serialize(Archive& ar, const unsigned int /*version*/)  // NOLINT
 {
-  ar& boost::serialization::make_nvp("instruction", instruction_);
+  ar& boost::serialization::make_nvp("base", boost::serialization::base_object<InstructionBase>(*this));
 }
 
 #include <tesseract_common/serialization.h>
-TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::detail_instruction::InstructionInnerBase)
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::detail_instruction::InstructionInterface)
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::InstructionBase)
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::Instruction)
+
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::detail_instruction::InstructionInterface)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::InstructionBase)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::Instruction)

--- a/tesseract_command_language/src/core/waypoint.cpp
+++ b/tesseract_command_language/src/core/waypoint.cpp
@@ -7,49 +7,26 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/core/waypoint.h>
 
 template <class Archive>
-void tesseract_planning::detail_waypoint::WaypointInnerBase::serialize(Archive& /*ar*/,
+void tesseract_planning::detail_waypoint::WaypointInterface::serialize(Archive& ar,
                                                                        const unsigned int /*version*/)  // NOLINT
 {
+  ar& boost::serialization::make_nvp("base",
+                                     boost::serialization::base_object<tesseract_common::TypeErasureInterface>(*this));
 }
 
-tesseract_planning::Waypoint::Waypoint()  // NOLINT
-  : waypoint_(nullptr)
-{
-}
-
-tesseract_planning::Waypoint::Waypoint(const Waypoint& other) { waypoint_ = other.waypoint_->clone(); }
-
-tesseract_planning::Waypoint::Waypoint(Waypoint&& other) noexcept { waypoint_.swap(other.waypoint_); }
-
-tesseract_planning::Waypoint& tesseract_planning::Waypoint::operator=(Waypoint&& other) noexcept
-{
-  waypoint_.swap(other.waypoint_);
-  return (*this);
-}
-
-tesseract_planning::Waypoint& tesseract_planning::Waypoint::operator=(const Waypoint& other)
-{
-  (*this) = Waypoint(other);
-  return (*this);
-}
-
-std::type_index tesseract_planning::Waypoint::getType() const { return waypoint_->getType(); }
-
-void tesseract_planning::Waypoint::print(const std::string& prefix) const { waypoint_->print(prefix); }
-
-bool tesseract_planning::Waypoint::operator==(const Waypoint& rhs) const
-{
-  return waypoint_->operator==(*rhs.waypoint_);
-}
-
-bool tesseract_planning::Waypoint::operator!=(const Waypoint& rhs) const { return !operator==(rhs); }
+void tesseract_planning::Waypoint::print(const std::string& prefix) const { interface().print(prefix); }
 
 template <class Archive>
 void tesseract_planning::Waypoint::serialize(Archive& ar, const unsigned int /*version*/)  // NOLINT
 {
-  ar& boost::serialization::make_nvp("waypoint", waypoint_);
+  ar& boost::serialization::make_nvp("base", boost::serialization::base_object<WaypointBase>(*this));
 }
 
 #include <tesseract_common/serialization.h>
-TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::detail_waypoint::WaypointInnerBase)
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::detail_waypoint::WaypointInterface)
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::WaypointBase)
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::Waypoint)
+
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::detail_waypoint::WaypointInterface)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::WaypointBase)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::Waypoint)

--- a/tesseract_command_language/test/CMakeLists.txt
+++ b/tesseract_command_language/test/CMakeLists.txt
@@ -145,8 +145,6 @@ add_dependencies(${PROJECT_NAME}_utils_unit ${PROJECT_NAME})
 find_package(benchmark REQUIRED)
 add_executable(${PROJECT_NAME}_type_erasure_benchmark type_erasure_benchmark.cpp)
 target_link_libraries(${PROJECT_NAME}_type_erasure_benchmark PRIVATE benchmark::benchmark ${PROJECT_NAME})
-#target_compile_options(${PROJECT_NAME}_type_erasure_benchmark PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
-#                                                          ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
 target_clang_tidy(${PROJECT_NAME}_type_erasure_benchmark ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_type_erasure_benchmark PRIVATE VERSION ${TESSERACT_CXX_VERSION})
 target_code_coverage(
@@ -154,5 +152,4 @@ target_code_coverage(
   ALL
   EXCLUDE ${COVERAGE_EXCLUDE}
   ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
-#add_run_benchmark_target(${PROJECT_NAME}_type_erasure_benchmark)
-
+# add_run_benchmark_target(${PROJECT_NAME}_type_erasure_benchmark)

--- a/tesseract_command_language/test/CMakeLists.txt
+++ b/tesseract_command_language/test/CMakeLists.txt
@@ -145,7 +145,6 @@ add_dependencies(${PROJECT_NAME}_utils_unit ${PROJECT_NAME})
 find_package(benchmark REQUIRED)
 add_executable(${PROJECT_NAME}_type_erasure_benchmark type_erasure_benchmark.cpp)
 target_link_libraries(${PROJECT_NAME}_type_erasure_benchmark PRIVATE benchmark::benchmark ${PROJECT_NAME})
-target_clang_tidy(${PROJECT_NAME}_type_erasure_benchmark ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
 target_cxx_version(${PROJECT_NAME}_type_erasure_benchmark PRIVATE VERSION ${TESSERACT_CXX_VERSION})
 target_code_coverage(
   ${PROJECT_NAME}_type_erasure_benchmark

--- a/tesseract_command_language/test/CMakeLists.txt
+++ b/tesseract_command_language/test/CMakeLists.txt
@@ -140,3 +140,19 @@ target_code_coverage(
 add_gtest_discover_tests(${PROJECT_NAME}_utils_unit)
 add_dependencies(run_tests ${PROJECT_NAME}_utils_unit)
 add_dependencies(${PROJECT_NAME}_utils_unit ${PROJECT_NAME})
+
+# Type Erasure Benchmarks
+find_package(benchmark REQUIRED)
+add_executable(${PROJECT_NAME}_type_erasure_benchmark type_erasure_benchmark.cpp)
+target_link_libraries(${PROJECT_NAME}_type_erasure_benchmark PRIVATE benchmark::benchmark ${PROJECT_NAME})
+#target_compile_options(${PROJECT_NAME}_type_erasure_benchmark PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
+#                                                          ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_clang_tidy(${PROJECT_NAME}_type_erasure_benchmark ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_type_erasure_benchmark PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}_type_erasure_benchmark
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+#add_run_benchmark_target(${PROJECT_NAME}_type_erasure_benchmark)
+

--- a/tesseract_command_language/test/serialize_test.cpp
+++ b/tesseract_command_language/test/serialize_test.cpp
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/serialization.h>
+#include <tesseract_common/any.h>
 #include <tesseract_command_language/command_language.h>
 #include <tesseract_command_language/utils/utils.h>
 #include <tesseract_common/utils.h>
@@ -194,6 +195,14 @@ TEST(TesseractCommandLanguageSerializeUnit, serializationCompositeInstruction)  
     auto nprogram = tesseract_common::Serialization::fromArchiveStringXML<Instruction>(program_string);
     EXPECT_TRUE(program == nprogram);
   }
+}
+
+TEST(TesseractCommandLanguageSerializeUnit, TypeErasureInTypeErasure)  // NOLINT
+{
+  tesseract_planning::Instruction instruction{ SetToolInstruction(5) };
+  tesseract_common::Any any_type;
+  any_type = instruction;
+  EXPECT_EQ(any_type.getType(), std::type_index(typeid(tesseract_planning::Instruction)));
 }
 
 int main(int argc, char** argv)

--- a/tesseract_command_language/test/type_erasure_benchmark.cpp
+++ b/tesseract_command_language/test/type_erasure_benchmark.cpp
@@ -181,6 +181,33 @@ CompositeInstruction getProgram()
   return program;
 }
 
+std::vector<Waypoint> createVectorStateWaypointPoly()
+{
+  std::vector<Waypoint> results;
+  results.reserve(1000);
+  for (std::size_t i = 0; i < 1000; ++i)
+  {
+    Waypoint wp1 = JointWaypoint({ "j1", "j2", "j3", "j4", "j5", "j6" }, Eigen::VectorXd::Ones(6));
+
+    results.push_back(std::move(wp1));
+  }
+  return results;
+}
+
+std::vector<std::unique_ptr<StateWaypoint>> createVectorStateWaypointUPtr()
+{
+  std::vector<std::unique_ptr<StateWaypoint>> results;
+  results.reserve(1000);
+  for (std::size_t i = 0; i < 1000; ++i)
+  {
+    std::vector<std::string> joint_names = { "j1", "j2", "j3", "j4", "j5", "j6" };
+    auto wp1 = std::make_unique<StateWaypoint>(joint_names, Eigen::VectorXd::Ones(6));
+
+    results.push_back(std::move(wp1));
+  }
+  return results;
+}
+
 static void BM_InstructionPolyCreation(benchmark::State& state)
 {
   for (auto _ : state)
@@ -302,5 +329,44 @@ static void BM_WaypointPolyAccess(benchmark::State& state)
 }
 
 BENCHMARK(BM_WaypointPolyAccess);
+
+static void BM_VectorStateWaypointPolyCreation(benchmark::State& state)
+{
+  for (auto _ : state)
+    std::vector<Waypoint> w = createVectorStateWaypointPoly();
+}
+
+BENCHMARK(BM_VectorStateWaypointPolyCreation);
+
+static void BM_VectorStateWaypointUPtrCreation(benchmark::State& state)
+{
+  for (auto _ : state)
+    std::vector<std::unique_ptr<StateWaypoint>> w = createVectorStateWaypointUPtr();
+}
+
+BENCHMARK(BM_VectorStateWaypointUPtrCreation);
+
+static void BM_VectorStateWaypointPolyCopy(benchmark::State& state)
+{
+  std::vector<Waypoint> w = createVectorStateWaypointPoly();
+  for (auto _ : state)
+    std::vector<Waypoint> copy(w);
+}
+
+BENCHMARK(BM_VectorStateWaypointPolyCopy);
+
+static void BM_VectorStateWaypointUPtrCopy(benchmark::State& state)
+{
+  std::vector<std::unique_ptr<StateWaypoint>> w = createVectorStateWaypointUPtr();
+  for (auto _ : state)
+  {
+    std::vector<std::unique_ptr<StateWaypoint>> copy;
+    copy.reserve(w.size());
+    for (const auto& i : w)
+      copy.emplace_back(std::make_unique<StateWaypoint>(*i));
+  }
+}
+
+BENCHMARK(BM_VectorStateWaypointUPtrCopy);
 
 BENCHMARK_MAIN();

--- a/tesseract_command_language/test/type_erasure_benchmark.cpp
+++ b/tesseract_command_language/test/type_erasure_benchmark.cpp
@@ -1,0 +1,306 @@
+/**
+ * @file type_erasure_benchmark.cpp
+ * @brief
+ *
+ * @author Levi Armstrong
+ * @date August 20, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <fstream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <benchmark/benchmark.h>
+#include <tesseract_common/serialization.h>
+#include <tesseract_common/any.h>
+#include <tesseract_command_language/command_language.h>
+#include <tesseract_command_language/utils/utils.h>
+#include <tesseract_common/utils.h>
+
+using namespace tesseract_planning;
+
+CompositeInstruction getProgram()
+{
+  CompositeInstruction program(
+      "raster_program", CompositeInstructionOrder::ORDERED, ManipulatorInfo("manipulator", "world", "tool0"));
+
+  // Start Joint Position for the program
+  std::vector<std::string> joint_names = { "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6" };
+  Waypoint wp0 = StateWaypoint(joint_names, Eigen::VectorXd::Zero(6));
+  PlanInstruction start_instruction(wp0, PlanInstructionType::START);
+  program.setStartInstruction(start_instruction);
+
+  // Define raster poses
+  Waypoint wp1 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.3, 0.8) *
+                                   Eigen::Quaterniond(0, 0, -1.0, 0));
+  Waypoint wp2 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.2, 0.8) *
+                                   Eigen::Quaterniond(0, 0, -1.0, 0));
+  Waypoint wp3 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, -0.1, 0.8) *
+                                   Eigen::Quaterniond(0, 0, -1.0, 0));
+  Waypoint wp4 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.0, 0.8) *
+                                   Eigen::Quaterniond(0, 0, -1.0, 0));
+  Waypoint wp5 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.1, 0.8) *
+                                   Eigen::Quaterniond(0, 0, -1.0, 0));
+  Waypoint wp6 = CartesianWaypoint(Eigen::Isometry3d::Identity() * Eigen::Translation3d(0.8, 0.2, 0.8) *
+                                   Eigen::Quaterniond(0, 0, -1.0, 0));
+  Waypoint wp7 = JointWaypoint(joint_names, Eigen::VectorXd::Ones(6));
+
+  // Define raster move instruction
+  PlanInstruction plan_c0(wp2, PlanInstructionType::LINEAR, "RASTER");
+  PlanInstruction plan_c1(wp3, PlanInstructionType::LINEAR, "RASTER", "RASTER");
+  PlanInstruction plan_c2(wp4, PlanInstructionType::LINEAR, "RASTER");
+  PlanInstruction plan_c3(wp5, PlanInstructionType::LINEAR, "RASTER", "RASTER");
+  PlanInstruction plan_c4(wp6, PlanInstructionType::LINEAR, "RASTER");
+  PlanInstruction plan_c5(wp7, PlanInstructionType::LINEAR, "RASTER", "RASTER");
+
+  PlanInstruction plan_f0(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  plan_f0.setDescription("from_start_plan");
+  CompositeInstruction from_start;
+  from_start.setDescription("from_start");
+  from_start.push_back(plan_f0);
+  program.push_back(from_start);
+
+  {
+    CompositeInstruction raster_segment;
+    raster_segment.setDescription("raster_segment");
+    raster_segment.push_back(plan_c0);
+    raster_segment.push_back(plan_c1);
+    raster_segment.push_back(plan_c2);
+    raster_segment.push_back(plan_c3);
+    raster_segment.push_back(plan_c4);
+    raster_segment.push_back(plan_c5);
+    program.push_back(raster_segment);
+  }
+
+  {
+    PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+    plan_f1.setDescription("transition_from_end_plan");
+    CompositeInstruction transition_from_end;
+    transition_from_end.setDescription("transition_from_end");
+    transition_from_end.push_back(plan_f1);
+    CompositeInstruction transition_from_start;
+    transition_from_start.setDescription("transition_from_start");
+    transition_from_start.push_back(plan_f1);
+
+    CompositeInstruction transitions(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::UNORDERED);
+    transitions.setDescription("transitions");
+    transitions.push_back(transition_from_start);
+    transitions.push_back(transition_from_end);
+    program.push_back(transitions);
+  }
+
+  {
+    CompositeInstruction raster_segment;
+    raster_segment.setDescription("raster_segment");
+    raster_segment.push_back(plan_c0);
+    raster_segment.push_back(plan_c1);
+    raster_segment.push_back(plan_c2);
+    raster_segment.push_back(plan_c3);
+    raster_segment.push_back(plan_c4);
+    raster_segment.push_back(plan_c5);
+    program.push_back(raster_segment);
+  }
+
+  {
+    PlanInstruction plan_f1(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+    plan_f1.setDescription("transition_from_end_plan");
+    CompositeInstruction transition_from_end;
+    transition_from_end.setDescription("transition_from_end");
+    transition_from_end.push_back(plan_f1);
+    CompositeInstruction transition_from_start;
+    transition_from_start.setDescription("transition_from_start");
+    transition_from_start.push_back(plan_f1);
+
+    CompositeInstruction transitions(DEFAULT_PROFILE_KEY, CompositeInstructionOrder::UNORDERED);
+    transitions.setDescription("transitions");
+    transitions.push_back(transition_from_start);
+    transitions.push_back(transition_from_end);
+    program.push_back(transitions);
+  }
+
+  {
+    CompositeInstruction raster_segment;
+    raster_segment.setDescription("raster_segment");
+    raster_segment.push_back(plan_c0);
+    raster_segment.push_back(plan_c1);
+    raster_segment.push_back(plan_c2);
+    raster_segment.push_back(plan_c3);
+    raster_segment.push_back(plan_c4);
+    raster_segment.push_back(plan_c5);
+    program.push_back(raster_segment);
+  }
+
+  PlanInstruction plan_f2(wp1, PlanInstructionType::FREESPACE, "freespace_profile");
+  plan_f2.setDescription("to_end_plan");
+  CompositeInstruction to_end;
+  to_end.setDescription("to_end");
+  to_end.push_back(plan_f2);
+  program.push_back(to_end);
+
+  // Add a wait instruction
+  WaitInstruction wait_instruction_time(1.5);
+  program.push_back(wait_instruction_time);
+
+  WaitInstruction wait_instruction_io(WaitInstructionType::DIGITAL_INPUT_LOW, 10);
+  program.push_back(wait_instruction_io);
+
+  // Add a timer instruction
+  TimerInstruction timer_instruction(TimerInstructionType::DIGITAL_OUTPUT_LOW, 3.1, 5);
+  program.push_back(timer_instruction);
+
+  // Add a set tool instruction
+  SetToolInstruction set_tool_instruction(5);
+  program.push_back(set_tool_instruction);
+
+  // Add a set tool instruction
+  SetAnalogInstruction set_analog_instruction("R", 0, 1.5);
+  program.push_back(set_analog_instruction);
+
+  return program;
+}
+
+static void BM_InstructionPolyCreation(benchmark::State& state)
+{
+  for (auto _ : state)
+    Instruction i{ NullInstruction() };
+}
+
+BENCHMARK(BM_InstructionPolyCreation);
+
+static void BM_WaypointPolyCreation(benchmark::State& state)
+{
+  for (auto _ : state)
+    Waypoint w{ NullWaypoint() };
+}
+
+BENCHMARK(BM_WaypointPolyCreation);
+
+static void BM_CompositeInstructionCreation(benchmark::State& state)
+{
+  for (auto _ : state)
+    CompositeInstruction ci;
+}
+
+BENCHMARK(BM_CompositeInstructionCreation);
+
+static void BM_ProgramCreation(benchmark::State& state)
+{
+  for (auto _ : state)
+    CompositeInstruction ci = getProgram();
+}
+
+BENCHMARK(BM_ProgramCreation);
+
+static void BM_InstructionPolyCopy(benchmark::State& state)
+{
+  Instruction i{ MoveInstruction() };
+  for (auto _ : state)
+    Instruction copy(i);
+}
+
+BENCHMARK(BM_InstructionPolyCopy);
+
+static void BM_WaypointPolyCopy(benchmark::State& state)
+{
+  Waypoint w{ StateWaypoint() };
+  for (auto _ : state)
+    Waypoint copy(w);
+}
+
+BENCHMARK(BM_WaypointPolyCopy);
+
+static void BM_CompositeInstructionCopy(benchmark::State& state)
+{
+  CompositeInstruction ci = getProgram();
+  for (auto _ : state)
+    CompositeInstruction copy(ci);
+}
+
+BENCHMARK(BM_CompositeInstructionCopy);
+
+static void BM_InstructionPolyAssign(benchmark::State& state)
+{
+  Instruction i{ MoveInstruction() };
+  for (auto _ : state)
+    Instruction copy = i;
+}
+
+BENCHMARK(BM_InstructionPolyAssign);
+
+static void BM_WaypointPolyAssign(benchmark::State& state)
+{
+  Waypoint w{ StateWaypoint() };
+  for (auto _ : state)
+    Waypoint copy = w;
+}
+
+BENCHMARK(BM_WaypointPolyAssign);
+
+static void BM_CompositeInstructionAssign(benchmark::State& state)
+{
+  CompositeInstruction ci = getProgram();
+  for (auto _ : state)
+    CompositeInstruction copy = ci;
+}
+
+BENCHMARK(BM_CompositeInstructionAssign);
+
+static void BM_InstructionPolyCast(benchmark::State& state)
+{
+  Instruction i{ MoveInstruction() };
+  for (auto _ : state)
+    auto& mi = i.as<MoveInstruction>();  // NOLINT
+}
+
+BENCHMARK(BM_InstructionPolyCast);
+
+static void BM_WaypointPolyCast(benchmark::State& state)
+{
+  Waypoint w{ StateWaypoint() };
+  for (auto _ : state)
+    auto& sw = w.as<StateWaypoint>();  // NOLINT
+}
+
+BENCHMARK(BM_WaypointPolyCast);
+
+static void BM_InstructionPolyAccess(benchmark::State& state)
+{
+  Instruction i{ MoveInstruction() };
+  for (auto _ : state)
+    const std::string& description = i.getDescription();  // NOLINT
+}
+
+BENCHMARK(BM_InstructionPolyAccess);
+
+static void BM_WaypointPolyAccess(benchmark::State& state)
+{
+  Waypoint w{ StateWaypoint() };
+  for (auto _ : state)
+    std::type_index type = w.getType();
+}
+
+BENCHMARK(BM_WaypointPolyAccess);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
- This updated to leverage the new type erasure interface to reduce code duplication. 
- Leverage Boost Concept check to confirm type interface at compile time

@mpowelson, @marip8 and @marrts  Need help with defining naming convention for type erasure. Currently it is not obvious based on the type to know if it is a type erasure or not. I noticed when reviewing adobe example they prefix the type with Poly. Let me know what you think or if you have alternative naming convention. 

Current Type Erasures
- Instruction
- Waypoint

Future Type Erasures (This is to support custom implementations)
- MoveInstruction
- CartesianWaypoint
- JointWaypoint
- StateWaypoint

Example suffix with Poly
- MoveInstructionPoly, This is the type erasure
  - MoveInstruction, Default implementation

Example prefix with Poly
- PolyMoveInstruction, This is the type erasure
  - MoveInstruction, Default implementation
