### PR TITLE
Fixed task composer yaml loading to expect a filepath

### DIFF
--- a/tesseract_task_composer/src/task_composer_plugin_factory.cpp
+++ b/tesseract_task_composer/src/task_composer_plugin_factory.cpp
@@ -86,7 +86,7 @@ void TaskComposerPluginFactory::loadConfig(const tesseract_common::fs::path& con
   loadConfig(YAML::LoadFile(config.string()));
 }
 
-void TaskComposerPluginFactory::loadConfig(const std::string& config) { loadConfig(YAML::Load(config)); }
+void TaskComposerPluginFactory::loadConfig(const std::string& config) { loadConfig(YAML::LoadFile(config)); }
 
 void TaskComposerPluginFactory::addSearchPath(const std::string& path) { plugin_loader_.search_paths.insert(path); }
 


### PR DESCRIPTION
Previously the loading of config file was expecting a string that was a YAML file. It makes more sense to me to load in a filepath.