### PR TITLE
Improve dynamic tasking support

### DIFF
--- a/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
@@ -130,7 +130,7 @@ void UpsampleTrajectoryTask::upsample(CompositeInstruction& composite,
       if (start_instruction.isNull())
       {
         start_instruction = i.as<MoveInstructionPoly>();
-        composite.push_back(i); // Prevents loss of very first waypoint when upsampling
+        composite.push_back(i);  // Prevents loss of very first waypoint when upsampling
         continue;
       }
 

--- a/tesseract_task_composer/taskflow/include/tesseract_task_composer/taskflow/taskflow_task_composer_executor.h
+++ b/tesseract_task_composer/taskflow/include/tesseract_task_composer/taskflow/taskflow_task_composer_executor.h
@@ -84,6 +84,10 @@ protected:
   std::size_t num_threads_;
   std::unique_ptr<tf::Executor> executor_;
 
+  std::mutex futures_mutex_;
+  std::map<boost::uuids::uuid, TaskComposerFuture::UPtr> futures_;
+  void removeFuture(const boost::uuids::uuid& uuid);
+
   TaskComposerFuture::UPtr run(const TaskComposerNode& node, TaskComposerContext::Ptr context) override final;
 
   static tf::Task convertToTaskflow(const TaskComposerGraph& task_graph,


### PR DESCRIPTION
Currently for dynamic tasking you must wait for the dynamic task to finished because the future must remain in scope. The executor now stores every future internally and leverage taskflows callback functionality to remove the future when the dynamic task flow is finished. 