### PR TITLE
Fix Default Raster Base Name

### DIFF
--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/raster_motion_task.hpp
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/raster_motion_task.hpp
@@ -69,7 +69,7 @@ public:
 
   RasterMotionTask() = default;  // Required for serialization
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
-  RasterMotionTask(std::string input_key, std::string output_key, bool is_conditional, std::string name)
+  RasterMotionTask(std::string input_key, std::string output_key, bool is_conditional, std::string name = "RasterMotionTask")
     : TaskComposerTask(is_conditional, std::move(name))
   {
     input_keys_.push_back(std::move(input_key));

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/raster_motion_task.hpp
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/raster_motion_task.hpp
@@ -69,7 +69,10 @@ public:
 
   RasterMotionTask() = default;  // Required for serialization
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
-  RasterMotionTask(std::string input_key, std::string output_key, bool is_conditional, std::string name = "RasterMotionTask")
+  RasterMotionTask(std::string input_key,
+                   std::string output_key,
+                   bool is_conditional,
+                   std::string name = "RasterMotionTask")
     : TaskComposerTask(is_conditional, std::move(name))
   {
     input_keys_.push_back(std::move(input_key));


### PR DESCRIPTION
Fixed issue relating to global planner being unusable since no raster motion task name was set