### PR TITLE
Updated to version of ICI with VCS shallow cloning

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -76,5 +76,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build repository
-        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:  ${{ matrix.env }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ matrix.distro }}-ccache-
 
       - name: Build workspace
-        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           ADDITIONAL_DEBS: 'taskflow libompl-dev'
           ROS_DISTRO: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Build repository
-        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           ADDITIONAL_DEBS: 'taskflow libompl-dev'
           ROS_DISTRO: false

--- a/.github/workflows/unstable_build.yml
+++ b/.github/workflows/unstable_build.yml
@@ -56,7 +56,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build repository
-        uses: 'tesseract-robotics/industrial_ci@2f4c8ab919f0aafddd514e586325defabd2911ea'
+        uses: 'tesseract-robotics/industrial_ci@0109bf3523050402490b56e19c9554e7d7c5379f'
         env:
           ADDITIONAL_DEBS: 'taskflow libompl-dev'
           ROS_DISTRO: false


### PR DESCRIPTION
Updates CI to use custom version of ICI with that clones shallow with VCS in addition to supporting ROS-independent builds