### PR TITLE
Fixed bug that wouldn't pass through a 'found' flag

### DIFF
--- a/tesseract_motion_planners/core/src/core/utils.cpp
+++ b/tesseract_motion_planners/core/src/core/utils.cpp
@@ -288,14 +288,15 @@ bool contactCheckProgram(std::vector<tesseract_collision::ContactResultMap>& con
     throw std::runtime_error("contactCheckProgram was given an CollisionEvaluatorType that is inconsistent with the "
                              "ContactManager type (Continuous)");
   manager.applyContactManagerConfig(config.contact_manager_config);
+
+  // Flatten results
+  std::vector<std::reference_wrapper<const InstructionPoly>> mi = program.flatten(moveFilter);
+
   bool found = false;
 
   if (config.type == tesseract_collision::CollisionEvaluatorType::LVS_CONTINUOUS)
   {
     assert(config.longest_valid_segment_length > 0);
-
-    // Flatten results
-    std::vector<std::reference_wrapper<const InstructionPoly>> mi = program.flatten(moveFilter);
 
     contacts.resize(mi.size() - 1);
     for (std::size_t iStep = 0; iStep < mi.size() - 1; ++iStep)
@@ -394,11 +395,6 @@ bool contactCheckProgram(std::vector<tesseract_collision::ContactResultMap>& con
   }
   else
   {
-    bool found = false;
-
-    // Flatten results
-    std::vector<std::reference_wrapper<const InstructionPoly>> mi = program.flatten(moveFilter);
-
     contacts.resize(mi.size() - 1);
     for (std::size_t iStep = 0; iStep < mi.size() - 1; ++iStep)
     {
@@ -452,12 +448,12 @@ bool contactCheckProgram(std::vector<tesseract_collision::ContactResultMap>& con
   manager.applyContactManagerConfig(config.contact_manager_config);
   bool found = false;
 
+  // Flatten results
+  std::vector<std::reference_wrapper<const InstructionPoly>> mi = program.flatten(moveFilter);
+
   if (config.type == tesseract_collision::CollisionEvaluatorType::LVS_DISCRETE)
   {
     assert(config.longest_valid_segment_length > 0);
-
-    // Flatten results
-    std::vector<std::reference_wrapper<const InstructionPoly>> mi = program.flatten(moveFilter);
 
     contacts.resize(mi.size());
     for (std::size_t iStep = 0; iStep < mi.size(); ++iStep)
@@ -552,9 +548,6 @@ bool contactCheckProgram(std::vector<tesseract_collision::ContactResultMap>& con
   }
   else
   {
-    // Flatten results
-    std::vector<std::reference_wrapper<const InstructionPoly>> mi = program.flatten(moveFilter);
-
     contacts.resize(mi.size());
     for (std::size_t iStep = 0; iStep < mi.size() - 1; ++iStep)
     {


### PR DESCRIPTION
In the `contactCheckProgram` method for a `ContinuousContactManager` in the scenario that a non `LVS_CONTINUOUS` type is used, `found` was being created inside the scope of the else statement, therefore a collision could be found and then it return that no collision was found since the `found` outside the scope is initialized as false.

I also made a small change that just moved the flatten call outside the if statements because it was just repeated in both places exactly the same.