### PR TITLE
Fix descartes global motion pipeline task

### DIFF
--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/profile/descartes_default_plan_profile.hpp
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/profile/descartes_default_plan_profile.hpp
@@ -248,7 +248,18 @@ void DescartesDefaultPlanProfile<FloatType>::apply(DescartesProblem<FloatType>& 
     }
     else
     {
-      prob.edge_evaluators.push_back(edge_evaluator(prob));
+      if (enable_edge_collision)
+      {
+        auto compound_evaluator = std::make_shared<descartes_light::CompoundEdgeEvaluator<FloatType>>();
+        compound_evaluator->evaluators.push_back(edge_evaluator(prob));
+        compound_evaluator->evaluators.push_back(std::make_shared<DescartesCollisionEdgeEvaluator<FloatType>>(
+            *prob.env, prob.manip, edge_collision_check_config, allow_collision, debug));
+        prob.edge_evaluators.push_back(compound_evaluator);
+      }
+      else
+      {
+        prob.edge_evaluators.push_back(edge_evaluator(prob));
+      }
     }
   }
 

--- a/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
@@ -297,34 +297,6 @@ PlannerResponse OMPLMotionPlanner::solve(const PlannerRequest& request) const
 
       ++start_index;
     }
-
-    //    bool found {false};
-    //    Eigen::Index row{0};
-    //    for (std::size_t i = start_index; i < results_flattened.size(); ++i)
-    //    {
-    //      auto& mi = results_flattened[i].get().as<MoveInstructionPoly>();
-    //      if (mi.getUUID() == pc.start_uuid)
-    //        found = true;
-
-    //      if (found)
-    //      {
-    //        if (mi.getWaypoint().isCartesianWaypoint())
-    //          mi.getWaypoint().as<CartesianWaypointPoly>().setSeed(tesseract_common::JointState(joint_names,
-    //          traj.row(row++)));
-    //        else if (mi.getWaypoint().isJointWaypoint())
-    //          mi.getWaypoint().as<JointWaypointPoly>().setPosition(traj.row(row++));
-    //        else if (mi.getWaypoint().isStateWaypoint())
-    //          mi.getWaypoint().as<StateWaypointPoly>().setPosition(traj.row(row++));
-    //        else
-    //          throw std::runtime_error("OMPLMotionPlannerDefaultConfig: unknown waypoint type");
-    //      }
-
-    //      if (mi.getUUID() == pc.end_uuid)
-    //      {
-    //        start_index = i;
-    //        break;
-    //      }
-    //    }
   }
 
   response.successful = true;

--- a/tesseract_task_composer/CMakeLists.txt
+++ b/tesseract_task_composer/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(
   src/nodes/continuous_contact_check_task.cpp
   src/nodes/descartes_global_motion_pipeline_task.cpp
   src/nodes/descartes_motion_pipeline_task.cpp
+  src/nodes/descartes_npc_motion_pipeline_task.cpp
   src/nodes/discrete_contact_check_task.cpp
   src/nodes/done_task.cpp
   src/nodes/error_task.cpp

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/descartes_npc_motion_pipeline_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/descartes_npc_motion_pipeline_task.h
@@ -1,0 +1,75 @@
+/**
+ * @file descartes_motion_planner_task.h
+ * @brief Descartes no post check motion planning pipeline
+ *
+ * @author Levi Armstrong
+ * @date July 29. 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2022, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_TASK_COMPOSER_DESCARTES_NPC_MOTION_PIPELINE_TASK_H
+#define TESSERACT_TASK_COMPOSER_DESCARTES_NPC_MOTION_PIPELINE_TASK_H
+
+#include <tesseract_task_composer/task_composer_graph.h>
+#include <tesseract_task_composer/task_composer_node_names.h>
+
+namespace tesseract_planning
+{
+class DescartesNPCMotionPipelineTask : public TaskComposerGraph
+{
+public:
+  using Ptr = std::shared_ptr<DescartesNPCMotionPipelineTask>;
+  using ConstPtr = std::shared_ptr<const DescartesNPCMotionPipelineTask>;
+  using UPtr = std::unique_ptr<DescartesNPCMotionPipelineTask>;
+  using ConstUPtr = std::unique_ptr<const DescartesNPCMotionPipelineTask>;
+
+  /**
+   * @brief DescartesMotionPipelineTask
+   * @details This will use the uuid as the input and output key
+   * @param name The name give to the task
+   */
+  DescartesNPCMotionPipelineTask(std::string name = node_names::DESCARTES_NPC_PIPELINE_NAME);
+  DescartesNPCMotionPipelineTask(std::string input_key,
+                                 std::string output_key,
+                                 std::string name = node_names::DESCARTES_NPC_PIPELINE_NAME);
+  ~DescartesNPCMotionPipelineTask() override = default;
+  DescartesNPCMotionPipelineTask(const DescartesNPCMotionPipelineTask&) = delete;
+  DescartesNPCMotionPipelineTask& operator=(const DescartesNPCMotionPipelineTask&) = delete;
+  DescartesNPCMotionPipelineTask(DescartesNPCMotionPipelineTask&&) = delete;
+  DescartesNPCMotionPipelineTask& operator=(DescartesNPCMotionPipelineTask&&) = delete;
+
+  bool operator==(const DescartesNPCMotionPipelineTask& rhs) const;
+  bool operator!=(const DescartesNPCMotionPipelineTask& rhs) const;
+
+protected:
+  friend class tesseract_common::Serialization;
+  friend class boost::serialization::access;
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version);  // NOLINT
+
+  void ctor(std::string input_key, std::string output_key);
+};
+}  // namespace tesseract_planning
+
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/tracking.hpp>
+BOOST_CLASS_EXPORT_KEY2(tesseract_planning::DescartesNPCMotionPipelineTask, "DescartesNPCMotionPipelineTask")
+
+#endif  // TESSERACT_TASK_COMPOSER_DESCARTES_NPC_MOTION_PIPELINE_TASK_H

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_names.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_names.h
@@ -51,6 +51,9 @@ static const std::string OMPL_PIPELINE_NAME = "OMPLPipeline";
 /** @brief Descartes pipeline */
 static const std::string DESCARTES_PIPELINE_NAME = "DescartesPipeline";
 
+/** @brief Descartes no post check pipeline */
+static const std::string DESCARTES_NPC_PIPELINE_NAME = "DescartesNPCPipeline";
+
 /** @brief Freespace pipeline */
 static const std::string FREESPACE_PIPELINE_NAME = "FreespacePipeline";
 

--- a/tesseract_task_composer/src/nodes/descartes_global_motion_pipeline_task.cpp
+++ b/tesseract_task_composer/src/nodes/descartes_global_motion_pipeline_task.cpp
@@ -67,7 +67,7 @@ void DescartesGlobalMotionPipelineTask::ctor(std::string input_key, std::string 
   // Setup TrajOpt
   auto motion_planner = std::make_shared<DescartesMotionPlannerF>();
   boost::uuids::uuid motion_planner_task =
-      addNode(std::make_unique<MotionPlannerTask>(motion_planner, input_keys_[0], output_keys_[0], false));
+      addNode(std::make_unique<MotionPlannerTask>(motion_planner, input_keys_[0], output_keys_[0], true, true));
 
   // Add edges
   addEdges(motion_planner_task, { error_task, done_task });

--- a/tesseract_task_composer/src/nodes/descartes_npc_motion_pipeline_task.cpp
+++ b/tesseract_task_composer/src/nodes/descartes_npc_motion_pipeline_task.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file descartes_npc_motion_planner_task.h
+ * @brief Descartes no post check motion planning pipeline
+ *
+ * @author Levi Armstrong
+ * @date January 17. 2022
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2023, Levi Armstrong
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <console_bridge/console.h>
+#include <boost/serialization/string.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_common/timer.h>
+
+#include <tesseract_task_composer/nodes/descartes_npc_motion_pipeline_task.h>
+
+#include <tesseract_task_composer/nodes/motion_planner_task.h>
+#include <tesseract_task_composer/nodes/min_length_task.h>
+#include <tesseract_task_composer/nodes/iterative_spline_parameterization_task.h>
+#include <tesseract_task_composer/nodes/done_task.h>
+#include <tesseract_task_composer/nodes/error_task.h>
+
+#include <tesseract_motion_planners/descartes/descartes_motion_planner.h>
+
+namespace tesseract_planning
+{
+DescartesNPCMotionPipelineTask::DescartesNPCMotionPipelineTask(std::string name) : TaskComposerGraph(std::move(name))
+{
+  ctor(uuid_str_, uuid_str_);
+}
+
+DescartesNPCMotionPipelineTask::DescartesNPCMotionPipelineTask(std::string input_key,
+                                                               std::string output_key,
+                                                               std::string name)
+  : TaskComposerGraph(std::move(name))
+{
+  ctor(std::move(input_key), std::move(output_key));
+}
+
+void DescartesNPCMotionPipelineTask::ctor(std::string input_key, std::string output_key)
+{
+  input_keys_.push_back(std::move(input_key));
+  output_keys_.push_back(std::move(output_key));
+
+  boost::uuids::uuid done_task = addNode(std::make_unique<DoneTask>());
+  boost::uuids::uuid error_task = addNode(std::make_unique<ErrorTask>());
+
+  // Setup Min Length Process Generator
+  // This is required because trajopt requires a minimum length trajectory.
+  // This is used to correct the seed if it is to short.
+  boost::uuids::uuid min_length_task = addNode(std::make_unique<MinLengthTask>(input_keys_[0], output_keys_[0]));
+
+  // Setup TrajOpt
+  auto motion_planner = std::make_shared<DescartesMotionPlannerF>();
+  boost::uuids::uuid motion_planner_task =
+      addNode(std::make_unique<MotionPlannerTask>(motion_planner, output_keys_[0], output_keys_[0], false));
+
+  // Setup time parameterization and smoothing
+  boost::uuids::uuid time_parameterization_task =
+      addNode(std::make_unique<IterativeSplineParameterizationTask>(output_keys_[0], output_keys_[0]));
+
+  // Add edges
+  addEdges(min_length_task, { motion_planner_task });
+  addEdges(motion_planner_task, { error_task, time_parameterization_task });
+  addEdges(time_parameterization_task, { error_task, done_task });
+}
+
+bool DescartesNPCMotionPipelineTask::operator==(const DescartesNPCMotionPipelineTask& rhs) const
+{
+  bool equal = true;
+  equal &= TaskComposerGraph::operator==(rhs);
+  return equal;
+}
+bool DescartesNPCMotionPipelineTask::operator!=(const DescartesNPCMotionPipelineTask& rhs) const
+{
+  return !operator==(rhs);
+}
+
+template <class Archive>
+void DescartesNPCMotionPipelineTask::serialize(Archive& ar, const unsigned int /*version*/)
+{
+  ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskComposerGraph);
+}
+
+}  // namespace tesseract_planning
+
+#include <tesseract_common/serialization.h>
+TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::DescartesNPCMotionPipelineTask)
+BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::DescartesNPCMotionPipelineTask)

--- a/tesseract_task_composer/src/nodes/update_end_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_end_state_task.cpp
@@ -98,16 +98,17 @@ TaskComposerNodeInfo::UPtr UpdateEndStateTask::runImpl(TaskComposerInput& input,
 
   // Make a non-const copy of the input instructions to update the start/end
   auto& instructions = input_data_poly.as<CompositeInstruction>();
-  const auto* next_start_move = input_next_data_poly.as<CompositeInstruction>().getFirstMoveInstruction();
+  auto* last_move_instruction = instructions.getLastMoveInstruction();
+  /** @todo Should the waypoint profile be updated to the path profile if it exists? **/
 
   // Update end instruction
+  const auto* next_start_move = input_next_data_poly.as<CompositeInstruction>().getFirstMoveInstruction();
   if (next_start_move->getWaypoint().isCartesianWaypoint())
-    instructions.getLastMoveInstruction()->assignCartesianWaypoint(
-        next_start_move->getWaypoint().as<CartesianWaypointPoly>());
+    last_move_instruction->assignCartesianWaypoint(next_start_move->getWaypoint().as<CartesianWaypointPoly>());
   else if (next_start_move->getWaypoint().isJointWaypoint())
-    instructions.getLastMoveInstruction()->assignJointWaypoint(next_start_move->getWaypoint().as<JointWaypointPoly>());
+    last_move_instruction->assignJointWaypoint(next_start_move->getWaypoint().as<JointWaypointPoly>());
   else if (next_start_move->getWaypoint().isStateWaypoint())
-    instructions.getLastMoveInstruction()->assignStateWaypoint(next_start_move->getWaypoint().as<StateWaypointPoly>());
+    last_move_instruction->assignStateWaypoint(next_start_move->getWaypoint().as<StateWaypointPoly>());
   else
     throw std::runtime_error("Invalid waypoint type");
 

--- a/tesseract_task_composer/src/task_composer_utils.cpp
+++ b/tesseract_task_composer/src/task_composer_utils.cpp
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_task_composer/nodes/trajopt_motion_pipeline_task.h>
 #include <tesseract_task_composer/nodes/ompl_motion_pipeline_task.h>
 #include <tesseract_task_composer/nodes/descartes_motion_pipeline_task.h>
+#include <tesseract_task_composer/nodes/descartes_npc_motion_pipeline_task.h>
 #include <tesseract_task_composer/nodes/cartesian_motion_pipeline_task.h>
 #include <tesseract_task_composer/nodes/freespace_motion_pipeline_task.h>
 #include <tesseract_task_composer/nodes/raster_ct_global_pipeline_task.h>
@@ -62,6 +63,7 @@ void loadDefaultTaskComposerNodes(TaskComposerServer& server,
 #endif
   server.addTask(std::make_unique<OMPLMotionPipelineTask>(input_key, output_key));
   server.addTask(std::make_unique<DescartesMotionPipelineTask>(input_key, output_key));
+  server.addTask(std::make_unique<DescartesNPCMotionPipelineTask>(input_key, output_key));
   server.addTask(std::make_unique<CartesianMotionPipelineTask>(input_key, output_key));
   server.addTask(std::make_unique<FreespaceMotionPipelineTask>(input_key, output_key));
   server.addTask(std::make_unique<RasterCtGlobalPipelineTask>(input_key, output_key));


### PR DESCRIPTION
This includes two bug fixes. 

1. Fix descartes global pipeline which was not formatting the results as input.
2. Fix descartes plan profile to add collision edge evaluator if enabled regardless of whether an evaluator was provided using a compound edge evaluator. 