### PR TITLE
Base code quality CI on 'unstable' (master) tesseract docker container

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -82,4 +82,6 @@ CheckOptions:
     value:           '1'
   - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
     value:           '1'
+ExtraArgs:
+  - '-std=c++17'
 ...

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -29,7 +29,7 @@ jobs:
             env:
               TARGET_CMAKE_ARGS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
     container:
-      image: ghcr.io/tesseract-robotics/tesseract:focal-0.21
+      image: ghcr.io/tesseract-robotics/tesseract:${{ matrix.distro }}-master
       env:
         CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache"
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -29,7 +29,7 @@ jobs:
             env:
               TARGET_CMAKE_ARGS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
     container:
-      image: ghcr.io/tesseract-robotics/tesseract:${{ matrix.distro }}-master
+      image: ghcr.io/tesseract-robotics/tesseract:jammy-master
       env:
         CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache"
         DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -53,8 +53,8 @@ jobs:
         uses: tesseract-robotics/colcon-action@v2
         with:
           before-script: source /opt/tesseract/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
-          vcs-file: dependencies.repos
+          ccache-prefix: ${{ matrix.job_type }}
+          vcs-file: dependencies_unstable.repos
           run-tests: false
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src

--- a/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/composite_instruction.h
@@ -464,7 +464,6 @@ private:
 
 }  // namespace tesseract_planning
 
-#include <tesseract_common/any_poly.h>
 TESSERACT_INSTRUCTION_EXPORT_KEY(tesseract_planning, CompositeInstruction);
 TESSERACT_ANY_EXPORT_KEY(tesseract_planning, CompositeInstruction);
 


### PR DESCRIPTION
For example [this PR](https://github.com/tesseract-robotics/tesseract_planning/pull/441) fails on code quality, as the used container from tesseract does not include [this PR](https://github.com/tesseract-robotics/tesseract/pull/989) it depends on.