### PR TITLE
Do not delete special member functions of Profile

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/profile.h
+++ b/tesseract_command_language/include/tesseract_command_language/profile.h
@@ -43,10 +43,6 @@ public:
 
   Profile() = default;
   Profile(std::size_t key);
-  Profile(const Profile&) = delete;
-  Profile& operator=(const Profile&) = delete;
-  Profile(Profile&&) = delete;
-  Profile&& operator=(Profile&&) = delete;
   virtual ~Profile() = default;
 
   /**
@@ -56,6 +52,11 @@ public:
   std::size_t getKey() const;
 
 protected:
+  Profile(const Profile&) = default;
+  Profile& operator=(const Profile&) = default;
+  Profile(Profile&&) = default;
+  Profile& operator=(Profile&&) = default;
+
   std::size_t key_{ 0 };
   friend class boost::serialization::access;
   template <class Archive>


### PR DESCRIPTION
Deleting these functions prevents code like this from working, as the loaded or create profile cannot be assigned to variable `profile`:
```
  std::shared_ptr<TimeOptimalParameterizationProfile> profile;
  try
  {
    profile = std::make_shared<TimeOptimalParameterizationProfile>(
        tesseract_common::Serialization::fromArchiveFileXML<TimeOptimalParameterizationProfile>(profile_path));
  }
  catch (const std::exception& ex)
  {
    RCLCPP_WARN_STREAM(logger, "Could not load profile " << profile_path.filename() << ": " << ex.what());
  }
  if (!profile)
  {
    // Create default profile
    profile = std::make_shared<TimeOptimalParameterizationProfile>(
        max_velocity_scaling_factor, max_acceleration_scaling_factor, max_jerk_scaling_factor, 0.1, 0.001);
  }
```

I think making the special functions protected is the right approach for an abstract base class.