### PR TITLE
Fix loss of first waypoint in upsample trajectory

### DIFF
--- a/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
@@ -130,7 +130,7 @@ void UpsampleTrajectoryTask::upsample(CompositeInstruction& composite,
       if (start_instruction.isNull())
       {
         start_instruction = i.as<MoveInstructionPoly>();
-        composite.push_back(i);
+        composite.push_back(i); // Prevents loss of very first waypoint when upsampling
         continue;
       }
 

--- a/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
@@ -130,6 +130,7 @@ void UpsampleTrajectoryTask::upsample(CompositeInstruction& composite,
       if (start_instruction.isNull())
       {
         start_instruction = i.as<MoveInstructionPoly>();
+        composite.push_back(i);
         continue;
       }
 

--- a/tesseract_task_composer/test/tesseract_task_composer_planning_unit.cpp
+++ b/tesseract_task_composer/test/tesseract_task_composer_planning_unit.cpp
@@ -1615,7 +1615,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerUpsampleTrajectoryTaskTest
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(context->isAborted(), false);
     EXPECT_EQ(context->isSuccessful(), true);
-    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(context->task_infos.getAbortingNode().is_nil());
   }
 
@@ -1736,7 +1736,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerIterativeSplineParameteriz
       UpsampleTrajectoryTask task("abc", "input_data", "output_data", true);
       EXPECT_EQ(task.run(*context), 1);
       data->setData("input_data", context->data_storage->getData("output_data"));
-      EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     }
     auto profiles = std::make_shared<ProfileDictionary>();
     auto problem = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, profiles, "abc");
@@ -1750,7 +1750,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerIterativeSplineParameteriz
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(context->isAborted(), false);
     EXPECT_EQ(context->isSuccessful(), true);
-    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(context->task_infos.getAbortingNode().is_nil());
   }
 
@@ -1874,7 +1874,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerTimeOptimalParameterizatio
       UpsampleTrajectoryTask task("abc", "input_data", "output_data", true);
       EXPECT_EQ(task.run(*context), 1);
       data->setData("input_data", context->data_storage->getData("output_data"));
-      EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     }
     auto profiles = std::make_shared<ProfileDictionary>();
     auto problem = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, profiles, "abc");
@@ -1888,7 +1888,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerTimeOptimalParameterizatio
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(context->isAborted(), false);
     EXPECT_EQ(context->isSuccessful(), true);
-    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(context->task_infos.getAbortingNode().is_nil());
 
     // Serialization
@@ -2015,7 +2015,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerRuckigTrajectorySmoothingT
       auto context = std::make_unique<TaskComposerContext>(std::move(problem), std::move(data2));
       UpsampleTrajectoryTask task("abc", "input_data", "output_data", true);
       EXPECT_EQ(task.run(*context), 1);
-      EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
 
       auto data3 = std::make_unique<TaskComposerDataStorage>();
       data3->setData("input_data", context->data_storage->getData("output_data"));
@@ -2024,7 +2024,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerRuckigTrajectorySmoothingT
       TimeOptimalParameterizationTask task2("abc", "input_data", "output_data", true);
       EXPECT_EQ(task2.run(*context2), 1);
       data->setData("input_data", context2->data_storage->getData("output_data"));
-      EXPECT_EQ(context2->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(context2->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     }
     auto profiles = std::make_shared<ProfileDictionary>();
     auto problem = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, profiles, "abc");
@@ -2038,7 +2038,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerRuckigTrajectorySmoothingT
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(context->isAborted(), false);
     EXPECT_EQ(context->isSuccessful(), true);
-    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(context->data_storage->getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(context->task_infos.getAbortingNode().is_nil());
   }
 


### PR DESCRIPTION
The current implementation of the upscale trajectory task fails to pass the first waypoint through to the output. This small patch fixes the problem. I have also adjusted the tests to account for the extra point in the outputs. I have tested this successfully with tesseract 0.20.2.

### Demonstration of bug
I ran the following dummy trajectory through the `UpsampleTrajectoryTask` with `longest_valid_segment_length=0.5`:
```
Composite Instruction, Description: Tesseract Composite Instruction
{
  Move Instruction, Move Type: 1, State WP: Pos=0 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=3 0 0 0 0 0
, Description: Tesseract Move Instruction
}
```

The current implementation returns the following. Note the loss of the 0 0 0 0 0 0 waypoint.
```
Composite Instruction, Description: Tesseract Composite Instruction
{
  Move Instruction, Move Type: 1, State WP: Pos=0.333333        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=0.666667        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=3 0 0 0 0 0
, Description: Tesseract Move Instruction
}
```

After applying my simple fix, the following is returned:
```
Composite Instruction, Description: Tesseract Composite Instruction
{
  Move Instruction, Move Type: 1, State WP: Pos=0 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=0.333333        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=0.666667        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=3 0 0 0 0 0
, Description: Tesseract Move Instruction
}
```

### Why the bug occurs
When looping through the waypoints of a composite instruction, pairs of waypoints are examined and interpolated between if necessary. To avoid duplication of the endpoints, the loop at line 162 ignores the first point (since it was already added as the last point of the previous interpolation). In doing so, the very first waypoint is lost when `continue` is called at line 140. The fix is simply to add the very first waypoint to the resulting composite instruction.