### PR TITLE
Add toleranced waypoints to TrajOpt Solver

### DIFF
--- a/tesseract_examples/src/basic_cartesian_example.cpp
+++ b/tesseract_examples/src/basic_cartesian_example.cpp
@@ -231,8 +231,12 @@ bool BasicCartesianExample::run()
     profiles->addProfile<TrajOptCompositeProfile>(TRAJOPT_DEFAULT_NAMESPACE, "cartesian_program", composite_profile);
 
     auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
-    plan_profile->cartesian_coeff = Eigen::VectorXd::Ones(6);
-    plan_profile->joint_coeff = Eigen::VectorXd::Ones(7);
+    plan_profile->cartesian_cost_config.enabled = false;
+    plan_profile->cartesian_constraint_config.enabled = true;
+    plan_profile->cartesian_constraint_config.coeff = Eigen::VectorXd::Ones(6);
+    plan_profile->joint_cost_config.enabled = false;
+    plan_profile->joint_constraint_config.enabled = true;
+    plan_profile->joint_constraint_config.coeff = Eigen::VectorXd::Ones(7);
     profiles->addProfile<TrajOptPlanProfile>(TRAJOPT_DEFAULT_NAMESPACE, "RASTER", plan_profile);
     profiles->addProfile<TrajOptPlanProfile>(TRAJOPT_DEFAULT_NAMESPACE, "freespace_profile", plan_profile);
   }

--- a/tesseract_examples/src/glass_upright_example.cpp
+++ b/tesseract_examples/src/glass_upright_example.cpp
@@ -221,10 +221,12 @@ bool GlassUprightExample::run()
     profiles->addProfile<TrajOptCompositeProfile>(TRAJOPT_DEFAULT_NAMESPACE, "UPRIGHT", composite_profile);
 
     auto plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
-    plan_profile->cartesian_coeff = Eigen::VectorXd::Constant(6, 1, 5);
-    plan_profile->cartesian_coeff(0) = 0;
-    plan_profile->cartesian_coeff(1) = 0;
-    plan_profile->cartesian_coeff(2) = 0;
+    plan_profile->cartesian_cost_config.enabled = false;
+    plan_profile->cartesian_constraint_config.enabled = true;
+    plan_profile->cartesian_constraint_config.coeff = Eigen::VectorXd::Constant(6, 1, 5);
+    plan_profile->cartesian_constraint_config.coeff(0) = 0;
+    plan_profile->cartesian_constraint_config.coeff(1) = 0;
+    plan_profile->cartesian_constraint_config.coeff(2) = 0;
 
     // Add profile to Dictionary
     profiles->addProfile<TrajOptPlanProfile>(TRAJOPT_DEFAULT_NAMESPACE, "UPRIGHT", plan_profile);

--- a/tesseract_examples/src/pick_and_place_example.cpp
+++ b/tesseract_examples/src/pick_and_place_example.cpp
@@ -193,7 +193,9 @@ bool PickAndPlaceExample::run()
 
   // Create TrajOpt Profile
   auto trajopt_plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
-  trajopt_plan_profile->cartesian_coeff = Eigen::VectorXd::Constant(6, 1, 10);
+  trajopt_plan_profile->cartesian_cost_config.enabled = false;
+  trajopt_plan_profile->cartesian_constraint_config.enabled = true;
+  trajopt_plan_profile->cartesian_constraint_config.coeff = Eigen::VectorXd::Constant(6, 1, 10);
 
   auto trajopt_composite_profile = std::make_shared<TrajOptDefaultCompositeProfile>();
   trajopt_composite_profile->longest_valid_segment_length = 0.05;

--- a/tesseract_examples/src/puzzle_piece_auxillary_axes_example.cpp
+++ b/tesseract_examples/src/puzzle_piece_auxillary_axes_example.cpp
@@ -197,10 +197,12 @@ bool PuzzlePieceAuxillaryAxesExample::run()
 
   // Create TrajOpt Profile
   auto trajopt_plan_profile = std::make_shared<tesseract_planning::TrajOptDefaultPlanProfile>();
-  trajopt_plan_profile->cartesian_coeff = Eigen::VectorXd::Constant(6, 1, 5);
-  trajopt_plan_profile->cartesian_coeff(3) = 2;
-  trajopt_plan_profile->cartesian_coeff(4) = 2;
-  trajopt_plan_profile->cartesian_coeff(5) = 0;
+  trajopt_plan_profile->cartesian_cost_config.enabled = false;
+  trajopt_plan_profile->cartesian_constraint_config.enabled = true;
+  trajopt_plan_profile->cartesian_constraint_config.coeff = Eigen::VectorXd::Constant(6, 1, 5);
+  trajopt_plan_profile->cartesian_constraint_config.coeff(3) = 2;
+  trajopt_plan_profile->cartesian_constraint_config.coeff(4) = 2;
+  trajopt_plan_profile->cartesian_constraint_config.coeff(5) = 0;
 
   auto trajopt_composite_profile = std::make_shared<TrajOptDefaultCompositeProfile>();
   trajopt_composite_profile->collision_constraint_config.enabled = false;

--- a/tesseract_examples/src/puzzle_piece_example.cpp
+++ b/tesseract_examples/src/puzzle_piece_example.cpp
@@ -193,8 +193,10 @@ bool PuzzlePieceExample::run()
 
   // Create TrajOpt Profile
   auto trajopt_plan_profile = std::make_shared<TrajOptDefaultPlanProfile>();
-  trajopt_plan_profile->cartesian_coeff = Eigen::VectorXd::Constant(6, 1, 10);
-  trajopt_plan_profile->cartesian_coeff(5) = 0;
+  trajopt_plan_profile->cartesian_cost_config.enabled = false;
+  trajopt_plan_profile->cartesian_constraint_config.enabled = true;
+  trajopt_plan_profile->cartesian_constraint_config.coeff = Eigen::VectorXd::Constant(6, 1, 10);
+  trajopt_plan_profile->cartesian_constraint_config.coeff(5) = 0;
 
   auto trajopt_composite_profile = std::make_shared<TrajOptDefaultCompositeProfile>();
   trajopt_composite_profile->collision_constraint_config.enabled = false;

--- a/tesseract_motion_planners/trajopt/CMakeLists.txt
+++ b/tesseract_motion_planners/trajopt/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(trajopt_sco REQUIRED)
 add_library(
   ${PROJECT_NAME}_trajopt
   src/trajopt_collision_config.cpp
+  src/trajopt_waypoint_config.cpp
   src/trajopt_motion_planner.cpp
   src/trajopt_utils.cpp
   src/profile/trajopt_default_plan_profile.cpp

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_default_plan_profile.h
@@ -33,6 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
+#include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
 #include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
 
 namespace tesseract_planning
@@ -51,9 +52,10 @@ public:
   TrajOptDefaultPlanProfile(TrajOptDefaultPlanProfile&&) = default;
   TrajOptDefaultPlanProfile& operator=(TrajOptDefaultPlanProfile&&) = default;
 
-  Eigen::VectorXd cartesian_coeff{ Eigen::VectorXd::Constant(1, 1, 5) };
-  Eigen::VectorXd joint_coeff{ Eigen::VectorXd::Constant(1, 1, 5) };
-  trajopt::TermType term_type{ trajopt::TermType::TT_CNT };
+  CartesianWaypointConfig cartesian_cost_config;
+  CartesianWaypointConfig cartesian_constraint_config;
+  JointWaypointConfig joint_cost_config;
+  JointWaypointConfig joint_constraint_config;
 
   /** @brief Error function that is set as a constraint for each timestep.
    *

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/trajopt_utils.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/trajopt_utils.h
@@ -42,15 +42,20 @@ trajopt::TermInfo::Ptr createCartesianWaypointTermInfo(int index,
                                                        const std::string& tcp_frame,
                                                        const Eigen::Isometry3d& tcp_offset,
                                                        const Eigen::VectorXd& coeffs,
-                                                       trajopt::TermType type);
+                                                       trajopt::TermType type,
+                                                       Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
+                                                       Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6));
 
-trajopt::TermInfo::Ptr createDynamicCartesianWaypointTermInfo(int index,
-                                                              const std::string& working_frame,
-                                                              const Eigen::Isometry3d& c_wp,
-                                                              const std::string& tcp_frame,
-                                                              const Eigen::Isometry3d& tcp_offset,
-                                                              const Eigen::VectorXd& coeffs,
-                                                              trajopt::TermType type);
+trajopt::TermInfo::Ptr
+createDynamicCartesianWaypointTermInfo(int index,
+                                       const std::string& working_frame,
+                                       const Eigen::Isometry3d& c_wp,
+                                       const std::string& tcp_frame,
+                                       const Eigen::Isometry3d& tcp_offset,
+                                       const Eigen::VectorXd& coeffs,
+                                       trajopt::TermType type,
+                                       Eigen::VectorXd lower_tolerance = Eigen::VectorXd::Zero(6),
+                                       Eigen::VectorXd upper_tolerance = Eigen::VectorXd::Zero(6));
 
 trajopt::TermInfo::Ptr createNearJointStateTermInfo(const Eigen::VectorXd& target,
                                                     const std::vector<std::string>& joint_names,

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/trajopt_waypoint_config.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/trajopt_waypoint_config.h
@@ -1,0 +1,95 @@
+/**
+ * @file trajopt_waypoint_config.h
+ * @brief TrajOpt waypoint configuration settings
+ *
+ * @author Tyler Marr
+ * @date November 2, 2023
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2023, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_WAYPOINT_CONFIG_H
+#define TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_WAYPOINT_CONFIG_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <trajopt/problem_description.hpp>
+#include <tinyxml2.h>
+#include <boost/algorithm/string.hpp>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/utils.h>
+
+namespace tesseract_planning
+{
+/**
+ * @brief Config settings for cartesian waypoints
+ */
+struct CartesianWaypointConfig
+{
+  CartesianWaypointConfig() = default;
+  CartesianWaypointConfig(const tinyxml2::XMLElement& xml_element);
+
+  /** @brief If true, a cost/constraint term will be added to the problem. Default: true*/
+  bool enabled = true;
+
+  /** @brief If true, will override existing waypoint tolerance with described tolerance here. Default: false
+   * This is useful if you want to have a smaller tolerance for the cost than the constraint.*/
+  bool use_tolerance_override = false;
+
+  /** @brief Distance below waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle()) */
+  Eigen::VectorXd lower_tolerance;
+  /** @brief Distance above waypoint that is allowed. Should be size = 6. First 3 elements are dx, dy, dz. The last 3
+   * elements are angle axis error allowed (Eigen::AngleAxisd.axis() * Eigen::AngleAxisd.angle())*/
+  Eigen::VectorXd upper_tolerance;
+
+  /** @brief coefficients corresponsing to dx, dy, dz, rx, ry, rz*/
+  Eigen::VectorXd coeff{ Eigen::VectorXd::Constant(1, 1, 5) };
+
+  tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const;
+};
+
+/**
+ * @brief Config settings for joint waypoints.
+ */
+struct JointWaypointConfig
+{
+  JointWaypointConfig() = default;
+  JointWaypointConfig(const tinyxml2::XMLElement& xml_element);
+
+  /** @brief If true, a cost/constraint term will be added to the problem. Default: true*/
+  bool enabled = true;
+
+  /** @brief If true, will override existing waypoint tolerance with described tolerance here. Default: false
+   * This is useful if you want to have a smaller tolerance for the cost than the constraint.*/
+  bool use_tolerance_override = false;
+
+  /** @brief Distance below waypoint that is allowed. Should be size of joints in a joint state*/
+  Eigen::VectorXd lower_tolerance;
+  /** @brief Distance above waypoint that is allowed. Should be size of joints in a joint state*/
+  Eigen::VectorXd upper_tolerance;
+
+  /** @brief coefficients corresponsing to joint values*/
+  Eigen::VectorXd coeff{ Eigen::VectorXd::Constant(1, 1, 5) };
+
+  tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const;
+};
+}  // namespace tesseract_planning
+
+#endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_CONFIG_TRAJOPT_WAYPOINT_CONFIG_H

--- a/tesseract_motion_planners/trajopt/src/trajopt_utils.cpp
+++ b/tesseract_motion_planners/trajopt/src/trajopt_utils.cpp
@@ -33,7 +33,9 @@ trajopt::TermInfo::Ptr createCartesianWaypointTermInfo(int index,
                                                        const std::string& tcp_frame,
                                                        const Eigen::Isometry3d& tcp_offset,
                                                        const Eigen::VectorXd& coeffs,
-                                                       trajopt::TermType type)
+                                                       trajopt::TermType type,
+                                                       Eigen::VectorXd lower_tolerance,
+                                                       Eigen::VectorXd upper_tolerance)
 {
   auto pose_info = std::make_shared<trajopt::CartPoseTermInfo>();
   pose_info->term_type = type;
@@ -57,6 +59,9 @@ trajopt::TermInfo::Ptr createCartesianWaypointTermInfo(int index,
     pose_info->rot_coeffs = coeffs.tail<3>();
   }
 
+  pose_info->lower_tolerance = lower_tolerance;
+  pose_info->upper_tolerance = upper_tolerance;
+
   return pose_info;
 }
 
@@ -66,7 +71,9 @@ trajopt::TermInfo::Ptr createDynamicCartesianWaypointTermInfo(int index,
                                                               const std::string& tcp_frame,
                                                               const Eigen::Isometry3d& tcp_offset,
                                                               const Eigen::VectorXd& coeffs,
-                                                              trajopt::TermType type)
+                                                              trajopt::TermType type,
+                                                              Eigen::VectorXd lower_tolerance,
+                                                              Eigen::VectorXd upper_tolerance)
 {
   std::shared_ptr<trajopt::DynamicCartPoseTermInfo> pose = std::make_shared<trajopt::DynamicCartPoseTermInfo>();
   pose->term_type = type;
@@ -89,6 +96,9 @@ trajopt::TermInfo::Ptr createDynamicCartesianWaypointTermInfo(int index,
     pose->pos_coeffs = coeffs.head<3>();
     pose->rot_coeffs = coeffs.tail<3>();
   }
+
+  pose->lower_tolerance = lower_tolerance;
+  pose->upper_tolerance = upper_tolerance;
 
   return pose;
 }

--- a/tesseract_motion_planners/trajopt/src/trajopt_waypoint_config.cpp
+++ b/tesseract_motion_planners/trajopt/src/trajopt_waypoint_config.cpp
@@ -1,0 +1,261 @@
+/**
+ * @file trajopt_collision_config.cpp
+ * @brief TrajOpt collision configuration settings
+ *
+ * @author Tyler Marr
+ * @date November 2, 2023
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2020, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <stdexcept>
+#include <iostream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
+#include <tesseract_common/utils.h>
+
+namespace tesseract_planning
+{
+CartesianWaypointConfig::CartesianWaypointConfig(const tinyxml2::XMLElement& xml_element)
+{
+  const tinyxml2::XMLElement* enabled_element = xml_element.FirstChildElement("Enabled");
+  const tinyxml2::XMLElement* use_tolerance_override_element = xml_element.FirstChildElement("UseToleranceOverride");
+  const tinyxml2::XMLElement* lower_tolerance_element = xml_element.FirstChildElement("LowerTolerance");
+  const tinyxml2::XMLElement* upper_tolerance_element = xml_element.FirstChildElement("UpperTolerance");
+  const tinyxml2::XMLElement* coefficients_element = xml_element.FirstChildElement("Coefficients");
+
+  if (enabled_element == nullptr)
+    throw std::runtime_error("CartesianWaypointConfig: Must have Enabled element.");
+
+  tinyxml2::XMLError status = enabled_element->QueryBoolText(&enabled);
+  if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    throw std::runtime_error("CartesianWaypointConfig: Error parsing Enabled string");
+
+  if (use_tolerance_override_element != nullptr)
+  {
+    status = use_tolerance_override_element->QueryBoolText(&use_tolerance_override);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("CartesianWaypointConfig: Error parsing UseToleranceOverride string");
+  }
+
+  if (lower_tolerance_element != nullptr)
+  {
+    std::vector<std::string> lower_tolerance_tokens;
+    std::string lower_tolerance_string;
+    status = tesseract_common::QueryStringText(lower_tolerance_element, lower_tolerance_string);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("CartesianWaypointConfig: Error parsing LowerTolerance string");
+
+    boost::split(lower_tolerance_tokens, lower_tolerance_string, boost::is_any_of(" "), boost::token_compress_on);
+
+    if (!tesseract_common::isNumeric(lower_tolerance_tokens))
+      throw std::runtime_error("CartesianWaypointConfig: LowerTolerance are not all numeric values.");
+
+    lower_tolerance.resize(static_cast<long>(lower_tolerance_tokens.size()));
+    for (std::size_t i = 0; i < lower_tolerance_tokens.size(); ++i)
+      tesseract_common::toNumeric<double>(lower_tolerance_tokens[i], lower_tolerance[static_cast<long>(i)]);
+  }
+
+  if (upper_tolerance_element != nullptr)
+  {
+    std::vector<std::string> upper_tolerance_tokens;
+    std::string upper_tolerance_string;
+    status = tesseract_common::QueryStringText(upper_tolerance_element, upper_tolerance_string);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("CartesianWaypointConfig: Error parsing UpperTolerance string");
+
+    boost::split(upper_tolerance_tokens, upper_tolerance_string, boost::is_any_of(" "), boost::token_compress_on);
+
+    if (!tesseract_common::isNumeric(upper_tolerance_tokens))
+      throw std::runtime_error("CartesianWaypointConfig: UpperTolerance are not all numeric values.");
+
+    upper_tolerance.resize(static_cast<long>(upper_tolerance_tokens.size()));
+    for (std::size_t i = 0; i < upper_tolerance_tokens.size(); ++i)
+      tesseract_common::toNumeric<double>(upper_tolerance_tokens[i], upper_tolerance[static_cast<long>(i)]);
+  }
+
+  if (coefficients_element != nullptr)
+  {
+    std::vector<std::string> coefficients_tokens;
+    std::string coefficients_string;
+    status = tesseract_common::QueryStringText(coefficients_element, coefficients_string);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("CartesianWaypointConfig: Error parsing Coefficients string");
+
+    boost::split(coefficients_tokens, coefficients_string, boost::is_any_of(" "), boost::token_compress_on);
+
+    if (!tesseract_common::isNumeric(coefficients_tokens))
+      throw std::runtime_error("CartesianWaypointConfig: Coefficients are not all numeric values.");
+
+    coeff.resize(static_cast<long>(coefficients_tokens.size()));
+    for (std::size_t i = 0; i < coefficients_tokens.size(); ++i)
+      tesseract_common::toNumeric<double>(coefficients_tokens[i], coeff[static_cast<long>(i)]);
+  }
+}
+
+tinyxml2::XMLElement* CartesianWaypointConfig::toXML(tinyxml2::XMLDocument& doc) const
+{
+  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
+
+  tinyxml2::XMLElement* xml_cartesian_waypoint_config = doc.NewElement("CartesianWaypointConfig");
+
+  tinyxml2::XMLElement* xml_enabled = doc.NewElement("Enabled");
+  xml_enabled->SetText(enabled);
+  xml_cartesian_waypoint_config->InsertEndChild(xml_enabled);
+
+  tinyxml2::XMLElement* xml_use_tolerance_override = doc.NewElement("UseToleranceOverride");
+  xml_use_tolerance_override->SetText(use_tolerance_override);
+  xml_cartesian_waypoint_config->InsertEndChild(xml_use_tolerance_override);
+
+  tinyxml2::XMLElement* xml_lower_tolerance = doc.NewElement("LowerTolerance");
+  std::stringstream lower_tolerance_ss;
+  lower_tolerance_ss << lower_tolerance.format(eigen_format);
+  xml_lower_tolerance->SetText(lower_tolerance_ss.str().c_str());
+  xml_cartesian_waypoint_config->InsertEndChild(xml_lower_tolerance);
+
+  tinyxml2::XMLElement* xml_upper_tolerance = doc.NewElement("UpperTolerance");
+  std::stringstream upper_tolerance_ss;
+  upper_tolerance_ss << upper_tolerance.format(eigen_format);
+  xml_upper_tolerance->SetText(upper_tolerance_ss.str().c_str());
+  xml_cartesian_waypoint_config->InsertEndChild(xml_upper_tolerance);
+
+  tinyxml2::XMLElement* xml_coeff = doc.NewElement("Coefficients");
+  std::stringstream coeff_ss;
+  coeff_ss << coeff.format(eigen_format);
+  xml_coeff->SetText(coeff_ss.str().c_str());
+  xml_cartesian_waypoint_config->InsertEndChild(xml_coeff);
+
+  return xml_cartesian_waypoint_config;
+}
+
+JointWaypointConfig::JointWaypointConfig(const tinyxml2::XMLElement& xml_element)
+{
+  const tinyxml2::XMLElement* enabled_element = xml_element.FirstChildElement("Enabled");
+  const tinyxml2::XMLElement* use_tolerance_override_element = xml_element.FirstChildElement("UseToleranceOverride");
+  const tinyxml2::XMLElement* lower_tolerance_element = xml_element.FirstChildElement("LowerTolerance");
+  const tinyxml2::XMLElement* upper_tolerance_element = xml_element.FirstChildElement("UpperTolerance");
+  const tinyxml2::XMLElement* coefficients_element = xml_element.FirstChildElement("Coefficients");
+
+  if (enabled_element == nullptr)
+    throw std::runtime_error("JointWaypointConfig: Must have Enabled element.");
+
+  tinyxml2::XMLError status = enabled_element->QueryBoolText(&enabled);
+  if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+    throw std::runtime_error("JointWaypointConfig: Error parsing Enabled string");
+
+  if (use_tolerance_override_element != nullptr)
+  {
+    status = use_tolerance_override_element->QueryBoolText(&use_tolerance_override);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("JointWaypointConfig: Error parsing UseToleranceOverride string");
+  }
+
+  if (lower_tolerance_element != nullptr)
+  {
+    std::vector<std::string> lower_tolerance_tokens;
+    std::string lower_tolerance_string;
+    status = tesseract_common::QueryStringText(lower_tolerance_element, lower_tolerance_string);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("JointWaypointConfig: Error parsing LowerTolerance string");
+
+    boost::split(lower_tolerance_tokens, lower_tolerance_string, boost::is_any_of(" "), boost::token_compress_on);
+
+    if (!tesseract_common::isNumeric(lower_tolerance_tokens))
+      throw std::runtime_error("JointWaypointConfig: LowerTolerance are not all numeric values.");
+
+    lower_tolerance.resize(static_cast<long>(lower_tolerance_tokens.size()));
+    for (std::size_t i = 0; i < lower_tolerance_tokens.size(); ++i)
+      tesseract_common::toNumeric<double>(lower_tolerance_tokens[i], lower_tolerance[static_cast<long>(i)]);
+  }
+
+  if (upper_tolerance_element != nullptr)
+  {
+    std::vector<std::string> upper_tolerance_tokens;
+    std::string upper_tolerance_string;
+    status = tesseract_common::QueryStringText(upper_tolerance_element, upper_tolerance_string);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("JointWaypointConfig: Error parsing UpperTolerance string");
+
+    boost::split(upper_tolerance_tokens, upper_tolerance_string, boost::is_any_of(" "), boost::token_compress_on);
+
+    if (!tesseract_common::isNumeric(upper_tolerance_tokens))
+      throw std::runtime_error("JointWaypointConfig: UpperTolerance are not all numeric values.");
+
+    upper_tolerance.resize(static_cast<long>(upper_tolerance_tokens.size()));
+    for (std::size_t i = 0; i < upper_tolerance_tokens.size(); ++i)
+      tesseract_common::toNumeric<double>(upper_tolerance_tokens[i], upper_tolerance[static_cast<long>(i)]);
+  }
+
+  if (coefficients_element != nullptr)
+  {
+    std::vector<std::string> coefficients_tokens;
+    std::string coefficients_string;
+    status = tesseract_common::QueryStringText(coefficients_element, coefficients_string);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("JointWaypointConfig: Error parsing Coefficients string");
+
+    boost::split(coefficients_tokens, coefficients_string, boost::is_any_of(" "), boost::token_compress_on);
+
+    if (!tesseract_common::isNumeric(coefficients_tokens))
+      throw std::runtime_error("JointWaypointConfig: Coefficients are not all numeric values.");
+
+    coeff.resize(static_cast<long>(coefficients_tokens.size()));
+    for (std::size_t i = 0; i < coefficients_tokens.size(); ++i)
+      tesseract_common::toNumeric<double>(coefficients_tokens[i], coeff[static_cast<long>(i)]);
+  }
+}
+
+tinyxml2::XMLElement* JointWaypointConfig::toXML(tinyxml2::XMLDocument& doc) const
+{
+  Eigen::IOFormat eigen_format(Eigen::StreamPrecision, Eigen::DontAlignCols, " ", " ");
+
+  tinyxml2::XMLElement* xml_cartesian_waypoint_config = doc.NewElement("CartesianWaypointConfig");
+
+  tinyxml2::XMLElement* xml_enabled = doc.NewElement("Enabled");
+  xml_enabled->SetText(enabled);
+  xml_cartesian_waypoint_config->InsertEndChild(xml_enabled);
+
+  tinyxml2::XMLElement* xml_use_tolerance_override = doc.NewElement("UseToleranceOverride");
+  xml_use_tolerance_override->SetText(use_tolerance_override);
+  xml_cartesian_waypoint_config->InsertEndChild(xml_use_tolerance_override);
+
+  tinyxml2::XMLElement* xml_lower_tolerance = doc.NewElement("LowerTolerance");
+  std::stringstream lower_tolerance_ss;
+  lower_tolerance_ss << lower_tolerance.format(eigen_format);
+  xml_lower_tolerance->SetText(lower_tolerance_ss.str().c_str());
+  xml_cartesian_waypoint_config->InsertEndChild(xml_lower_tolerance);
+
+  tinyxml2::XMLElement* xml_upper_tolerance = doc.NewElement("UpperTolerance");
+  std::stringstream upper_tolerance_ss;
+  upper_tolerance_ss << upper_tolerance.format(eigen_format);
+  xml_upper_tolerance->SetText(upper_tolerance_ss.str().c_str());
+  xml_cartesian_waypoint_config->InsertEndChild(xml_upper_tolerance);
+
+  tinyxml2::XMLElement* xml_coeff = doc.NewElement("Coefficients");
+  std::stringstream coeff_ss;
+  coeff_ss << coeff.format(eigen_format);
+  xml_coeff->SetText(coeff_ss.str().c_str());
+  xml_cartesian_waypoint_config->InsertEndChild(xml_coeff);
+
+  return xml_cartesian_waypoint_config;
+}
+}  // namespace tesseract_planning


### PR DESCRIPTION
In conjunction with [this PR](https://github.com/tesseract-robotics/trajopt/pull/354) in TrajOpt. This allows users to set tolerances on Cartesian and joint waypoints. Additionally you can now set both costs and constraints for waypoints so you can drive the solver to match the waypoint exactly while enforcing strict limits that are nonzero on where the waypoint can actually move.

This is a breaking change because it changes the interface for the TrajOpt default plan profile.

I think this new interface would also be useful for the TrajOpt IFOPT work that is going on.