### PR TITLE
Added ability to colorize dotgraphs with planning results

### DIFF
--- a/tesseract_task_composer/config/task_composer_plugins.yaml
+++ b/tesseract_task_composer/config/task_composer_plugins.yaml
@@ -52,7 +52,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [DescartesMotionPlannerTask]
+              destinations: [ErrorTask, DescartesMotionPlannerTask]
             - source: DescartesMotionPlannerTask
               destinations: [ErrorTask, DiscreteContactCheckTask]
             - source: DiscreteContactCheckTask
@@ -99,7 +99,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [DescartesMotionPlannerTask]
+              destinations: [ErrorTask, DescartesMotionPlannerTask]
             - source: DescartesMotionPlannerTask
               destinations: [ErrorTask, DiscreteContactCheckTask]
             - source: DiscreteContactCheckTask
@@ -141,7 +141,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [DescartesMotionPlannerTask]
+              destinations: [ErrorTask, DescartesMotionPlannerTask]
             - source: DescartesMotionPlannerTask
               destinations: [ErrorTask, IterativeSplineParameterizationTask]
             - source: IterativeSplineParameterizationTask
@@ -181,7 +181,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [DescartesMotionPlannerTask]
+              destinations: [ErrorTask, DescartesMotionPlannerTask]
             - source: DescartesMotionPlannerTask
               destinations: [ErrorTask, IterativeSplineParameterizationTask]
             - source: IterativeSplineParameterizationTask
@@ -226,7 +226,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [OMPLMotionPlannerTask]
+              destinations: [ErrorTask, OMPLMotionPlannerTask]
             - source: OMPLMotionPlannerTask
               destinations: [ErrorTask, DiscreteContactCheckTask]
             - source: DiscreteContactCheckTask
@@ -273,7 +273,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [TrajOptMotionPlannerTask]
+              destinations: [ErrorTask, TrajOptMotionPlannerTask]
             - source: TrajOptMotionPlannerTask
               destinations: [ErrorTask, DiscreteContactCheckTask]
             - source: DiscreteContactCheckTask
@@ -320,7 +320,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [TrajOptIfoptMotionPlannerTask]
+              destinations: [ErrorTask, TrajOptIfoptMotionPlannerTask]
             - source: TrajOptIfoptMotionPlannerTask
               destinations: [ErrorTask, DiscreteContactCheckTask]
             - source: DiscreteContactCheckTask
@@ -374,7 +374,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [DescartesMotionPlannerTask]
+              destinations: [ErrorTask, DescartesMotionPlannerTask]
             - source: DescartesMotionPlannerTask
               destinations: [ErrorTask, TrajOptMotionPlannerTask]
             - source: TrajOptMotionPlannerTask
@@ -430,7 +430,7 @@ task_composer_plugins:
                 outputs: [output_data]
           edges:
             - source: MinLengthTask
-              destinations: [OMPLMotionPlannerTask]
+              destinations: [ErrorTask, OMPLMotionPlannerTask]
             - source: OMPLMotionPlannerTask
               destinations: [ErrorTask, TrajOptMotionPlannerTask]
             - source: TrajOptMotionPlannerTask

--- a/tesseract_task_composer/examples/task_composer_example.cpp
+++ b/tesseract_task_composer/examples/task_composer_example.cpp
@@ -23,7 +23,10 @@ public:
   TaskComposerNodeInfo::UPtr runImpl(TaskComposerInput& input,
                                      OptionalTaskComposerExecutor /*executor*/) const override final
   {
-    auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+    auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+    if (info->isAborted())
+      return info;
+
     info->return_value = 0;
     std::cout << name_ << std::endl;
     double result =
@@ -52,7 +55,10 @@ public:
   TaskComposerNodeInfo::UPtr runImpl(TaskComposerInput& input,
                                      OptionalTaskComposerExecutor /*executor*/) const override final
   {
-    auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+    auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+    if (info->isAborted())
+      return info;
+
     info->return_value = 0;
     std::cout << name_ << std::endl;
     double result =

--- a/tesseract_task_composer/examples/task_composer_raster_example.cpp
+++ b/tesseract_task_composer/examples/task_composer_raster_example.cpp
@@ -66,17 +66,18 @@ int main()
 
   // Create task input
   auto task_input = std::make_shared<TaskComposerInput>(task_problem, profiles);
-
-  // Save dot graph
-  std::ofstream tc_out_data;
-  tc_out_data.open(tesseract_common::getTempPath() + "task_composer_raster_example.dot");
-  task->dump(tc_out_data);  // dump the graph including dynamic tasks
-  tc_out_data.close();
+  task_input->dotgraph = true;
 
   // Solve raster plan
   auto task_executor = factory.createTaskComposerExecutor("TaskflowExecutor");
   TaskComposerFuture::UPtr future = task_executor->run(*task, *task_input);
   future->wait();
+
+  // Save dot graph
+  std::ofstream tc_out_data;
+  tc_out_data.open(tesseract_common::getTempPath() + "task_composer_raster_example.dot");
+  task->dump(tc_out_data, nullptr, task_input->task_infos.getInfoMap());
+  tc_out_data.close();
 
   // Plot Process Trajectory
   auto output_program = task_input->data_storage.getData(output_key).as<CompositeInstruction>();

--- a/tesseract_task_composer/examples/task_composer_trajopt_example.cpp
+++ b/tesseract_task_composer/examples/task_composer_trajopt_example.cpp
@@ -66,14 +66,15 @@ int main()
   // Create task input
   auto task_input = std::make_shared<TaskComposerInput>(task_problem, profiles);
 
-  std::ofstream tc_out_data;
-  tc_out_data.open(tesseract_common::getTempPath() + "task_composer_trajopt_graph_example.dot");
-  task->dump(tc_out_data);  // dump the graph including dynamic tasks
-  tc_out_data.close();
-
   auto task_executor = factory.createTaskComposerExecutor("TaskflowExecutor");
   TaskComposerFuture::UPtr future = task_executor->run(*task, *task_input);
   future->wait();
+
+  // Save dot graph
+  std::ofstream tc_out_data;
+  tc_out_data.open(tesseract_common::getTempPath() + "task_composer_trajopt_graph_example.dot");
+  task->dump(tc_out_data, nullptr, task_input->task_infos.getInfoMap());
+  tc_out_data.close();
 
   // Plot Process Trajectory
   auto output_program = task_input->data_storage.getData(output_key).as<CompositeInstruction>();

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/continuous_contact_check_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/continuous_contact_check_task.h
@@ -79,7 +79,7 @@ public:
   using ConstUPtr = std::unique_ptr<const ContinuousContactCheckTaskInfo>;
 
   ContinuousContactCheckTaskInfo() = default;
-  ContinuousContactCheckTaskInfo(const ContinuousContactCheckTask& task);
+  ContinuousContactCheckTaskInfo(const ContinuousContactCheckTask& task, const TaskComposerInput& input);
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;
 

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/discrete_contact_check_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/discrete_contact_check_task.h
@@ -79,7 +79,7 @@ public:
   using ConstUPtr = std::unique_ptr<const DiscreteContactCheckTaskInfo>;
 
   DiscreteContactCheckTaskInfo() = default;
-  DiscreteContactCheckTaskInfo(const DiscreteContactCheckTask& task);
+  DiscreteContactCheckTaskInfo(const DiscreteContactCheckTask& task, const TaskComposerInput& input);
 
   std::vector<tesseract_collision::ContactResultMap> contact_results;
 

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/fix_state_collision_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/fix_state_collision_task.h
@@ -89,7 +89,7 @@ public:
   using ConstUPtr = std::unique_ptr<const FixStateCollisionTaskInfo>;
 
   FixStateCollisionTaskInfo() = default;
-  FixStateCollisionTaskInfo(const FixStateCollisionTask& task);
+  FixStateCollisionTaskInfo(const FixStateCollisionTask& task, const TaskComposerInput& input);
 
   TaskComposerNodeInfo::UPtr clone() const override;
 

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/motion_planner_task.hpp
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/motion_planner_task.hpp
@@ -168,7 +168,7 @@ protected:
       input.data_storage.setData(output_keys_[0], response.results);
 
       info->return_value = 1;
-      info->successful = true;
+      info->color = "green";
       info->message = response.message;
       info->elapsed_time = timer.elapsedSeconds();
       CONSOLE_BRIDGE_logDebug("Motion Planner process succeeded");

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/motion_planner_task.hpp
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/motion_planner_task.hpp
@@ -114,16 +114,12 @@ protected:
   TaskComposerNodeInfo::UPtr runImpl(TaskComposerInput& input,
                                      OptionalTaskComposerExecutor /*executor*/ = std::nullopt) const override
   {
-    auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+    auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+    if (info->isAborted())
+      return info;
+
     info->return_value = 0;
     info->env = input.problem.env;
-
-    if (input.isAborted())
-    {
-      info->message = "Aborted";
-      return info;
-    }
-
     tesseract_common::Timer timer;
     timer.start();
 
@@ -172,6 +168,7 @@ protected:
       input.data_storage.setData(output_keys_[0], response.results);
 
       info->return_value = 1;
+      info->successful = true;
       info->message = response.message;
       info->elapsed_time = timer.elapsedSeconds();
       CONSOLE_BRIDGE_logDebug("Motion Planner process succeeded");

--- a/tesseract_task_composer/include/tesseract_task_composer/nodes/time_optimal_parameterization_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/nodes/time_optimal_parameterization_task.h
@@ -82,7 +82,7 @@ public:
   using ConstUPtr = std::unique_ptr<const TimeOptimalParameterizationTaskInfo>;
 
   TimeOptimalParameterizationTaskInfo() = default;
-  TimeOptimalParameterizationTaskInfo(const TimeOptimalParameterizationTask& task);
+  TimeOptimalParameterizationTaskInfo(const TimeOptimalParameterizationTask& task, const TaskComposerInput& input);
 
   TaskComposerNodeInfo::UPtr clone() const override;
 

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/task_composer_node.h>
+#include <tesseract_task_composer/task_composer_node_info.h>
 
 namespace tesseract_planning
 {
@@ -84,7 +85,9 @@ public:
 
   void renameOutputKeys(const std::map<std::string, std::string>& output_keys) override;
 
-  void dump(std::ostream& os) const override;
+  void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const override;
+
+  void dump(std::ostream& os, std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
 
   bool operator==(const TaskComposerGraph& rhs) const;
   bool operator!=(const TaskComposerGraph& rhs) const;
@@ -96,7 +99,7 @@ protected:
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 
-  void dumpHelper(std::ostream& os, const TaskComposerGraph& parent) const;
+  void dumpHelper(std::ostream& os, const TaskComposerGraph& parent, std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
 
   std::map<boost::uuids::uuid, TaskComposerNode::Ptr> nodes_;
 };

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
@@ -87,7 +87,7 @@ public:
 
   void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const override;
 
-  void dump(std::ostream& os, std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
+  void dump(std::ostream& os, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
 
   bool operator==(const TaskComposerGraph& rhs) const;
   bool operator!=(const TaskComposerGraph& rhs) const;
@@ -99,7 +99,7 @@ protected:
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 
-  void dumpHelper(std::ostream& os, const TaskComposerGraph& parent, std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
+  void dumpHelper(std::ostream& os, const TaskComposerGraph& parent, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
 
   std::map<boost::uuids::uuid, TaskComposerNode::Ptr> nodes_;
 };

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
@@ -99,7 +99,9 @@ protected:
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 
-  void dumpHelper(std::ostream& os, const TaskComposerGraph& parent, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
+  void dumpHelper(std::ostream& os,
+                  const TaskComposerGraph& parent,
+                  const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
 
   std::map<boost::uuids::uuid, TaskComposerNode::Ptr> nodes_;
 };

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_graph.h
@@ -85,9 +85,9 @@ public:
 
   void renameOutputKeys(const std::map<std::string, std::string>& output_keys) override;
 
-  void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const override;
-
-  void dump(std::ostream& os, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
+  std::string dump(std::ostream& os,
+                   const TaskComposerNode* parent = nullptr,
+                   const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map = {}) const override;
 
   bool operator==(const TaskComposerGraph& rhs) const;
   bool operator!=(const TaskComposerGraph& rhs) const;
@@ -98,10 +98,6 @@ protected:
 
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
-
-  void dumpHelper(std::ostream& os,
-                  const TaskComposerGraph& parent,
-                  const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const;
 
   std::map<boost::uuids::uuid, TaskComposerNode::Ptr> nodes_;
 };

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_input.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_input.h
@@ -33,6 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/profile_dictionary.h>
 #include <tesseract_task_composer/task_composer_data_storage.h>
+#include <tesseract_task_composer/task_composer_dotgraph_logger.h>
 #include <tesseract_task_composer/task_composer_node_info.h>
 #include <tesseract_task_composer/task_composer_problem.h>
 
@@ -70,6 +71,9 @@ struct TaskComposerInput
 
   /** @brief The location where task info is stored during execution */
   TaskComposerNodeInfoContainer task_infos;
+
+  /** @brief Indicate if dotgraph should be provided */
+  bool dotgraph{ false };
 
   /**
    * @brief Check if process has been aborted

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_input.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_input.h
@@ -33,7 +33,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/profile_dictionary.h>
 #include <tesseract_task_composer/task_composer_data_storage.h>
-#include <tesseract_task_composer/task_composer_dotgraph_logger.h>
 #include <tesseract_task_composer/task_composer_node_info.h>
 #include <tesseract_task_composer/task_composer_problem.h>
 

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_input.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_input.h
@@ -89,9 +89,17 @@ struct TaskComposerInput
 
   /**
    * @brief Abort the process input
+   * @note If calling within a node you must provide the uuid
    * @details This accesses the internal process interface class to abort the process
    */
-  void abort();
+  void abort(const boost::uuids::uuid& calling_node = boost::uuids::uuid{});
+
+  /**
+   * @brief Abort the process input
+   * @note This method should be used if calling abort from within an node
+   * @param caller The node calling abort
+   */
+  void abort(const TaskComposerNode& caller);
 
   /** @brief Reset abort and data storage to constructed state */
   void reset();

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_node.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_node.h
@@ -106,8 +106,13 @@ public:
   /** @brief Rename output keys */
   virtual void renameOutputKeys(const std::map<std::string, std::string>& output_keys);
 
-  /** @brief dump the task to dot */
-  virtual void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const;
+  /**
+   * @brief dump the task to dot
+   * @brief Return additional subgraphs which should get appended if needed
+   */
+  virtual std::string dump(std::ostream& os,
+                           const TaskComposerNode* parent = nullptr,
+                           const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map = {}) const;
 
   bool operator==(const TaskComposerNode& rhs) const;
   bool operator!=(const TaskComposerNode& rhs) const;

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_node.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_node.h
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/task_composer_input.h>
 #include <tesseract_task_composer/task_composer_data_storage.h>
+#include <tesseract_task_composer/task_composer_node_info.h>
 
 namespace tesseract_planning
 {
@@ -106,7 +107,7 @@ public:
   virtual void renameOutputKeys(const std::map<std::string, std::string>& output_keys);
 
   /** @brief dump the task to dot */
-  virtual void dump(std::ostream& os) const;
+  virtual void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const;
 
   bool operator==(const TaskComposerNode& rhs) const;
   bool operator!=(const TaskComposerNode& rhs) const;

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_info.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_info.h
@@ -92,6 +92,9 @@ public:
   /** @brief Time spent in this task in seconds*/
   double elapsed_time{ 0 };
 
+  /** @brief dot graph string for visualization*/
+  std::string dot_graph;
+
   bool operator==(const TaskComposerNodeInfo& rhs) const;
   bool operator!=(const TaskComposerNodeInfo& rhs) const;
 

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_info.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_info.h
@@ -41,7 +41,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 class TaskComposerNode;
-class TaskComposerInput;
+struct TaskComposerInput;
 
 /** Stores information about a node */
 class TaskComposerNodeInfo

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_info.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_node_info.h
@@ -66,6 +66,12 @@ public:
   /** @brief The task uuid */
   boost::uuids::uuid uuid{};
 
+  /**
+   * @brief The parent uuid
+   * @details This is set when the node is added to a graph
+   */
+  boost::uuids::uuid parent_uuid{};
+
   /** @brief The nodes inbound edges */
   std::vector<boost::uuids::uuid> inbound_edges;
 
@@ -87,18 +93,14 @@ public:
   /** @brief Value returned from the Task on completion */
   int return_value{ -1 };
 
-  /**
-   * @brief Indicate if successful
-   * @details The return value is user defined so cannot be used to know if successful or not so this is used to know if
-   * the node was successful
-   */
-  bool successful{ false };
-
   /** @brief Status message */
   std::string message;
 
   /** @brief Time spent in this task in seconds*/
   double elapsed_time{ 0 };
+
+  /** @brief The DOT Graph color to fill with */
+  std::string color{ "red" };
 
   /**
    *  @brief dot graph string for visualization
@@ -153,20 +155,17 @@ struct TaskComposerNodeInfoContainer
    */
   void addInfo(TaskComposerNodeInfo::UPtr info);
 
-  /**
-   * @brief Get node info provided the uuid
-   * @param key The uuid to retrieve the node info for
-   * @return The node info if the
-   */
-  const TaskComposerNodeInfo& getInfo(boost::uuids::uuid key) const;
-
   /** @brief Get a copy of the task_info_map_ in case it gets resized*/
   std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr> getInfoMap() const;
 
+  /**
+   * @brief Called if aborted
+   * @details This is set if abort is called in input
+   */
+  void setAborted(const boost::uuids::uuid& node_uuid);
+
   /** @brief Clear the contents */
   void clear();
-
-  const TaskComposerNodeInfo& operator[](boost::uuids::uuid key) const;
 
   bool operator==(const TaskComposerNodeInfoContainer& rhs) const;
   bool operator!=(const TaskComposerNodeInfoContainer& rhs) const;
@@ -178,7 +177,11 @@ private:
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 
   mutable std::shared_mutex mutex_;
+  boost::uuids::uuid aborting_node_{};
   std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr> info_map_;
+
+  void updateParents(std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& info_map,
+                     const boost::uuids::uuid& uuid) const;
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_task.h
@@ -65,7 +65,9 @@ public:
 
   bool isConditional() const;
 
-  void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const override;
+  std::string dump(std::ostream& os,
+                   const TaskComposerNode* parent = nullptr,
+                   const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map = {}) const override;
 
 protected:
   friend struct tesseract_common::Serialization;

--- a/tesseract_task_composer/include/tesseract_task_composer/task_composer_task.h
+++ b/tesseract_task_composer/include/tesseract_task_composer/task_composer_task.h
@@ -65,7 +65,7 @@ public:
 
   bool isConditional() const;
 
-  void dump(std::ostream& os) const override;
+  void dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info = nullptr) const override;
 
 protected:
   friend struct tesseract_common::Serialization;

--- a/tesseract_task_composer/src/nodes/check_input_task.cpp
+++ b/tesseract_task_composer/src/nodes/check_input_task.cpp
@@ -94,7 +94,7 @@ TaskComposerNodeInfo::UPtr CheckInputTask::runImpl(TaskComposerInput& input,
   }
 
   info->env = input.problem.env;
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   return info;

--- a/tesseract_task_composer/src/nodes/check_input_task.cpp
+++ b/tesseract_task_composer/src/nodes/check_input_task.cpp
@@ -63,16 +63,12 @@ CheckInputTask::CheckInputTask(std::string name,
 TaskComposerNodeInfo::UPtr CheckInputTask::runImpl(TaskComposerInput& input,
                                                    OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
-  info->return_value = 0;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
     return info;
-  }
 
   // Get Composite Profile
+  info->return_value = 0;
   for (const auto& key : input_keys_)
   {
     auto input_data_poly = input.data_storage.getData(key);
@@ -98,6 +94,7 @@ TaskComposerNodeInfo::UPtr CheckInputTask::runImpl(TaskComposerInput& input,
   }
 
   info->env = input.problem.env;
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   return info;

--- a/tesseract_task_composer/src/nodes/continuous_contact_check_task.cpp
+++ b/tesseract_task_composer/src/nodes/continuous_contact_check_task.cpp
@@ -67,16 +67,12 @@ ContinuousContactCheckTask::ContinuousContactCheckTask(std::string name,
 TaskComposerNodeInfo::UPtr ContinuousContactCheckTask::runImpl(TaskComposerInput& input,
                                                                OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<ContinuousContactCheckTaskInfo>(*this);
+  auto info = std::make_unique<ContinuousContactCheckTaskInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -132,6 +128,7 @@ TaskComposerNodeInfo::UPtr ContinuousContactCheckTask::runImpl(TaskComposerInput
     return info;
   }
 
+  info->successful = true;
   info->message = "Continuous contact check succeeded";
   CONSOLE_BRIDGE_logDebug("%s", info->message.c_str());
   info->return_value = 1;
@@ -153,8 +150,9 @@ void ContinuousContactCheckTask::serialize(Archive& ar, const unsigned int /*ver
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskComposerTask);
 }
 
-ContinuousContactCheckTaskInfo::ContinuousContactCheckTaskInfo(const ContinuousContactCheckTask& task)
-  : TaskComposerNodeInfo(task)
+ContinuousContactCheckTaskInfo::ContinuousContactCheckTaskInfo(const ContinuousContactCheckTask& task,
+                                                               const TaskComposerInput& input)
+  : TaskComposerNodeInfo(task, input)
 {
 }
 

--- a/tesseract_task_composer/src/nodes/continuous_contact_check_task.cpp
+++ b/tesseract_task_composer/src/nodes/continuous_contact_check_task.cpp
@@ -128,7 +128,7 @@ TaskComposerNodeInfo::UPtr ContinuousContactCheckTask::runImpl(TaskComposerInput
     return info;
   }
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Continuous contact check succeeded";
   CONSOLE_BRIDGE_logDebug("%s", info->message.c_str());
   info->return_value = 1;

--- a/tesseract_task_composer/src/nodes/discrete_contact_check_task.cpp
+++ b/tesseract_task_composer/src/nodes/discrete_contact_check_task.cpp
@@ -126,7 +126,7 @@ TaskComposerNodeInfo::UPtr DiscreteContactCheckTask::runImpl(TaskComposerInput& 
     return info;
   }
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Discrete contact check succeeded";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/discrete_contact_check_task.cpp
+++ b/tesseract_task_composer/src/nodes/discrete_contact_check_task.cpp
@@ -67,16 +67,12 @@ DiscreteContactCheckTask::DiscreteContactCheckTask(std::string name,
 TaskComposerNodeInfo::UPtr DiscreteContactCheckTask::runImpl(TaskComposerInput& input,
                                                              OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<DiscreteContactCheckTaskInfo>(*this);
+  auto info = std::make_unique<DiscreteContactCheckTaskInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -130,6 +126,7 @@ TaskComposerNodeInfo::UPtr DiscreteContactCheckTask::runImpl(TaskComposerInput& 
     return info;
   }
 
+  info->successful = true;
   info->message = "Discrete contact check succeeded";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();
@@ -151,8 +148,9 @@ void DiscreteContactCheckTask::serialize(Archive& ar, const unsigned int /*versi
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskComposerTask);
 }
 
-DiscreteContactCheckTaskInfo::DiscreteContactCheckTaskInfo(const DiscreteContactCheckTask& task)
-  : TaskComposerNodeInfo(task)
+DiscreteContactCheckTaskInfo::DiscreteContactCheckTaskInfo(const DiscreteContactCheckTask& task,
+                                                           const TaskComposerInput& input)
+  : TaskComposerNodeInfo(task, input)
 {
 }
 

--- a/tesseract_task_composer/src/nodes/done_task.cpp
+++ b/tesseract_task_composer/src/nodes/done_task.cpp
@@ -47,7 +47,7 @@ TaskComposerNodeInfo::UPtr DoneTask::runImpl(TaskComposerInput& input, OptionalT
   if (info->isAborted())
     return info;
 
-  info->successful = true;
+  info->color = "green";
   info->env = input.problem.env;
   info->return_value = 1;
   info->message = "Successful";

--- a/tesseract_task_composer/src/nodes/done_task.cpp
+++ b/tesseract_task_composer/src/nodes/done_task.cpp
@@ -43,16 +43,12 @@ DoneTask::DoneTask(std::string name, const YAML::Node& config, const TaskCompose
 
 TaskComposerNodeInfo::UPtr DoneTask::runImpl(TaskComposerInput& input, OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
-  info->return_value = 0;
-  info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
     return info;
-  }
 
+  info->successful = true;
+  info->env = input.problem.env;
   info->return_value = 1;
   info->message = "Successful";
   CONSOLE_BRIDGE_logDebug("%s", info->message.c_str());

--- a/tesseract_task_composer/src/nodes/error_task.cpp
+++ b/tesseract_task_composer/src/nodes/error_task.cpp
@@ -43,16 +43,13 @@ ErrorTask::ErrorTask(std::string name, const YAML::Node& config, const TaskCompo
 
 TaskComposerNodeInfo::UPtr ErrorTask::runImpl(TaskComposerInput& input, OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
+  info->successful = false;
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   input.abort();
   info->message = "Error";
   CONSOLE_BRIDGE_logDebug("%s", info->message.c_str());

--- a/tesseract_task_composer/src/nodes/error_task.cpp
+++ b/tesseract_task_composer/src/nodes/error_task.cpp
@@ -47,10 +47,10 @@ TaskComposerNodeInfo::UPtr ErrorTask::runImpl(TaskComposerInput& input, Optional
   if (info->isAborted())
     return info;
 
-  info->successful = false;
+  info->color = "red";
   info->return_value = 0;
   info->env = input.problem.env;
-  input.abort();
+  input.abort(uuid_);
   info->message = "Error";
   CONSOLE_BRIDGE_logDebug("%s", info->message.c_str());
   return info;

--- a/tesseract_task_composer/src/nodes/fix_state_bounds_task.cpp
+++ b/tesseract_task_composer/src/nodes/fix_state_bounds_task.cpp
@@ -233,7 +233,7 @@ TaskComposerNodeInfo::UPtr FixStateBoundsTask::runImpl(TaskComposerInput& input,
 
   input.data_storage.setData(output_keys_[0], input_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/fix_state_bounds_task.cpp
+++ b/tesseract_task_composer/src/nodes/fix_state_bounds_task.cpp
@@ -71,16 +71,12 @@ FixStateBoundsTask::FixStateBoundsTask(std::string name,
 TaskComposerNodeInfo::UPtr FixStateBoundsTask::runImpl(TaskComposerInput& input,
                                                        OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -236,6 +232,8 @@ TaskComposerNodeInfo::UPtr FixStateBoundsTask::runImpl(TaskComposerInput& input,
   }
 
   input.data_storage.setData(output_keys_[0], input_data_poly);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/fix_state_collision_task.cpp
+++ b/tesseract_task_composer/src/nodes/fix_state_collision_task.cpp
@@ -676,7 +676,7 @@ TaskComposerNodeInfo::UPtr FixStateCollisionTask::runImpl(TaskComposerInput& inp
 
   input.data_storage.setData(output_keys_[0], input_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/fix_state_collision_task.cpp
+++ b/tesseract_task_composer/src/nodes/fix_state_collision_task.cpp
@@ -343,16 +343,12 @@ FixStateCollisionTask::FixStateCollisionTask(std::string name,
 TaskComposerNodeInfo::UPtr FixStateCollisionTask::runImpl(TaskComposerInput& input,
                                                           OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<FixStateCollisionTaskInfo>(*this);
+  auto info = std::make_unique<FixStateCollisionTaskInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -679,6 +675,8 @@ TaskComposerNodeInfo::UPtr FixStateCollisionTask::runImpl(TaskComposerInput& inp
   }
 
   input.data_storage.setData(output_keys_[0], input_data_poly);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();
@@ -700,7 +698,10 @@ void FixStateCollisionTask::serialize(Archive& ar, const unsigned int /*version*
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskComposerTask);
 }
 
-FixStateCollisionTaskInfo::FixStateCollisionTaskInfo(const FixStateCollisionTask& task) : TaskComposerNodeInfo(task) {}
+FixStateCollisionTaskInfo::FixStateCollisionTaskInfo(const FixStateCollisionTask& task, const TaskComposerInput& input)
+  : TaskComposerNodeInfo(task, input)
+{
+}
 
 TaskComposerNodeInfo::UPtr FixStateCollisionTaskInfo::clone() const
 {

--- a/tesseract_task_composer/src/nodes/format_as_input_task.cpp
+++ b/tesseract_task_composer/src/nodes/format_as_input_task.cpp
@@ -151,7 +151,7 @@ TaskComposerNodeInfo::UPtr FormatAsInputTask::runImpl(TaskComposerInput& input,
 
   input.data_storage.setData(output_keys_[0], input_formatted_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/format_as_input_task.cpp
+++ b/tesseract_task_composer/src/nodes/format_as_input_task.cpp
@@ -72,16 +72,12 @@ FormatAsInputTask::FormatAsInputTask(std::string name,
 TaskComposerNodeInfo::UPtr FormatAsInputTask::runImpl(TaskComposerInput& input,
                                                       OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -155,6 +151,7 @@ TaskComposerNodeInfo::UPtr FormatAsInputTask::runImpl(TaskComposerInput& input,
 
   input.data_storage.setData(output_keys_[0], input_formatted_data_poly);
 
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/iterative_spline_parameterization_task.cpp
+++ b/tesseract_task_composer/src/nodes/iterative_spline_parameterization_task.cpp
@@ -185,7 +185,7 @@ TaskComposerNodeInfo::UPtr IterativeSplineParameterizationTask::runImpl(TaskComp
     return info;
   }
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   input.data_storage.setData(output_keys_[0], input_data_poly);
   info->return_value = 1;

--- a/tesseract_task_composer/src/nodes/iterative_spline_parameterization_task.cpp
+++ b/tesseract_task_composer/src/nodes/iterative_spline_parameterization_task.cpp
@@ -91,16 +91,12 @@ IterativeSplineParameterizationTask::IterativeSplineParameterizationTask(
 TaskComposerNodeInfo::UPtr IterativeSplineParameterizationTask::runImpl(TaskComposerInput& input,
                                                                         OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -189,6 +185,7 @@ TaskComposerNodeInfo::UPtr IterativeSplineParameterizationTask::runImpl(TaskComp
     return info;
   }
 
+  info->successful = true;
   info->message = "Successful";
   input.data_storage.setData(output_keys_[0], input_data_poly);
   info->return_value = 1;

--- a/tesseract_task_composer/src/nodes/min_length_task.cpp
+++ b/tesseract_task_composer/src/nodes/min_length_task.cpp
@@ -72,16 +72,12 @@ MinLengthTask::MinLengthTask(std::string name,
 TaskComposerNodeInfo::UPtr MinLengthTask::runImpl(TaskComposerInput& input,
                                                   OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
   //  saveInputs(*info, input);
@@ -151,6 +147,7 @@ TaskComposerNodeInfo::UPtr MinLengthTask::runImpl(TaskComposerInput& input,
     input.data_storage.setData(output_keys_[0], ci);
   }
 
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/min_length_task.cpp
+++ b/tesseract_task_composer/src/nodes/min_length_task.cpp
@@ -147,7 +147,7 @@ TaskComposerNodeInfo::UPtr MinLengthTask::runImpl(TaskComposerInput& input,
     input.data_storage.setData(output_keys_[0], ci);
   }
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/profile_switch_task.cpp
+++ b/tesseract_task_composer/src/nodes/profile_switch_task.cpp
@@ -94,7 +94,7 @@ TaskComposerNodeInfo::UPtr ProfileSwitchTask::runImpl(TaskComposerInput& input,
   // Return the value specified in the profile
   CONSOLE_BRIDGE_logDebug("ProfileSwitchProfile returning %d", cur_composite_profile->return_value);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = cur_composite_profile->return_value;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/profile_switch_task.cpp
+++ b/tesseract_task_composer/src/nodes/profile_switch_task.cpp
@@ -62,16 +62,12 @@ ProfileSwitchTask::ProfileSwitchTask(std::string name,
 TaskComposerNodeInfo::UPtr ProfileSwitchTask::runImpl(TaskComposerInput& input,
                                                       OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -98,6 +94,7 @@ TaskComposerNodeInfo::UPtr ProfileSwitchTask::runImpl(TaskComposerInput& input,
   // Return the value specified in the profile
   CONSOLE_BRIDGE_logDebug("ProfileSwitchProfile returning %d", cur_composite_profile->return_value);
 
+  info->successful = true;
   info->message = "Successful";
   info->return_value = cur_composite_profile->return_value;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/raster_motion_task.cpp
+++ b/tesseract_task_composer/src/nodes/raster_motion_task.cpp
@@ -446,6 +446,12 @@ TaskComposerNodeInfo::UPtr RasterMotionTask::runImpl(TaskComposerInput& input,
   TaskComposerFuture::UPtr future = executor.value().get().run(task_graph, input);
   future->wait();
 
+  auto info_map = input.task_infos.getInfoMap();
+
+  std::stringstream dot_graph;
+  task_graph.dump(dot_graph, info_map);  // dump the graph including dynamic tasks
+  info->dot_graph = dot_graph.str();
+
   if (input.isAborted())
   {
     info->message = "Raster subgraph failed";

--- a/tesseract_task_composer/src/nodes/raster_motion_task.cpp
+++ b/tesseract_task_composer/src/nodes/raster_motion_task.cpp
@@ -284,16 +284,12 @@ void RasterMotionTask::serialize(Archive& ar, const unsigned int /*version*/)  /
 TaskComposerNodeInfo::UPtr RasterMotionTask::runImpl(TaskComposerInput& input,
                                                      OptionalTaskComposerExecutor executor) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -448,9 +444,15 @@ TaskComposerNodeInfo::UPtr RasterMotionTask::runImpl(TaskComposerInput& input,
 
   auto info_map = input.task_infos.getInfoMap();
 
-  std::stringstream dot_graph;
-  task_graph.dump(dot_graph, info_map);  // dump the graph including dynamic tasks
-  info->dot_graph = dot_graph.str();
+  if (input.dotgraph)
+  {
+    std::stringstream dot_graph;
+    dot_graph << "subgraph cluster_" << toString(uuid_) << " {\n color=black;\n label = \"" << name_ << "\\n("
+              << uuid_str_ << ")\";\n";
+    task_graph.dump(dot_graph, this, info_map);  // dump the graph including dynamic tasks
+    dot_graph << "}\n";
+    info->dotgraph = dot_graph.str();
+  }
 
   if (input.isAborted())
   {
@@ -483,6 +485,7 @@ TaskComposerNodeInfo::UPtr RasterMotionTask::runImpl(TaskComposerInput& input,
 
   input.data_storage.setData(output_keys_[0], program);
 
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/raster_motion_task.cpp
+++ b/tesseract_task_composer/src/nodes/raster_motion_task.cpp
@@ -485,7 +485,7 @@ TaskComposerNodeInfo::UPtr RasterMotionTask::runImpl(TaskComposerInput& input,
 
   input.data_storage.setData(output_keys_[0], program);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/raster_only_motion_task.cpp
+++ b/tesseract_task_composer/src/nodes/raster_only_motion_task.cpp
@@ -353,14 +353,14 @@ TaskComposerNodeInfo::UPtr RasterOnlyMotionTask::runImpl(TaskComposerInput& inpu
     transition_idx++;
   }
 
-  // Debug remove
-  std::ofstream tc_out_data;
-  tc_out_data.open(tesseract_common::getTempPath() + "task_composer_raster_subgraph_example.dot");
-  task_graph.dump(tc_out_data);  // dump the graph including dynamic tasks
-  tc_out_data.close();
-
   TaskComposerFuture::UPtr future = executor.value().get().run(task_graph, input);
   future->wait();
+
+  auto info_map = input.task_infos.getInfoMap();
+
+  std::stringstream dot_graph;
+  task_graph.dump(dot_graph, info_map);  // dump the graph including dynamic tasks
+  info->dot_graph = dot_graph.str();
 
   if (input.isAborted())
   {

--- a/tesseract_task_composer/src/nodes/raster_only_motion_task.cpp
+++ b/tesseract_task_composer/src/nodes/raster_only_motion_task.cpp
@@ -392,7 +392,7 @@ TaskComposerNodeInfo::UPtr RasterOnlyMotionTask::runImpl(TaskComposerInput& inpu
 
   input.data_storage.setData(output_keys_[0], program);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/ruckig_trajectory_smoothing_task.cpp
+++ b/tesseract_task_composer/src/nodes/ruckig_trajectory_smoothing_task.cpp
@@ -75,16 +75,12 @@ RuckigTrajectorySmoothingTask::RuckigTrajectorySmoothingTask(std::string name,
 TaskComposerNodeInfo::UPtr RuckigTrajectorySmoothingTask::runImpl(TaskComposerInput& input,
                                                                   OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -181,6 +177,8 @@ TaskComposerNodeInfo::UPtr RuckigTrajectorySmoothingTask::runImpl(TaskComposerIn
   }
 
   input.data_storage.setData(output_keys_[0], input_data_poly);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/ruckig_trajectory_smoothing_task.cpp
+++ b/tesseract_task_composer/src/nodes/ruckig_trajectory_smoothing_task.cpp
@@ -178,7 +178,7 @@ TaskComposerNodeInfo::UPtr RuckigTrajectorySmoothingTask::runImpl(TaskComposerIn
 
   input.data_storage.setData(output_keys_[0], input_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/start_task.cpp
+++ b/tesseract_task_composer/src/nodes/start_task.cpp
@@ -49,18 +49,14 @@ StartTask::StartTask(std::string name, const YAML::Node& config, const TaskCompo
 }
 TaskComposerNodeInfo::UPtr StartTask::runImpl(TaskComposerInput& input, OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
-  info->return_value = 0;
-  info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
     return info;
-  }
 
-  info->return_value = 1;
+  info->env = input.problem.env;
+  info->successful = true;
   info->message = "Successful";
+  info->return_value = 1;
   return info;
 }
 

--- a/tesseract_task_composer/src/nodes/start_task.cpp
+++ b/tesseract_task_composer/src/nodes/start_task.cpp
@@ -54,7 +54,7 @@ TaskComposerNodeInfo::UPtr StartTask::runImpl(TaskComposerInput& input, Optional
     return info;
 
   info->env = input.problem.env;
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   return info;

--- a/tesseract_task_composer/src/nodes/time_optimal_parameterization_task.cpp
+++ b/tesseract_task_composer/src/nodes/time_optimal_parameterization_task.cpp
@@ -160,7 +160,7 @@ TaskComposerNodeInfo::UPtr TimeOptimalParameterizationTask::runImpl(TaskComposer
 
   input.data_storage.setData(output_keys_[0], copy_ci);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/time_optimal_parameterization_task.cpp
+++ b/tesseract_task_composer/src/nodes/time_optimal_parameterization_task.cpp
@@ -81,16 +81,12 @@ TimeOptimalParameterizationTask::TimeOptimalParameterizationTask(std::string nam
 TaskComposerNodeInfo::UPtr TimeOptimalParameterizationTask::runImpl(TaskComposerInput& input,
                                                                     OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TimeOptimalParameterizationTaskInfo>(*this);
+  auto info = std::make_unique<TimeOptimalParameterizationTaskInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -163,6 +159,8 @@ TaskComposerNodeInfo::UPtr TimeOptimalParameterizationTask::runImpl(TaskComposer
   }
 
   input.data_storage.setData(output_keys_[0], copy_ci);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();
@@ -187,8 +185,9 @@ void TimeOptimalParameterizationTask::serialize(Archive& ar, const unsigned int 
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskComposerTask);
 }
 
-TimeOptimalParameterizationTaskInfo::TimeOptimalParameterizationTaskInfo(const TimeOptimalParameterizationTask& task)
-  : TaskComposerNodeInfo(task)
+TimeOptimalParameterizationTaskInfo::TimeOptimalParameterizationTaskInfo(const TimeOptimalParameterizationTask& task,
+                                                                         const TaskComposerInput& input)
+  : TaskComposerNodeInfo(task, input)
 {
 }
 

--- a/tesseract_task_composer/src/nodes/update_end_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_end_state_task.cpp
@@ -111,7 +111,7 @@ TaskComposerNodeInfo::UPtr UpdateEndStateTask::runImpl(TaskComposerInput& input,
   // Store results
   input.data_storage.setData(output_keys_[0], input_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/update_end_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_end_state_task.cpp
@@ -61,16 +61,12 @@ UpdateEndStateTask::UpdateEndStateTask(std::string name,
 TaskComposerNodeInfo::UPtr UpdateEndStateTask::runImpl(TaskComposerInput& input,
                                                        OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -114,6 +110,8 @@ TaskComposerNodeInfo::UPtr UpdateEndStateTask::runImpl(TaskComposerInput& input,
 
   // Store results
   input.data_storage.setData(output_keys_[0], input_data_poly);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/update_start_and_end_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_start_and_end_state_task.cpp
@@ -130,7 +130,7 @@ TaskComposerNodeInfo::UPtr UpdateStartAndEndStateTask::runImpl(TaskComposerInput
   // Store results
   input.data_storage.setData(output_keys_[0], input_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/update_start_and_end_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_start_and_end_state_task.cpp
@@ -65,16 +65,12 @@ UpdateStartAndEndStateTask::UpdateStartAndEndStateTask(std::string name,
 TaskComposerNodeInfo::UPtr UpdateStartAndEndStateTask::runImpl(TaskComposerInput& input,
                                                                OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -133,6 +129,8 @@ TaskComposerNodeInfo::UPtr UpdateStartAndEndStateTask::runImpl(TaskComposerInput
 
   // Store results
   input.data_storage.setData(output_keys_[0], input_data_poly);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/update_start_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_start_state_task.cpp
@@ -102,7 +102,7 @@ TaskComposerNodeInfo::UPtr UpdateStartStateTask::runImpl(TaskComposerInput& inpu
   // Store results
   input.data_storage.setData(output_keys_[0], input_data_poly);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/update_start_state_task.cpp
+++ b/tesseract_task_composer/src/nodes/update_start_state_task.cpp
@@ -61,16 +61,12 @@ UpdateStartStateTask::UpdateStartStateTask(std::string name,
 TaskComposerNodeInfo::UPtr UpdateStartStateTask::runImpl(TaskComposerInput& input,
                                                          OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -105,6 +101,8 @@ TaskComposerNodeInfo::UPtr UpdateStartStateTask::runImpl(TaskComposerInput& inpu
 
   // Store results
   input.data_storage.setData(output_keys_[0], input_data_poly);
+
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/src/nodes/upsample_trajectory_task.cpp
@@ -73,16 +73,12 @@ UpsampleTrajectoryTask::UpsampleTrajectoryTask(std::string name,
 TaskComposerNodeInfo::UPtr UpsampleTrajectoryTask::runImpl(TaskComposerInput& input,
                                                            OptionalTaskComposerExecutor /*executor*/) const
 {
-  auto info = std::make_unique<TaskComposerNodeInfo>(*this);
+  auto info = std::make_unique<TaskComposerNodeInfo>(*this, input);
+  if (info->isAborted())
+    return info;
+
   info->return_value = 0;
   info->env = input.problem.env;
-
-  if (input.isAborted())
-  {
-    info->message = "Aborted";
-    return info;
-  }
-
   tesseract_common::Timer timer;
   timer.start();
 
@@ -112,6 +108,7 @@ TaskComposerNodeInfo::UPtr UpsampleTrajectoryTask::runImpl(TaskComposerInput& in
   upsample(new_results, ci, start_instruction, cur_composite_profile->longest_valid_segment_length);
   input.data_storage.setData(output_keys_[0], new_results);
 
+  info->successful = true;
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/src/nodes/upsample_trajectory_task.cpp
@@ -108,7 +108,7 @@ TaskComposerNodeInfo::UPtr UpsampleTrajectoryTask::runImpl(TaskComposerInput& in
   upsample(new_results, ci, start_instruction, cur_composite_profile->longest_valid_segment_length);
   input.data_storage.setData(output_keys_[0], new_results);
 
-  info->successful = true;
+  info->color = "green";
   info->message = "Successful";
   info->return_value = 1;
   info->elapsed_time = timer.elapsedSeconds();

--- a/tesseract_task_composer/src/task_composer_graph.cpp
+++ b/tesseract_task_composer/src/task_composer_graph.cpp
@@ -195,14 +195,17 @@ void TaskComposerGraph::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr&
   os << "}\n";
 }
 
-void TaskComposerGraph::dump(std::ostream& os, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
+void TaskComposerGraph::dump(std::ostream& os,
+                             const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
 {
   os << "digraph TaskComposer {\n";
   dumpHelper(os, *this, results_map);
   os << "}\n";
 }
 
-void TaskComposerGraph::dumpHelper(std::ostream& os, const TaskComposerGraph& /*parent*/, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
+void TaskComposerGraph::dumpHelper(std::ostream& os,
+                                   const TaskComposerGraph& /*parent*/,
+                                   const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
 {
   std::ostringstream sub_graphs;
   const std::string tmp = toString(uuid_);

--- a/tesseract_task_composer/src/task_composer_graph.cpp
+++ b/tesseract_task_composer/src/task_composer_graph.cpp
@@ -195,14 +195,14 @@ void TaskComposerGraph::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr&
   os << "}\n";
 }
 
-void TaskComposerGraph::dump(std::ostream& os, std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
+void TaskComposerGraph::dump(std::ostream& os, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
 {
   os << "digraph TaskComposer {\n";
   dumpHelper(os, *this, results_map);
   os << "}\n";
 }
 
-void TaskComposerGraph::dumpHelper(std::ostream& os, const TaskComposerGraph& /*parent*/, std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
+void TaskComposerGraph::dumpHelper(std::ostream& os, const TaskComposerGraph& /*parent*/, const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
 {
   std::ostringstream sub_graphs;
   const std::string tmp = toString(uuid_);

--- a/tesseract_task_composer/src/task_composer_graph.cpp
+++ b/tesseract_task_composer/src/task_composer_graph.cpp
@@ -206,10 +206,12 @@ std::string TaskComposerGraph::dump(std::ostream& os,
     }
     else if (node->getType() == TaskComposerNodeType::GRAPH)
     {
+      auto it = results_map.find(node->getUUID());
+      std::string color = (it == results_map.end()) ? "blue" : it->second->color;
       const std::string tmp = toString(node->uuid_, "node_");
       os << std::endl
          << tmp << " [shape=box3d, label=\"Subgraph: " << node->name_ << "\\n(" << node->uuid_str_
-         << ")\", color=blue, margin=\"0.1\"];\n";
+         << ")\", margin=\"0.1\", color=" << color << "];\n";
       node->dump(sub_graphs, this, results_map);
     }
   }

--- a/tesseract_task_composer/src/task_composer_input.cpp
+++ b/tesseract_task_composer/src/task_composer_input.cpp
@@ -35,6 +35,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/task_composer_input.h>
+#include <tesseract_task_composer/task_composer_node.h>
 
 namespace tesseract_planning
 {
@@ -47,7 +48,13 @@ bool TaskComposerInput::isAborted() const { return aborted_; }
 
 bool TaskComposerInput::isSuccessful() const { return !aborted_; }
 
-void TaskComposerInput::abort() { aborted_ = true; }
+void TaskComposerInput::abort(const boost::uuids::uuid& calling_node)
+{
+  if (!calling_node.is_nil())
+    task_infos.setAborted(calling_node);
+
+  aborted_ = true;
+}
 
 void TaskComposerInput::reset()
 {

--- a/tesseract_task_composer/src/task_composer_node.cpp
+++ b/tesseract_task_composer/src/task_composer_node.cpp
@@ -91,9 +91,9 @@ void TaskComposerNode::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& 
   }
   else
   {
-    if(node_info->return_value == 0 && outbound_edges_.size() > 1)
+    if (node_info->return_value == 0 && outbound_edges_.size() > 1)
       color = "red";
-    else if(node_info->return_value == 1 || outbound_edges_.size() == 1)
+    else if (node_info->return_value == 1 || outbound_edges_.size() == 1)
       color = "green";
     else
       color = "white";

--- a/tesseract_task_composer/src/task_composer_node.cpp
+++ b/tesseract_task_composer/src/task_composer_node.cpp
@@ -88,7 +88,7 @@ std::string TaskComposerNode::dump(std::ostream& os,
   std::string color{ "white" };
   auto it = results_map.find(uuid_);
   if (it != results_map.end() && !it->second->isAborted())
-    color = (it->second->successful) ? "green" : "red";
+    color = it->second->color;
 
   os << std::endl << tmp << " [label=\"" << name_ << "\\n(" << uuid_str_ << ")";
   if (it != results_map.end())

--- a/tesseract_task_composer/src/task_composer_node.cpp
+++ b/tesseract_task_composer/src/task_composer_node.cpp
@@ -79,10 +79,34 @@ void TaskComposerNode::renameOutputKeys(const std::map<std::string, std::string>
     std::replace(output_keys_.begin(), output_keys_.end(), key.first, key.second);
 }
 
-void TaskComposerNode::dump(std::ostream& os) const
+void TaskComposerNode::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info) const
 {
   const std::string tmp = toString(uuid_, "node_");
-  os << std::endl << tmp << " [label=\"" << name_ << "\\n(" << uuid_str_ << ")\", color=black];\n";
+
+  std::string color;
+
+  if (!node_info)
+  {
+    color = "white";
+  }
+  else
+  {
+    if(node_info->return_value == 0 && outbound_edges_.size() > 1)
+      color = "red";
+    else if(node_info->return_value == 1 || outbound_edges_.size() == 1)
+      color = "green";
+    else
+      color = "white";
+  }
+
+  os << std::endl << tmp << " [label=\"" << name_ << "\\n(" << uuid_str_ << ")";
+  if (node_info)
+  {
+    os << "\\nTime: " << std::fixed << std::setprecision(3) << node_info->elapsed_time << "s"
+       << "\\n\"" << node_info->message << "\"";
+  }
+  os << "\", fillcolor=" << color << ", style=filled];\n";
+
   for (const auto& edge : outbound_edges_)
     os << tmp << " -> " << toString(edge, "node_") << ";\n";
 }

--- a/tesseract_task_composer/src/task_composer_task.cpp
+++ b/tesseract_task_composer/src/task_composer_task.cpp
@@ -84,61 +84,48 @@ int TaskComposerTask::run(TaskComposerInput& input, OptionalTaskComposerExecutor
   }
   catch (const std::exception& e)
   {
-    results = std::make_unique<TaskComposerNodeInfo>(*this);
-    results->return_value = 0;
+    results = std::make_unique<TaskComposerNodeInfo>(*this, input);
+    results->successful = false;
     results->message = "Exception thrown: " + std::string(e.what());
+    results->return_value = 0;
   }
 
   int value = results->return_value;
+  assert(value >= 0);
   input.task_infos.addInfo(std::move(results));
   return value;
 }
 
-void TaskComposerTask::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& node_info) const
+std::string TaskComposerTask::dump(std::ostream& os,
+                                   const TaskComposerNode* /*parent*/,
+                                   const std::map<boost::uuids::uuid, TaskComposerNodeInfo::UPtr>& results_map) const
 {
   const std::string tmp = toString(uuid_, "node_");
 
-  std::string color;
+  std::string color{ "white" };
   int return_value = -1;
 
-  if (!node_info || !is_conditional_)
+  auto it = results_map.find(uuid_);
+  if (it != results_map.end())
   {
-    color = "white";
-  }
-  else
-  {
-    return_value = node_info->return_value;
-    if (node_info->return_value == 0 && outbound_edges_.size() > 1)
-    {
-      color = "red";
-    }
-    else if (node_info->return_value >= 1 || outbound_edges_.size() == 1)
-    {
-      color = "green";
-    }
-    else
-    {
-      color = "white";
-    }
+    return_value = it->second->return_value;
+    if (!it->second->isAborted())
+      color = (it->second->successful) ? "green" : "red";
   }
 
   if (is_conditional_)
   {
     os << std::endl << tmp << " [shape=diamond, label=\"" << name_ << "\\n(" << uuid_str_ << ")";
-    if (node_info)
+    if (it != results_map.end())
     {
-      os << "\\nTime: " << std::fixed << std::setprecision(3) << node_info->elapsed_time << "s"
-         << "\\n`" << node_info->message << "`";
+      os << "\\nTime: " << std::fixed << std::setprecision(3) << it->second->elapsed_time << "s"
+         << "\\n`" << it->second->message << "`";
     }
     os << "\", color=black, fillcolor=" << color << ", style=filled];\n";
 
     for (std::size_t i = 0; i < outbound_edges_.size(); ++i)
     {
-      std::string line_type = "dashed";
-      if (return_value == static_cast<int>(i))
-      {
-        line_type = "bold";
-      }
+      std::string line_type = (return_value == static_cast<int>(i)) ? "bold" : "dashed";
       os << tmp << " -> " << toString(outbound_edges_[i], "node_") << " [style=" << line_type << ", label=\"["
          << std::to_string(i) << "]\""
          << "];\n";
@@ -147,16 +134,21 @@ void TaskComposerTask::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& 
   else
   {
     os << std::endl << tmp << " [label=\"" << name_ << "\\n(" << uuid_str_ << ")";
-    if (node_info)
+    if (it != results_map.end())
     {
-      os << "\\nTime: " << std::fixed << std::setprecision(3) << node_info->elapsed_time << "s"
-         << "\\n'" << node_info->message << "'";
+      os << "\\nTime: " << std::fixed << std::setprecision(3) << it->second->elapsed_time << "s"
+         << "\\n'" << it->second->message << "'";
     }
     os << "\", color=black, fillcolor=" << color << ", style=filled];\n";
 
     for (const auto& edge : outbound_edges_)
       os << tmp << " -> " << toString(edge, "node_") << ";\n";
   }
+
+  if (it == results_map.end())
+    return {};
+
+  return it->second->dotgraph;
 }
 
 bool TaskComposerTask::operator==(const TaskComposerTask& rhs) const

--- a/tesseract_task_composer/src/task_composer_task.cpp
+++ b/tesseract_task_composer/src/task_composer_task.cpp
@@ -85,7 +85,7 @@ int TaskComposerTask::run(TaskComposerInput& input, OptionalTaskComposerExecutor
   catch (const std::exception& e)
   {
     results = std::make_unique<TaskComposerNodeInfo>(*this, input);
-    results->successful = false;
+    results->color = "red";
     results->message = "Exception thrown: " + std::string(e.what());
     results->return_value = 0;
   }
@@ -110,7 +110,7 @@ std::string TaskComposerTask::dump(std::ostream& os,
   {
     return_value = it->second->return_value;
     if (!it->second->isAborted())
-      color = (it->second->successful) ? "green" : "red";
+      color = it->second->color;
   }
 
   if (is_conditional_)

--- a/tesseract_task_composer/src/task_composer_task.cpp
+++ b/tesseract_task_composer/src/task_composer_task.cpp
@@ -108,11 +108,11 @@ void TaskComposerTask::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& 
   else
   {
     return_value = node_info->return_value;
-    if(node_info->return_value == 0 && outbound_edges_.size() > 1)
+    if (node_info->return_value == 0 && outbound_edges_.size() > 1)
     {
       color = "red";
     }
-    else if(node_info->return_value >= 1 || outbound_edges_.size() == 1)
+    else if (node_info->return_value >= 1 || outbound_edges_.size() == 1)
     {
       color = "green";
     }
@@ -124,8 +124,7 @@ void TaskComposerTask::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& 
 
   if (is_conditional_)
   {
-    os << std::endl
-       << tmp << " [shape=diamond, label=\"" << name_ << "\\n(" << uuid_str_ << ")";
+    os << std::endl << tmp << " [shape=diamond, label=\"" << name_ << "\\n(" << uuid_str_ << ")";
     if (node_info)
     {
       os << "\\nTime: " << std::fixed << std::setprecision(3) << node_info->elapsed_time << "s"
@@ -140,8 +139,8 @@ void TaskComposerTask::dump(std::ostream& os, const TaskComposerNodeInfo::UPtr& 
       {
         line_type = "bold";
       }
-      os << tmp << " -> " << toString(outbound_edges_[i], "node_") << " [style=" << line_type <<", label=\"[" << std::to_string(i)
-         << "]\""
+      os << tmp << " -> " << toString(outbound_edges_[i], "node_") << " [style=" << line_type << ", label=\"["
+         << std::to_string(i) << "]\""
          << "];\n";
     }
   }

--- a/tesseract_task_composer/src/taskflow/taskflow_task_composer_executor.cpp
+++ b/tesseract_task_composer/src/taskflow/taskflow_task_composer_executor.cpp
@@ -165,6 +165,12 @@ TaskflowTaskComposerExecutor::convertToTaskflow(const TaskComposerGraph& task_gr
     else if (pair.second->getType() == TaskComposerNodeType::GRAPH)
     {
       const auto& graph = static_cast<const TaskComposerGraph&>(*pair.second);
+
+      // Must add a Node Info object for the graph
+      auto info = std::make_unique<TaskComposerNodeInfo>(graph, task_input);
+      info->color = "green";
+      task_input.task_infos.addInfo(std::move(info));
+
       auto sub_tf_container = convertToTaskflow(graph, task_input, task_executor);
       tasks[pair.first] = tf_container->front()->composed_of(*sub_tf_container->front());
       tf_container->insert(tf_container->end(),


### PR DESCRIPTION
Often it can be hard to determine the source of a planning failure, particularly when several threads are running at the same time. The NodeInfo object holds information about success or failure of tasks as well as the time spent running a given task. 
This PR:
- Extracts the NodeInfo information and populates a dotgraph with it 
- Adds a dotgraph string field to the NodeInfo so that tasks that make graphs can pass the resulting graphs back out to the highest level of the planning request. (Previously the actual dotgraph for planning rasters was inaccessible)

## A dotgraph with the top level global descartes followed by raster planning:
![image](https://github.com/tesseract-robotics/tesseract_planning/assets/41449746/d035f49f-68a1-417b-b225-53cb6c690a55)

## A dotgraph with the raster plans:
![image](https://github.com/tesseract-robotics/tesseract_planning/assets/41449746/acb7638f-a180-4d73-ae98-a2e45f1e0576)

## A failed raster dotgraph:
![image](https://github.com/tesseract-robotics/tesseract_planning/assets/41449746/2d91f32f-d77e-4379-a6b1-7ac24b0f1dec)
