### PR TITLE
Add UUID to the MoveInstructionPoly interface

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -106,6 +106,12 @@ public:
                   std::string path_profile,
                   tesseract_common::ManipulatorInfo manipulator_info = tesseract_common::ManipulatorInfo());
 
+  const boost::uuids::uuid& getUUID() const;
+  void regenerateUUID();
+
+  const boost::uuids::uuid& getParentUUID() const;
+  void setParentUUID(const boost::uuids::uuid& uuid);
+
   void setMoveType(MoveInstructionType move_type);
 
   MoveInstructionType getMoveType() const;
@@ -143,7 +149,16 @@ public:
   bool operator!=(const MoveInstruction& rhs) const;
 
 private:
+  /** @brief The instructions UUID */
+  boost::uuids::uuid uuid_{};
+
+  /** @brief The parent UUID if created from createChild */
+  boost::uuids::uuid parent_uuid_{};
+
+  /** @brief The move instruction type */
   MoveInstructionType move_type_{ MoveInstructionType::START };
+
+  /** @brief The description of the instruction */
   std::string description_{ "Tesseract Move Instruction" };
 
   /** @brief The profile used for this move instruction */

--- a/tesseract_command_language/src/move_instruction.cpp
+++ b/tesseract_command_language/src/move_instruction.cpp
@@ -28,6 +28,9 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <iostream>
 #include <console_bridge/console.h>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_serialize.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/move_instruction.h>
@@ -41,7 +44,8 @@ MoveInstruction::MoveInstruction(CartesianWaypointPoly waypoint,
                                  MoveInstructionType type,
                                  std::string profile,
                                  tesseract_common::ManipulatorInfo manipulator_info)
-  : move_type_(type)
+  : uuid_(boost::uuids::random_generator()())
+  , move_type_(type)
   , profile_(std::move(profile))
   , waypoint_(std::move(waypoint))
   , manipulator_info_(std::move(manipulator_info))
@@ -54,7 +58,8 @@ MoveInstruction::MoveInstruction(JointWaypointPoly waypoint,
                                  MoveInstructionType type,
                                  std::string profile,
                                  tesseract_common::ManipulatorInfo manipulator_info)
-  : move_type_(type)
+  : uuid_(boost::uuids::random_generator()())
+  , move_type_(type)
   , profile_(std::move(profile))
   , waypoint_(std::move(waypoint))
   , manipulator_info_(std::move(manipulator_info))
@@ -67,7 +72,8 @@ MoveInstruction::MoveInstruction(StateWaypointPoly waypoint,
                                  MoveInstructionType type,
                                  std::string profile,
                                  tesseract_common::ManipulatorInfo manipulator_info)
-  : move_type_(type)
+  : uuid_(boost::uuids::random_generator()())
+  , move_type_(type)
   , profile_(std::move(profile))
   , waypoint_(std::move(waypoint))
   , manipulator_info_(std::move(manipulator_info))
@@ -81,7 +87,8 @@ MoveInstruction::MoveInstruction(CartesianWaypointPoly waypoint,
                                  std::string profile,
                                  std::string path_profile,
                                  tesseract_common::ManipulatorInfo manipulator_info)
-  : move_type_(type)
+  : uuid_(boost::uuids::random_generator()())
+  , move_type_(type)
   , profile_(std::move(profile))
   , path_profile_(std::move(path_profile))
   , waypoint_(std::move(waypoint))
@@ -94,7 +101,8 @@ MoveInstruction::MoveInstruction(JointWaypointPoly waypoint,
                                  std::string profile,
                                  std::string path_profile,
                                  tesseract_common::ManipulatorInfo manipulator_info)
-  : move_type_(type)
+  : uuid_(boost::uuids::random_generator()())
+  , move_type_(type)
   , profile_(std::move(profile))
   , path_profile_(std::move(path_profile))
   , waypoint_(std::move(waypoint))
@@ -107,13 +115,20 @@ MoveInstruction::MoveInstruction(StateWaypointPoly waypoint,
                                  std::string profile,
                                  std::string path_profile,
                                  tesseract_common::ManipulatorInfo manipulator_info)
-  : move_type_(type)
+  : uuid_(boost::uuids::random_generator()())
+  , move_type_(type)
   , profile_(std::move(profile))
   , path_profile_(std::move(path_profile))
   , waypoint_(std::move(waypoint))
   , manipulator_info_(std::move(manipulator_info))
 {
 }
+
+const boost::uuids::uuid& MoveInstruction::getUUID() const { return uuid_; }
+void MoveInstruction::regenerateUUID() { uuid_ = boost::uuids::random_generator()(); }
+
+const boost::uuids::uuid& MoveInstruction::getParentUUID() const { return parent_uuid_; }
+void MoveInstruction::setParentUUID(const boost::uuids::uuid& uuid) { parent_uuid_ = uuid; }
 
 void MoveInstruction::setMoveType(MoveInstructionType move_type) { move_type_ = move_type; }
 
@@ -169,6 +184,8 @@ bool MoveInstruction::operator!=(const MoveInstruction& rhs) const { return !ope
 template <class Archive>
 void MoveInstruction::serialize(Archive& ar, const unsigned int /*version*/)
 {
+  ar& boost::serialization::make_nvp("uuid", uuid_);
+  ar& boost::serialization::make_nvp("parent_uuid", parent_uuid_);
   ar& boost::serialization::make_nvp("move_type", move_type_);
   ar& boost::serialization::make_nvp("description", description_);
   ar& boost::serialization::make_nvp("profile", profile_);
@@ -181,4 +198,4 @@ void MoveInstruction::serialize(Archive& ar, const unsigned int /*version*/)
 
 #include <tesseract_common/serialization.h>
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::MoveInstruction)
-TESSERACT_MOVE_INSTRUCTION_EXPORT_IMPLEMENT(tesseract_planning::MoveInstruction);
+TESSERACT_MOVE_INSTRUCTION_EXPORT_IMPLEMENT(tesseract_planning::MoveInstruction)

--- a/tesseract_command_language/src/poly/move_instruction_poly.cpp
+++ b/tesseract_command_language/src/poly/move_instruction_poly.cpp
@@ -14,6 +14,20 @@ void tesseract_planning::detail_move_instruction::MoveInstructionInterface::seri
                                      boost::serialization::base_object<tesseract_common::TypeErasureInterface>(*this));
 }
 
+const boost::uuids::uuid& tesseract_planning::MoveInstructionPoly::getUUID() const { return getInterface().getUUID(); }
+
+void tesseract_planning::MoveInstructionPoly::regenerateUUID() { getInterface().regenerateUUID(); }
+
+const boost::uuids::uuid& tesseract_planning::MoveInstructionPoly::getParentUUID() const
+{
+  return getInterface().getParentUUID();
+}
+
+void tesseract_planning::MoveInstructionPoly::setParentUUID(const boost::uuids::uuid& uuid)
+{
+  getInterface().setParentUUID(uuid);
+}
+
 void tesseract_planning::MoveInstructionPoly::assignCartesianWaypoint(CartesianWaypointPoly waypoint)
 {
   getInterface().assignCartesianWaypoint(std::move(waypoint));
@@ -97,6 +111,14 @@ tesseract_planning::StateWaypointPoly tesseract_planning::MoveInstructionPoly::c
   return getInterface().createStateWaypoint();
 }
 
+tesseract_planning::MoveInstructionPoly tesseract_planning::MoveInstructionPoly::createChild() const
+{
+  MoveInstructionPoly child(*this);
+  child.setParentUUID(getUUID());
+  child.regenerateUUID();
+  return child;
+}
+
 bool tesseract_planning::MoveInstructionPoly::isLinear() const
 {
   return (getInterface().getMoveType() == MoveInstructionType::LINEAR);
@@ -117,6 +139,8 @@ bool tesseract_planning::MoveInstructionPoly::isStart() const
   return (getInterface().getMoveType() == MoveInstructionType::START);
 }
 
+bool tesseract_planning::MoveInstructionPoly::isChild() const { return (!getInterface().getParentUUID().is_nil()); }
+
 template <class Archive>
 void tesseract_planning::MoveInstructionPoly::serialize(Archive& ar, const unsigned int /*version*/)  // NOLINT
 {
@@ -132,4 +156,4 @@ BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::detail_move_instruction::MoveIn
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::MoveInstructionPolyBase)
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::MoveInstructionPoly)
 
-TESSERACT_INSTRUCTION_EXPORT_IMPLEMENT(tesseract_planning::MoveInstructionPoly);
+TESSERACT_INSTRUCTION_EXPORT_IMPLEMENT(tesseract_planning::MoveInstructionPoly)

--- a/tesseract_command_language/test/move_instruction_unit.cpp
+++ b/tesseract_command_language/test/move_instruction_unit.cpp
@@ -51,6 +51,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
     EXPECT_TRUE(instr.getPathProfile().empty());
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   {
@@ -60,6 +62,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
     EXPECT_TRUE(instr.getPathProfile().empty());
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   {
@@ -69,6 +73,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
     EXPECT_EQ(instr.getPathProfile(), DEFAULT_PROFILE_KEY);
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   // With plan profile
@@ -79,6 +85,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
     EXPECT_TRUE(instr.getPathProfile().empty());
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   {
@@ -88,6 +96,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
     EXPECT_TRUE(instr.getPathProfile().empty());
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   {
@@ -97,6 +107,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
     EXPECT_EQ(instr.getPathProfile(), "TEST_PROFILE");
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   // With plan and path profile
@@ -107,6 +119,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
     EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   {
@@ -116,6 +130,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
     EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 
   {
@@ -125,6 +141,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, constructor)  // NOLINT
     EXPECT_EQ(instr.getProfile(), "TEST_PROFILE");
     EXPECT_EQ(instr.getPathProfile(), "TEST_PATH_PROFILE");
     EXPECT_FALSE(instr.getDescription().empty());
+    EXPECT_FALSE(instr.getUUID().is_nil());
+    EXPECT_TRUE(instr.getParentUUID().is_nil());
   }
 }
 
@@ -140,6 +158,8 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, setters)  // NOLINT
   EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
   EXPECT_TRUE(instr.getPathProfile().empty());
   EXPECT_FALSE(instr.getDescription().empty());
+  EXPECT_FALSE(instr.getUUID().is_nil());
+  EXPECT_TRUE(instr.getParentUUID().is_nil());
 
   StateWaypoint test_swp(jn, 5 * jv);
   instr.assignStateWaypoint(test_swp);
@@ -156,6 +176,41 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, setters)  // NOLINT
 
   instr.setDescription("This is a test.");
   EXPECT_EQ(instr.getDescription(), "This is a test.");
+
+  boost::uuids::uuid uuid = instr.getUUID();
+  instr.regenerateUUID();
+  EXPECT_FALSE(uuid == instr.getUUID());
+
+  instr.setParentUUID(uuid);
+  EXPECT_FALSE(instr.getParentUUID().is_nil());
+  EXPECT_TRUE(uuid == instr.getParentUUID());
+}
+
+TEST(TesseractCommandLanguageMoveInstructionUnit, UUID)  // NOLINT
+{
+  Eigen::VectorXd jv = Eigen::VectorXd::Ones(6);
+  std::vector<std::string> jn = { "j1", "j2", "j3", "j4", "j5", "j6" };
+  StateWaypointPoly swp(StateWaypoint(jn, jv));
+
+  MoveInstruction instr(swp, MoveInstructionType::START);
+  EXPECT_EQ(instr.getWaypoint(), swp);
+  EXPECT_EQ(instr.getMoveType(), MoveInstructionType::START);
+  EXPECT_EQ(instr.getProfile(), DEFAULT_PROFILE_KEY);
+  EXPECT_TRUE(instr.getPathProfile().empty());
+  EXPECT_FALSE(instr.getDescription().empty());
+  EXPECT_FALSE(instr.getUUID().is_nil());
+
+  MoveInstruction assign = instr;
+  EXPECT_TRUE(assign == instr);
+  EXPECT_TRUE(assign.getUUID() == instr.getUUID());
+
+  MoveInstruction copy(instr);
+  EXPECT_TRUE(copy == instr);
+  EXPECT_TRUE(assign.getUUID() == instr.getUUID());
+
+  boost::uuids::uuid uuid = instr.getUUID();
+  instr.regenerateUUID();
+  EXPECT_FALSE(uuid == instr.getUUID());
 }
 
 TEST(TesseractCommandLanguageMoveInstructionUnit, boostSerialization)  // NOLINT
@@ -169,6 +224,7 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, boostSerialization)  // NOLINT
   instr.setProfile("TEST_PROFILE");
   instr.setPathProfile("TEST_PATH_PROFILE");
   instr.setDescription("This is a test.");
+  boost::uuids::uuid uuid = instr.getUUID();
 
   tesseract_common::Serialization::toArchiveFileXML<MoveInstruction>(instr, "/tmp/move_instruction_boost.xml");
 
@@ -180,6 +236,7 @@ TEST(TesseractCommandLanguageMoveInstructionUnit, boostSerialization)  // NOLINT
   EXPECT_EQ(ninstr.getProfile(), "TEST_PROFILE");
   EXPECT_EQ(ninstr.getPathProfile(), "TEST_PATH_PROFILE");
   EXPECT_EQ(ninstr.getDescription(), "This is a test.");
+  EXPECT_EQ(ninstr.getUUID(), uuid);
 }
 
 TEST(TesseractCommandLanguageMoveInstructionPolyUnit, boostSerialization)  // NOLINT
@@ -193,6 +250,7 @@ TEST(TesseractCommandLanguageMoveInstructionPolyUnit, boostSerialization)  // NO
   instr.setProfile("TEST_PROFILE");
   instr.setPathProfile("TEST_PATH_PROFILE");
   instr.setDescription("This is a test.");
+  boost::uuids::uuid uuid = instr.getUUID();
 
   MoveInstructionPoly instr_poly(instr);
 
@@ -200,13 +258,36 @@ TEST(TesseractCommandLanguageMoveInstructionPolyUnit, boostSerialization)  // NO
 
   auto ninstr = tesseract_common::Serialization::fromArchiveFileXML<MoveInstructionPoly>("/tmp/"
                                                                                          "move_instruction_boost.xml");
-
   EXPECT_TRUE(ninstr == instr_poly);
   EXPECT_EQ(ninstr.getWaypoint(), swp);
   EXPECT_EQ(ninstr.getMoveType(), MoveInstructionType::LINEAR);
   EXPECT_EQ(ninstr.getProfile(), "TEST_PROFILE");
   EXPECT_EQ(ninstr.getPathProfile(), "TEST_PATH_PROFILE");
   EXPECT_EQ(ninstr.getDescription(), "This is a test.");
+  EXPECT_EQ(ninstr.getUUID(), uuid);
+  EXPECT_FALSE(ninstr.getUUID().is_nil());
+  EXPECT_TRUE(ninstr.getParentUUID().is_nil());
+
+  MoveInstructionPoly child_instr_poly = instr_poly.createChild();
+  boost::uuids::uuid child_uuid = child_instr_poly.getUUID();
+
+  tesseract_common::Serialization::toArchiveFileXML<MoveInstructionPoly>(child_instr_poly,
+                                                                         "/tmp/child_move_instruction_boost.xml");
+
+  auto child_ninstr = tesseract_common::Serialization::fromArchiveFileXML<MoveInstructionPoly>("/tmp/"
+                                                                                               "child_move_instruction_"
+                                                                                               "boost.xml");
+  EXPECT_TRUE(child_ninstr == instr_poly);
+  EXPECT_EQ(child_ninstr.getWaypoint(), swp);
+  EXPECT_EQ(child_ninstr.getMoveType(), MoveInstructionType::LINEAR);
+  EXPECT_EQ(child_ninstr.getProfile(), "TEST_PROFILE");
+  EXPECT_EQ(child_ninstr.getPathProfile(), "TEST_PATH_PROFILE");
+  EXPECT_EQ(child_ninstr.getDescription(), "This is a test.");
+  EXPECT_EQ(child_ninstr.getUUID(), child_uuid);
+  EXPECT_EQ(child_ninstr.getParentUUID(), uuid);
+  EXPECT_NE(child_ninstr.getParentUUID(), child_ninstr.getUUID());
+  EXPECT_FALSE(child_ninstr.getUUID().is_nil());
+  EXPECT_FALSE(child_ninstr.getParentUUID().is_nil());
 }
 
 int main(int argc, char** argv)

--- a/tesseract_command_language/test/type_erasure_benchmark.cpp
+++ b/tesseract_command_language/test/type_erasure_benchmark.cpp
@@ -232,6 +232,44 @@ static void BM_WaypointPolyCreation(benchmark::State& state)
 
 BENCHMARK(BM_WaypointPolyCreation);
 
+static void BM_MoveInstructionCreation(benchmark::State& state)
+{
+  CartesianWaypointPoly w{ CartesianWaypoint(Eigen::Isometry3d::Identity()) };
+  for (auto _ : state)
+    MoveInstruction i(w, MoveInstructionType::START);
+}
+
+BENCHMARK(BM_MoveInstructionCreation);
+
+static void BM_StateWaypointCreation(benchmark::State& state)
+{
+  std::vector<std::string> joint_names{ "a1", "a2", "a3", "a4", "a5", "a6" };
+  Eigen::VectorXd joint_values = Eigen::VectorXd::Zero(6);
+  for (auto _ : state)
+    StateWaypoint w(joint_names, joint_values);
+}
+
+BENCHMARK(BM_StateWaypointCreation);
+
+static void BM_JointWaypointCreation(benchmark::State& state)
+{
+  std::vector<std::string> joint_names{ "a1", "a2", "a3", "a4", "a5", "a6" };
+  Eigen::VectorXd joint_values = Eigen::VectorXd::Zero(6);
+  for (auto _ : state)
+    JointWaypoint w(joint_names, joint_values);
+}
+
+BENCHMARK(BM_JointWaypointCreation);
+
+static void BM_CartesianWaypointCreation(benchmark::State& state)
+{
+  Eigen::Isometry3d pose{ Eigen::Isometry3d::Identity() };
+  for (auto _ : state)
+    CartesianWaypoint w(pose);
+}
+
+BENCHMARK(BM_CartesianWaypointCreation);
+
 static void BM_CompositeInstructionCreation(benchmark::State& state)
 {
   for (auto _ : state)

--- a/tesseract_motion_planners/core/src/simple/profile/simple_planner_utils.cpp
+++ b/tesseract_motion_planners/core/src/simple/profile/simple_planner_utils.cpp
@@ -149,7 +149,7 @@ CompositeInstruction getInterpolatedComposite(const std::vector<std::string>& jo
   // Convert to MoveInstructions
   for (long i = 1; i < states.cols() - 1; ++i)
   {
-    MoveInstructionPoly move_instruction{ base_instruction };
+    MoveInstructionPoly move_instruction = base_instruction.createChild();
     StateWaypointPoly swp = move_instruction.createStateWaypoint();
     swp.setNames(joint_names);
     swp.setPosition(states.col(i));
@@ -159,7 +159,7 @@ CompositeInstruction getInterpolatedComposite(const std::vector<std::string>& jo
     composite.appendMoveInstruction(move_instruction);
   }
 
-  MoveInstructionPoly move_instruction{ base_instruction };
+  MoveInstructionPoly move_instruction = base_instruction.createChild();
   StateWaypointPoly swp = move_instruction.createStateWaypoint();
   swp.setNames(joint_names);
   swp.setPosition(states.col(states.cols() - 1));


### PR DESCRIPTION
I updated the benchmark data because it did not capture the creation of the implemenation type MoveInstruction, StateWaypoint, JointWaypoint and CartesianWaypoint. It does show that adding the boost::uuids::uuid to the MoveInstruction increase the creation time from 155ns to 900ns. This still a very small time where if you were to create 1000 instruction the time would to create all move instructions would be 0.0009s vs 0.000155s and since this does not impact copying which is what occurs during the planning pipeline I feel this is acceptable.

Before:

``` bash
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
BM_InstructionPolyCreation              0.000 ns        0.000 ns   1000000000
BM_WaypointPolyCreation                 0.000 ns        0.000 ns   1000000000
BM_MoveInstructionCreation                155 ns          155 ns      4427227
BM_StateWaypointCreation                 52.3 ns         52.3 ns     13160799
BM_JointWaypointCreation                 46.6 ns         46.6 ns     14589245
BM_CartesianWaypointCreation             10.7 ns         10.7 ns     65025243
BM_CompositeInstructionCreation          49.8 ns         49.8 ns     13885873
BM_ProgramCreation                      26792 ns        26790 ns        25928
BM_InstructionPolyCopy                   62.3 ns         62.3 ns     10998026
BM_WaypointPolyCopy                      19.6 ns         19.6 ns     35652538
BM_CompositeInstructionCopy              6128 ns         6128 ns       118155
BM_InstructionPolyAssign                 62.6 ns         62.6 ns     11250108
BM_WaypointPolyAssign                    19.7 ns         19.7 ns     35535057
BM_CompositeInstructionAssign            5806 ns         5806 ns       119602
BM_InstructionPolyCast                   1.96 ns         1.96 ns    355923076
BM_WaypointPolyCast                      1.75 ns         1.75 ns    400402308
BM_InstructionPolyAccess                 2.18 ns         2.18 ns    320238369
BM_WaypointPolyAccess                   0.218 ns        0.218 ns   1000000000
BM_VectorStateWaypointPolyCreation     153191 ns       153190 ns         4612
BM_VectorStateWaypointUPtrCreation     144173 ns       144171 ns         4875
BM_VectorStateWaypointPolyCopy          86024 ns        86023 ns         8134
BM_VectorStateWaypointUPtrCopy          86456 ns        86455 ns         8058
```

After:

``` bash
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
BM_InstructionPolyCreation              0.000 ns        0.000 ns   1000000000
BM_WaypointPolyCreation                 0.000 ns        0.000 ns   1000000000
BM_MoveInstructionCreation                900 ns          900 ns       771254
BM_StateWaypointCreation                 54.6 ns         54.6 ns     13039459
BM_JointWaypointCreation                 47.6 ns         47.6 ns     14743474
BM_CartesianWaypointCreation             10.6 ns         10.6 ns     66011077
BM_CompositeInstructionCreation          51.1 ns         51.1 ns     13678986
BM_ProgramCreation                      34201 ns        34200 ns        20446
BM_InstructionPolyCopy                   66.5 ns         66.5 ns     10512135
BM_WaypointPolyCopy                      20.4 ns         20.4 ns     34139015
BM_CompositeInstructionCopy              5820 ns         5820 ns       120516
BM_InstructionPolyAssign                 65.3 ns         65.3 ns     10846574
BM_WaypointPolyAssign                    21.3 ns         21.3 ns     33852431
BM_CompositeInstructionAssign            5905 ns         5905 ns       118460
BM_InstructionPolyCast                   1.77 ns         1.77 ns    397620001
BM_WaypointPolyCast                      1.79 ns         1.79 ns    394245538
BM_InstructionPolyAccess                 2.21 ns         2.21 ns    315709956
BM_WaypointPolyAccess                   0.219 ns        0.219 ns   1000000000
BM_VectorStateWaypointPolyCreation     151456 ns       151453 ns         4644
BM_VectorStateWaypointUPtrCreation     145443 ns       145440 ns         4800
BM_VectorStateWaypointPolyCopy          86364 ns        86364 ns         8097
BM_VectorStateWaypointUPtrCopy          86519 ns        86518 ns         8082
```
