### PR TITLE
Revised planner profile interfaces

### DIFF
--- a/tesseract_command_language/test/move_instruction_unit.cpp
+++ b/tesseract_command_language/test/move_instruction_unit.cpp
@@ -296,7 +296,7 @@ TEST(TesseractCommandLanguageMoveInstructionPolyUnit, ProfileOverrides)  // NOLI
   Eigen::VectorXd jv = Eigen::VectorXd::Ones(6);
   std::vector<std::string> jn = { "j1", "j2", "j3", "j4", "j5", "j6" };
   StateWaypointPoly swp(StateWaypoint(jn, jv));
-  MoveInstruction instr(swp, MoveInstructionType::START, DEFAULT_PROFILE_KEY, DEFAULT_PROFILE_KEY);
+  MoveInstruction instr(swp, MoveInstructionType::FREESPACE, DEFAULT_PROFILE_KEY, DEFAULT_PROFILE_KEY);
 
   // Create arbitrary profile overrides under arbitrary namespaces
   const std::string ns1 = "ns1";

--- a/tesseract_examples/src/car_seat_example.cpp
+++ b/tesseract_examples/src/car_seat_example.cpp
@@ -283,7 +283,7 @@ bool CarSeatExample::run()
     StateWaypointPoly wp1{ StateWaypoint(joint_group->getJointNames(), pick_pose) };
 
     // Start Joint Position for the program
-    MoveInstruction start_instruction(wp0, MoveInstructionType::FREESPACE, "FREESPACE");
+    MoveInstruction start_instruction(wp0, MoveInstructionType::FREESPACE, DEFAULT_PROFILE_KEY);
     start_instruction.setDescription("Start Instruction");
 
     // Plan freespace from start
@@ -369,7 +369,7 @@ bool CarSeatExample::run()
     StateWaypointPoly wp1{ StateWaypoint(joint_group->getJointNames(), pick_pose) };
 
     // Start Joint Position for the program
-    MoveInstruction start_instruction(wp0, MoveInstructionType::FREESPACE, "FREESPACE");
+    MoveInstruction start_instruction(wp0, MoveInstructionType::FREESPACE, DEFAULT_PROFILE_KEY);
     start_instruction.setDescription("Start Instruction");
 
     // Plan freespace from start

--- a/tesseract_examples/src/glass_upright_example.cpp
+++ b/tesseract_examples/src/glass_upright_example.cpp
@@ -152,7 +152,7 @@ bool GlassUprightExample::run()
   StateWaypointPoly wp0{ StateWaypoint(joint_names, joint_start_pos) };
   StateWaypointPoly wp1{ StateWaypoint(joint_names, joint_end_pos) };
 
-  MoveInstruction start_instruction(wp0, MoveInstructionType::LINEAR, "UPRIGHT");
+  MoveInstruction start_instruction(wp0, MoveInstructionType::LINEAR, DEFAULT_PROFILE_KEY);
   start_instruction.setDescription("Start Instruction");
 
   // Plan freespace from start

--- a/tesseract_motion_planners/core/CMakeLists.txt
+++ b/tesseract_motion_planners/core/CMakeLists.txt
@@ -2,7 +2,13 @@ find_package(tesseract_environment REQUIRED)
 find_package(tesseract_command_language REQUIRED)
 
 # Create interface for core
-add_library(${PROJECT_NAME}_core src/core/planner.cpp src/core/utils.cpp src/core/interpolation.cpp)
+add_library(
+  ${PROJECT_NAME}_core
+  src/core/interpolation.cpp
+  src/core/planner.cpp
+  src/core/profiles.cpp
+  src/core/profile_dictionary.cpp
+  src/core/utils.cpp)
 target_link_libraries(
   ${PROJECT_NAME}_core
   PUBLIC tesseract::tesseract_environment

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/core/profile_dictionary.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/core/profile_dictionary.h
@@ -1,0 +1,103 @@
+/**
+ * @file profile_dictionary.h
+ * @brief This is a profile dictionary for storing all profiles
+ *
+ * @author Michael Ripperger
+ * @date January 11, 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_CORE_PROFILE_DICTIONARY_H
+#define TESSERACT_MOTION_PLANNERS_CORE_PROFILE_DICTIONARY_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <any>
+#include <boost/serialization/serialization.hpp>
+#include <iostream>
+#include <unordered_map>
+#include <memory>
+#include <shared_mutex>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#ifdef SWIG
+%shared_ptr(tesseract_planning::ProfileDictionary)
+#endif  // SWIG
+#include <tesseract_motion_planners/core/profiles.h>
+
+namespace tesseract_planning::tmp
+{
+/**
+ * @brief Stores profiles for motion planning and process planning
+ * @details This class is thread-safe
+ */
+template <typename ProfileT>
+class ProfileDictionary
+{
+public:
+  using Ptr = std::shared_ptr<ProfileDictionary<ProfileT>>;
+  using ConstPtr = std::shared_ptr<const ProfileDictionary<ProfileT>>;
+
+  ProfileDictionary() = default;
+  virtual ~ProfileDictionary() = default;
+
+  ProfileDictionary(const ProfileDictionary& rhs);
+  ProfileDictionary(ProfileDictionary&& rhs) noexcept;
+  ProfileDictionary& operator=(const ProfileDictionary& rhs);
+  ProfileDictionary& operator=(ProfileDictionary&& rhs) noexcept;
+
+  /**
+   * @brief Checks if a profile exists in the provided namespace
+   * @return True if exists, false otherwise
+   */
+  bool hasProfile(const std::string& ns, const std::string& profile) const;
+
+  /**
+   * @brief Gets a profile by name under a given namespace
+   * @throws Runtime exception if the namespace or profile do not exist
+   */
+  typename ProfileT::ConstPtr getProfile(const std::string& ns, const std::string& profile_name) const;
+
+  /**
+   * @brief Gets a profile entry from a given namespace
+   */
+  std::unordered_map<std::string, typename ProfileT::ConstPtr> getProfileEntry(const std::string& ns) const;
+
+  /**
+   * @brief Adds a profile with the input name under the given namespace
+   */
+  void addProfile(const std::string& ns, const std::string& profile_name, typename ProfileT::ConstPtr profile);
+
+  /**
+   * @brief Removes a profile entry from a given namespace
+   */
+  void removeProfile(const std::string& ns, const std::string& profile);
+
+protected:
+  std::unordered_map<std::string, std::unordered_map<std::string, typename ProfileT::ConstPtr>> profiles_;
+  mutable std::shared_mutex mutex_;
+};
+
+using WaypointProfileDictionary = ProfileDictionary<WaypointProfile>;
+using CompositeProfileDictionary = ProfileDictionary<CompositeProfile>;
+using PlannerProfileDictionary = ProfileDictionary<PlannerProfile>;
+
+}  // namespace tesseract_planning::tmp
+
+#endif  // TESSERACT_MOTION_PLANNERS_CORE_PROFILE_DICTIONARY_H

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/core/profiles.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/core/profiles.h
@@ -1,0 +1,131 @@
+/**
+ * @file profile_dictionary.h
+ * @brief This is a profile dictionary for storing all profiles
+ *
+ * @author Levi Armstrong
+ * @date December 2, 2020
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_CORE_PROFILES_H
+#define TESSERACT_MOTION_PLANNERS_CORE_PROFILES_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <any>
+#include <iostream>
+#include <typeindex>
+#include <unordered_map>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_environment/environment.h>
+#include <tesseract_command_language/move_instruction.h>
+#include <tesseract_command_language/composite_instruction.h>
+
+namespace tesseract_planning
+{
+/**
+ * @brief Struct to produce a planner-specific planning profile to apply to a single waypoint.
+ * @details Examples of waypoint profiles might include costs/constraints for a waypoint or a waypoint sampler
+ */
+class WaypointProfile
+{
+public:
+  using Ptr = std::shared_ptr<WaypointProfile>;
+  using ConstPtr = std::shared_ptr<const WaypointProfile>;
+
+  WaypointProfile() = default;
+  WaypointProfile(const WaypointProfile&) = delete;
+  WaypointProfile& operator=(const WaypointProfile&) = delete;
+  WaypointProfile(WaypointProfile&&) = delete;
+  WaypointProfile&& operator=(WaypointProfile&&) = delete;
+
+  virtual ~WaypointProfile() = default;
+
+  virtual std::any create(const MoveInstruction& instruction,
+                          tesseract_environment::Environment::ConstPtr env) const = 0;
+
+protected:
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive&, const unsigned int);  // NOLINT
+};
+
+/**
+ * @brief Struct to produce a planner-specific planning profile to apply to a collection of waypoints defined in a
+ * composite instruction.
+ * @details Examples of composite profiles include costs/constraints that apply collectively to a group of waypoints
+ */
+class CompositeProfile
+{
+public:
+  using Ptr = std::shared_ptr<CompositeProfile>;
+  using ConstPtr = std::shared_ptr<const CompositeProfile>;
+
+  CompositeProfile() = default;
+  CompositeProfile(const CompositeProfile&) = delete;
+  CompositeProfile& operator=(const CompositeProfile&) = delete;
+  CompositeProfile(CompositeProfile&&) = delete;
+  CompositeProfile&& operator=(CompositeProfile&&) = delete;
+
+  virtual ~CompositeProfile() = default;
+  virtual std::any create(const CompositeInstruction& instruction,
+                          tesseract_environment::Environment::ConstPtr env) const = 0;
+
+protected:
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive&, const unsigned int);  // NOLINT
+};
+
+/**
+ * @brief Struct to produce configuration parameters for the motion planner
+ */
+struct PlannerProfile
+{
+public:
+  using Ptr = std::shared_ptr<PlannerProfile>;
+  using ConstPtr = std::shared_ptr<const PlannerProfile>;
+
+  PlannerProfile() = default;
+  PlannerProfile(const PlannerProfile&) = delete;
+  PlannerProfile& operator=(const PlannerProfile&) = delete;
+  PlannerProfile(PlannerProfile&&) = delete;
+  PlannerProfile&& operator=(PlannerProfile&&) = delete;
+
+  virtual ~PlannerProfile() = default;
+
+  virtual std::any create() const = 0;
+
+protected:
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive&, const unsigned int);  // NOLINT
+};
+
+}  // namespace tesseract_planning
+
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::WaypointProfile);
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::CompositeProfile);
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::PlannerProfile);
+
+#endif  // TESSERACT_MOTION_PLANNERS_CORE_PROFILES_H

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/core/types.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/core/types.h
@@ -32,6 +32,8 @@
 #include <tesseract_command_language/composite_instruction.h>
 #include <tesseract_command_language/profile_dictionary.h>
 
+#include <tesseract_motion_planners/core/profile_dictionary.h>
+
 namespace tesseract_planning
 {
 struct PlannerRequest
@@ -51,6 +53,10 @@ struct PlannerRequest
 
   /** @brief The profile dictionary */
   ProfileDictionary::ConstPtr profiles{ std::make_shared<ProfileDictionary>() };
+
+  tmp::WaypointProfileDictionary::ConstPtr waypoint_profiles{ std::make_shared<tmp::WaypointProfileDictionary>() };
+  tmp::CompositeProfileDictionary::ConstPtr composite_profiles{ std::make_shared<tmp::CompositeProfileDictionary>() };
+  tmp::PlannerProfileDictionary::ConstPtr planner_profiles{ std::make_shared<tmp::PlannerProfileDictionary>() };
 
   /**
    * @brief The program instruction

--- a/tesseract_motion_planners/core/src/core/profile_dictionary.cpp
+++ b/tesseract_motion_planners/core/src/core/profile_dictionary.cpp
@@ -1,0 +1,117 @@
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <sstream>
+#include <boost/core/demangle.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_motion_planners/core/profile_dictionary.h>
+
+namespace tesseract_planning::tmp
+{
+template <typename ProfileT>
+ProfileDictionary<ProfileT>::ProfileDictionary(const ProfileDictionary& rhs) : profiles_(rhs.profiles_)
+{
+}
+
+template <typename ProfileT>
+ProfileDictionary<ProfileT>::ProfileDictionary(ProfileDictionary&& rhs) noexcept : profiles_(std::move(rhs.profiles_))
+{
+}
+
+template <typename ProfileT>
+ProfileDictionary<ProfileT>& ProfileDictionary<ProfileT>::operator=(const ProfileDictionary& rhs)
+{
+  profiles_ = rhs.profiles_;
+  return *this;
+}
+
+template <typename ProfileT>
+ProfileDictionary<ProfileT>& ProfileDictionary<ProfileT>::operator=(ProfileDictionary&& rhs) noexcept
+{
+  profiles_ = std::move(rhs.profiles_);
+  return *this;
+}
+
+template <typename ProfileT>
+bool ProfileDictionary<ProfileT>::hasProfile(const std::string& ns, const std::string& profile) const
+{
+  std::shared_lock lock(mutex_);
+
+  auto ns_it = profiles_.find(ns);
+  if (ns_it == profiles_.end())
+    return false;
+
+  auto prof_it = ns_it->second.find(profile);
+  return prof_it != ns_it->second.end();
+}
+
+template <typename ProfileT>
+typename ProfileT::ConstPtr ProfileDictionary<ProfileT>::getProfile(const std::string& ns,
+                                                                    const std::string& profile) const
+{
+  std::shared_lock lock(mutex_);
+  auto ns_it = profiles_.find(ns);
+  if (ns_it == profiles_.end())
+    throw std::runtime_error("Profile namespace does not exist for '" + ns + "'!");
+
+  auto prof_it = ns_it->second.find(profile);
+  if (prof_it == ns_it->second.end())
+    throw std::runtime_error("Profile entry does not exist for profile '" + profile + "' in namespace '" + ns + "'");
+
+  return prof_it->second;
+}
+
+template <typename ProfileT>
+std::unordered_map<std::string, typename ProfileT::ConstPtr>
+ProfileDictionary<ProfileT>::getProfileEntry(const std::string& ns) const
+{
+  std::shared_lock lock(mutex_);
+  auto ns_it = profiles_.find(ns);
+  if (ns_it == profiles_.end())
+    throw std::runtime_error("Profile namespace does not exist for '" + ns + "'!");
+
+  return ns_it->second;
+}
+
+template <typename ProfileT>
+void ProfileDictionary<ProfileT>::addProfile(const std::string& ns,
+                                             const std::string& profile_name,
+                                             typename ProfileT::ConstPtr profile)
+{
+  if (ns.empty())
+    throw std::runtime_error("Namespace cannot be empty");
+
+  if (profile_name.empty())
+    throw std::runtime_error("Profile name cannot be empty");
+
+  if (profile == nullptr)
+    throw std::runtime_error("Profile cannot be a nullptr");
+
+  std::unique_lock lock(mutex_);
+  auto it = profiles_.find(ns);
+  if (it == profiles_.end())
+  {
+    // Create a new map for the namespace
+    profiles_[ns] = { { profile_name, profile } };
+  }
+  else
+  {
+    profiles_[ns][profile_name] = profile;
+  }
+}
+
+template <typename ProfileT>
+void ProfileDictionary<ProfileT>::removeProfile(const std::string& ns, const std::string& profile)
+{
+  std::unique_lock lock(mutex_);
+
+  auto it = profiles_.find(ns);
+  if (it != profiles_.end())
+    it->second.erase(profile);
+}
+
+template class ProfileDictionary<WaypointProfile>;
+template class ProfileDictionary<CompositeProfile>;
+template class ProfileDictionary<PlannerProfile>;
+
+}  // namespace tesseract_planning::tmp

--- a/tesseract_motion_planners/core/src/core/profiles.cpp
+++ b/tesseract_motion_planners/core/src/core/profiles.cpp
@@ -1,0 +1,30 @@
+#include <tesseract_motion_planners/core/profiles.h>
+
+namespace tesseract_planning
+{
+template <class Archive>
+void WaypointProfile::serialize(Archive&, const unsigned int)
+{
+}
+
+template <class Archive>
+void CompositeProfile::serialize(Archive&, const unsigned int)
+{
+}
+
+template <class Archive>
+void PlannerProfile::serialize(Archive&, const unsigned int)
+{
+}
+
+}  // namespace tesseract_planning
+
+#include <tesseract_common/serialization.h>
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::WaypointProfile);
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::WaypointProfile);
+
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::CompositeProfile);
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::CompositeProfile);
+
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(tesseract_planning::PlannerProfile);
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::PlannerProfile);


### PR DESCRIPTION
This PR provides new interfaces for motion planner waypoint, composite, and planner level profiles. Each profile produces a type-erased, planner-specific data object from a relevant input (an instruction for the waypoint profile, a composite instruction for the composite profile). The individual planners can look up profiles in the profile dictionary by a combination of namespace and name, and can cast them to the required type. Since the objects returned by the profiles are std::any type-erasers, any issues with incorrect casts will result in an exception that can be handled.

The addition of new planner profile interfaces supports an on-going larger refactor and simplification of the various motion planners class (started in https://github.com/tesseract-robotics/tesseract_planning/pull/138). Additionally, the new profiles will be easier to store and retrieve in the profile dictionary since they will no longer be stored by class typeid.

This PR adds three new maps in the profile dictionary to hold these waypoints. Currently these maps are public members of the profile dictionary for convenience and to minimize API breakage. As motion planners are refactored to use these profile interfaces, the planners will retrieve profiles from these maps. Ultimately, the map storing profiles by typeid will be removed, the three maps holding the new profiles will be made private, and the existing profile dictionary API will be revised to access the new profile maps.

Replaces #156