### PR TITLE
Add TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT to tesseract_process_managers

### DIFF
--- a/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract_process_managers/CMakeLists.txt
@@ -87,7 +87,6 @@ target_link_libraries(
          tesseract::tesseract_environment
          tesseract::tesseract_command_language
          tesseract::tesseract_motion_planners_simple
-         tesseract::tesseract_motion_planners_trajopt_ifopt
          tesseract::tesseract_motion_planners_trajopt
          tesseract::tesseract_motion_planners_descartes
          tesseract::tesseract_motion_planners_ompl
@@ -109,6 +108,16 @@ target_code_coverage(
   ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:include>")
+
+
+option(TESSERACT_BUILD_TRAJOPT_IFOPT "Build the Trajopt IFOPT planner" ON)
+if(TESSERACT_BUILD_TRAJOPT_IFOPT)
+target_link_libraries(
+  ${PROJECT_NAME}
+  PUBLIC tesseract::tesseract_motion_planners_trajopt_ifopt)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT=1)
+endif()
+
 list(APPEND Targets ${PROJECT_NAME})
 
 add_library(${PROJECT_NAME}_utils src/utils/task_info_statistics.cpp)

--- a/tesseract_process_managers/CMakeLists.txt
+++ b/tesseract_process_managers/CMakeLists.txt
@@ -109,12 +109,9 @@ target_code_coverage(
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                   "$<INSTALL_INTERFACE:include>")
 
-
 option(TESSERACT_BUILD_TRAJOPT_IFOPT "Build the Trajopt IFOPT planner" ON)
 if(TESSERACT_BUILD_TRAJOPT_IFOPT)
-target_link_libraries(
-  ${PROJECT_NAME}
-  PUBLIC tesseract::tesseract_motion_planners_trajopt_ifopt)
+  target_link_libraries(${PROJECT_NAME} PUBLIC tesseract::tesseract_motion_planners_trajopt_ifopt)
   target_compile_definitions(${PROJECT_NAME} PUBLIC TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT=1)
 endif()
 

--- a/tesseract_process_managers/include/tesseract_process_managers/core/default_process_planners.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/default_process_planners.h
@@ -33,8 +33,10 @@ namespace tesseract_planning
 /** @brief Create TrajOpt Process Pipeline */
 TaskflowGenerator::UPtr createTrajOptGenerator(bool check_input = true, bool post_collision_check = true);
 
+#ifdef TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT
 /** @brief Create TrajOpt IFOPT Process Pipeline */
 TaskflowGenerator::UPtr createTrajOptIfoptGenerator(bool check_input = true, bool post_collision_check = true);
+#endif
 
 /** @brief Create OMPL Process Pipeline */
 TaskflowGenerator::UPtr createOMPLGenerator(bool check_input = true, bool post_collision_check = true);

--- a/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_request.h
+++ b/tesseract_process_managers/include/tesseract_process_managers/core/process_planning_request.h
@@ -95,8 +95,10 @@ namespace process_planner_names
 /** @brief TrajOpt Planner */
 static const std::string TRAJOPT_PLANNER_NAME = "TrajOptPlanner";
 
+#ifdef TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT
 /** @brief TrajOpt IFOPT Planner */
 static const std::string TRAJOPT_IFOPT_PLANNER_NAME = "TrajOptIfoptPlanner";
+#endif
 
 /** @brief OMPL Planner */
 static const std::string OMPL_PLANNER_NAME = "OMPLPlanner";

--- a/tesseract_process_managers/src/core/default_process_planners.cpp
+++ b/tesseract_process_managers/src/core/default_process_planners.cpp
@@ -43,7 +43,9 @@
 
 #include <tesseract_motion_planners/simple/simple_motion_planner.h>
 #include <tesseract_motion_planners/trajopt/trajopt_motion_planner.h>
+#ifdef TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT
 #include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_motion_planner.h>
+#endif
 #include <tesseract_motion_planners/ompl/ompl_motion_planner.h>
 #include <tesseract_motion_planners/descartes/descartes_motion_planner.h>
 
@@ -103,6 +105,7 @@ TaskflowGenerator::UPtr createTrajOptGenerator(bool check_input, bool post_colli
   return tf;
 }
 
+#ifdef TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT
 TaskflowGenerator::UPtr createTrajOptIfoptGenerator(bool check_input, bool post_collision_check)
 {
   auto tf = std::make_unique<GraphTaskflow>("TrajOptIfoptTaskflow");
@@ -156,6 +159,7 @@ TaskflowGenerator::UPtr createTrajOptIfoptGenerator(bool check_input, bool post_
 
   return tf;
 }
+#endif
 
 TaskflowGenerator::UPtr createOMPLGenerator(bool check_input, bool post_collision_check)
 {

--- a/tesseract_process_managers/src/core/process_planning_server.cpp
+++ b/tesseract_process_managers/src/core/process_planning_server.cpp
@@ -104,7 +104,9 @@ void ProcessPlanningServer::loadDefaultProcessPlanners()
 {
   // This currently call registerProcessPlanner which takes a lock
   registerProcessPlanner(process_planner_names::TRAJOPT_PLANNER_NAME, createTrajOptGenerator());
+#ifdef TESSERACT_PROCESS_MANAGERS_HAS_TRAJOPT_IFOPT
   registerProcessPlanner(process_planner_names::TRAJOPT_IFOPT_PLANNER_NAME, createTrajOptIfoptGenerator());
+#endif
   registerProcessPlanner(process_planner_names::OMPL_PLANNER_NAME, createOMPLGenerator());
   registerProcessPlanner(process_planner_names::DESCARTES_PLANNER_NAME, createDescartesGenerator());
   registerProcessPlanner(process_planner_names::CARTESIAN_PLANNER_NAME, createCartesianGenerator());


### PR DESCRIPTION
Currently trajopt_ifopt is causing a lot of problems on Conda and Windows, and it isn't being widely used. This PR looks for the TESSERACT_BUILD_TRAJOPT_IFOPT cmake option and disables trajopt_ifopt in tesseract_process_managers if set. These planners should probably be plugins at some point instead of being hard coded into the process manager.