### PR TITLE
Boost 1.74 issue fix

### DIFF
--- a/tesseract_process_managers/src/core/process_planning_future.cpp
+++ b/tesseract_process_managers/src/core/process_planning_future.cpp
@@ -27,6 +27,9 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/unique_ptr.hpp>

--- a/tesseract_process_managers/src/core/process_planning_problem.cpp
+++ b/tesseract_process_managers/src/core/process_planning_problem.cpp
@@ -27,6 +27,9 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/unique_ptr.hpp>

--- a/tesseract_process_managers/src/core/process_planning_request.cpp
+++ b/tesseract_process_managers/src/core/process_planning_request.cpp
@@ -26,6 +26,9 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/nvp.hpp>
+#if (BOOST_VERSION >= 107400) && (BOOST_VERSION < 107500)
+#include <boost/serialization/library_version_type.hpp>
+#endif
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/shared_ptr.hpp>


### PR DESCRIPTION
Including <boost/serialization/library_version_type.hpp> for Boost 1.74. Fixes tesseract-robotics/tesseract#764