### PR TITLE
Revert "Changed CI base directory to `/opt`"

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -88,17 +88,16 @@ jobs:
           ADDITIONAL_DEBS: 'taskflow libompl-dev'
           ROS_DISTRO: false
           DOCKER_IMAGE: ${{ env.REGISTRY }}/tesseract-robotics/tesseract:${{ matrix.distro }}-${{ env.TESSERACT_VERSION }}
+          UNDERLAY: /root/tesseract-robotics/tesseract_target_ws/install
           CCACHE_DIR: ${{ github.workspace }}/${{ matrix.distro }}/.ccache
-          BASEDIR: /opt
           PREFIX: ${{ github.repository }}_
-          UNDERLAY: ${BASEDIR}/tesseract-robotics/tesseract_target_ws/install
           BEFORE_INIT: './.github/workflows/add_sources.sh'
           AFTER_INIT: ''
           UPSTREAM_WORKSPACE: dependencies.repos
           UPSTREAM_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Release"
           ROSDEP_SKIP_KEYS: "fcl opw_kinematics ros_industrial_cmake_boilerplate iwyu octomap catkin ompl taskflow descartes_light trajopt trajopt_ifopt trajopt_sco trajopt_sqp ruckig"
           TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DTESSERACT_ENABLE_TESTING=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
-          AFTER_SCRIPT: 'rm -r ${BASEDIR}/${PREFIX}upstream_ws/build ${BASEDIR}/${PREFIX}target_ws/build'
+          AFTER_SCRIPT: 'rm -r $BASEDIR/${PREFIX}upstream_ws/build $BASEDIR/${PREFIX}target_ws/build'
           DOCKER_COMMIT: ${{ steps.meta.outputs.tags }}
 
       - name: Push post-build Docker


### PR DESCRIPTION
I am unable to hack ICI to build the repo outside of /root and copy the install artifacts to a persistent directory in the Docker image in a way that doesn't refer to the temporary location in which it was built. Reverts tesseract-robotics/tesseract_planning#410