### PR TITLE
Fixing Descartes not aborting on collision failure

### DIFF
--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_motion_planner.hpp
@@ -86,7 +86,12 @@ PlannerResponse DescartesMotionPlanner<FloatType>::solve(const PlannerRequest& r
   try
   {
     descartes_light::LadderGraphSolver<FloatType> solver(problem->num_threads);
-    solver.build(problem->samplers, problem->edge_evaluators, problem->state_evaluators);
+    if (!solver.build(problem->samplers, problem->edge_evaluators, problem->state_evaluators))
+    {
+      response.successful = false;
+      response.message = ERROR_FAILED_TO_BUILD_GRAPH;
+      return response;
+    }
     descartes_result = solver.search();
     if (descartes_result.trajectory.empty())
     {

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/nodes/motion_planner_task.hpp
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/nodes/motion_planner_task.hpp
@@ -179,6 +179,8 @@ protected:
       return info;
     }
 
+    context.abort(uuid_);
+
     CONSOLE_BRIDGE_logInform("%s motion planning failed (%s) for process input: %s",
                              planner_->getName().c_str(),
                              response.message.c_str(),


### PR DESCRIPTION
Two fixes here that I would like thoughts on. While testing some of our Descartes-based motions I noticed that the `context->isSuccessful` was returning `true` although the planner failed to build the LadderGraph because of collisions.

First fix is that the Descartes implementation is returning a failed BuildStatus from build that we aren't checking, so added the same check that is ran on an exception. That signals the failure but then we come to the abort not being done.

Second fix is making it so the MotionPlannerTask aborts when there is a failure... now this might be incorrect. Looking through `tesseract_task_graph` I saw there is `abort_terminals` but they don't exist for class types. How else are we supposed to have the Planning Tasks signal that they failed and fail out? This is the part I am confused about.