### PR TITLE
Add new task composer plugin factory constructor

### DIFF
--- a/.github/workflows/add_sources.sh
+++ b/.github/workflows/add_sources.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+apt update -qq
 apt install -y --no-install-recommends software-properties-common
 add-apt-repository -y ppa:ros-industrial/ppa
 apt update -qq

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
@@ -96,6 +96,12 @@ public:
   TaskComposerPluginFactory& operator=(TaskComposerPluginFactory&&) = default;
 
   /**
+   * @brief Load plugins from a configuration object
+   * @param config The config object
+   */
+  TaskComposerPluginFactory(const tesseract_common::TaskComposerPluginInfo& config);
+
+  /**
    * @brief Load plugins from yaml node
    * @param config The config node
    */
@@ -112,6 +118,12 @@ public:
    * @param config The config string
    */
   TaskComposerPluginFactory(const std::string& config);
+
+  /**
+   * @brief Loads plugins from a configuration object
+   * @param config the config object
+   */
+  void loadConfig(const tesseract_common::TaskComposerPluginInfo& config);
 
   /**
    * @brief Load plugins from yaml node

--- a/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
+++ b/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
@@ -49,6 +49,12 @@ TaskComposerPluginFactory::TaskComposerPluginFactory()
                  boost::token_compress_on);
 }
 
+TaskComposerPluginFactory::TaskComposerPluginFactory(const tesseract_common::TaskComposerPluginInfo& config)
+  : TaskComposerPluginFactory()
+{
+  loadConfig(config);
+}
+
 TaskComposerPluginFactory::TaskComposerPluginFactory(const YAML::Node& config) : TaskComposerPluginFactory()
 {
   loadConfig(config);
@@ -68,6 +74,19 @@ TaskComposerPluginFactory::TaskComposerPluginFactory(const std::string& config) 
 // This prevents it from being defined inline.
 // If not the forward declare of PluginLoader cause compiler error.
 TaskComposerPluginFactory::~TaskComposerPluginFactory() = default;
+
+void TaskComposerPluginFactory::loadConfig(const tesseract_common::TaskComposerPluginInfo& config)
+{
+  plugin_loader_.search_libraries.insert(config.search_libraries.begin(), config.search_libraries.end());
+  plugin_loader_.search_paths.insert(config.search_paths.begin(), config.search_paths.end());
+
+  executor_plugin_info_.plugins.insert(config.executor_plugin_infos.plugins.begin(),
+                                       config.executor_plugin_infos.plugins.end());
+  executor_plugin_info_.default_plugin = config.executor_plugin_infos.default_plugin;
+
+  task_plugin_info_.plugins.insert(config.task_plugin_infos.plugins.begin(), config.task_plugin_infos.plugins.end());
+  task_plugin_info_.default_plugin = config.task_plugin_infos.default_plugin;
+}
 
 void TaskComposerPluginFactory::loadConfig(const YAML::Node& config)
 {


### PR DESCRIPTION
This PR adds another constructor and `loadConfig` method to the task composer plugin factory to configure it with a `tesseract_common::TaskComposerPluginInfo` struct. This makes it easier to programmatically configure a plugin loader (e.g., from a GUI representation of a task composer graph/task) 