### PR TITLE
Add task composer graph validation

### DIFF
--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_graph.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_graph.h
@@ -111,6 +111,13 @@ public:
    */
   void setTerminalTriggerAbortByIndex(int terminal_index);
 
+  /**
+   * @brief Check if the current state of the graph is valid
+   * @todo Replace return type with std::expected when upgraded to use c++23
+   * @return True if valid otherwise false with a reason
+   */
+  virtual std::pair<bool, std::string> isValid() const;
+
   void renameInputKeys(const std::map<std::string, std::string>& input_keys) override;
 
   void renameOutputKeys(const std::map<std::string, std::string>& output_keys) override;


### PR DESCRIPTION
This looks for more than one root node and termination node with outbound edges. It can be expanded in the future to check for discrepancies in input keys and output keys.