### PR TITLE
Make abort configurable in ErrorTask

### DIFF
--- a/tesseract_task_composer/README.rst
+++ b/tesseract_task_composer/README.rst
@@ -454,6 +454,7 @@ The final task that is called in a task graph if error occurs
      class: ErrorTaskFactory
      config:
        conditional: false
+       trigger_abort: true
     
 Fix State Bounds Task
 ^^^^^^^^^^^^^^^^^^^^^

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/nodes/error_task.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/nodes/error_task.h
@@ -57,6 +57,8 @@ protected:
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version);  // NOLINT
 
+  bool trigger_abort_{ true };
+
   TaskComposerNodeInfo::UPtr runImpl(TaskComposerInput& input,
                                      OptionalTaskComposerExecutor executor = std::nullopt) const override final;
 };


### PR DESCRIPTION
@marip8 and @marrts  I am starting to think this should leverage a profile instead; what do you think? The use case is for when you want to spin up say a bunch of raster plans but you do not want to have a raster failure abort all of them because you will manage the failed one internal to the task, similar to the next best planner approach.