### PR TITLE
Allow setting minimum timestamp delta between trajectory points in Iterative Spline Parameterization

### DIFF
--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/iterative_spline_parameterization_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/iterative_spline_parameterization_profile.h
@@ -50,6 +50,8 @@ struct IterativeSplineParameterizationProfile
 
   /** @brief max_velocity_scaling_factor The max acceleration scaling factor passed to the solver */
   double max_acceleration_scaling_factor{ 1.0 };
+
+  double minimum_time_delta{ std::numeric_limits<double>::epsilon() };
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_task_composer/planning/src/nodes/iterative_spline_parameterization_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/iterative_spline_parameterization_task.cpp
@@ -191,6 +191,8 @@ IterativeSplineParameterizationTask::runImpl(TaskComposerContext& context,
                                                  cur_composite_profile->max_acceleration_scaling_factor;
   Eigen::VectorXd jerk_scaling_factors = Eigen::VectorXd::Ones(static_cast<Eigen::Index>(flattened.size()));
 
+  const auto minimum_time_delta = cur_composite_profile->minimum_time_delta;
+
   // Loop over all MoveInstructions
   for (Eigen::Index idx = 0; idx < static_cast<Eigen::Index>(flattened.size()); idx++)
   {
@@ -219,7 +221,8 @@ IterativeSplineParameterizationTask::runImpl(TaskComposerContext& context,
                        limits.jerk_limits,
                        velocity_scaling_factors,
                        acceleration_scaling_factors,
-                       jerk_scaling_factors))
+                       jerk_scaling_factors,
+                       minimum_time_delta))
   {
     // If the output key is not the same as the input key the output data should be assigned the input data for error
     // branching

--- a/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/time_parameterization.h
+++ b/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/time_parameterization.h
@@ -43,6 +43,7 @@ public:
    * @param velocity_scaling_factor The velocity scaling factor. Size should be trajectory.size()
    * @param acceleration_scaling_factor The acceleration scaling factor. Size should be trajectory.size()
    * @param jerk_scaling_factor The jerk scaling factor. Size should be trajectory.size()
+   * @param minimum_time_delta The smallest-allowable difference in seconds between timestamps of consecutive trajectory points.
    * @return True if successful, otherwise false
    */
   virtual bool compute(TrajectoryContainer& trajectory,
@@ -51,7 +52,8 @@ public:
                        const Eigen::Ref<const Eigen::MatrixX2d>& jerk_limits,
                        const Eigen::Ref<const Eigen::VectorXd>& velocity_scaling_factors,
                        const Eigen::Ref<const Eigen::VectorXd>& acceleration_scaling_factors,
-                       const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors) const = 0;
+                       const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors,
+                       const double& minimum_time_delta) const = 0;
 };
 }  // namespace tesseract_planning
 #endif  // TESSERACT_TIME_PARAMETERIZATION_TIME_PARAMETERIZATION_H

--- a/tesseract_time_parameterization/isp/include/tesseract_time_parameterization/isp/iterative_spline_parameterization.h
+++ b/tesseract_time_parameterization/isp/include/tesseract_time_parameterization/isp/iterative_spline_parameterization.h
@@ -91,7 +91,8 @@ public:
                const Eigen::Ref<const Eigen::MatrixX2d>& jerk_limits,
                const Eigen::Ref<const Eigen::VectorXd>& velocity_scaling_factors = Eigen::VectorXd::Ones(1),
                const Eigen::Ref<const Eigen::VectorXd>& acceleration_scaling_factors = Eigen::VectorXd::Ones(1),
-               const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors = Eigen::VectorXd::Ones(1)) const override;
+               const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors = Eigen::VectorXd::Ones(1),
+               const double& minimum_time_delta = std::numeric_limits<double>::epsilon()) const override;
 
 private:
   /**

--- a/tesseract_time_parameterization/ruckig/include/tesseract_time_parameterization/ruckig/ruckig_trajectory_smoothing.h
+++ b/tesseract_time_parameterization/ruckig/include/tesseract_time_parameterization/ruckig/ruckig_trajectory_smoothing.h
@@ -57,7 +57,8 @@ public:
                const Eigen::Ref<const Eigen::MatrixX2d>& jerk_limits,
                const Eigen::Ref<const Eigen::VectorXd>& velocity_scaling_factors = Eigen::VectorXd::Ones(1),
                const Eigen::Ref<const Eigen::VectorXd>& acceleration_scaling_factors = Eigen::VectorXd::Ones(1),
-               const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors = Eigen::VectorXd::Ones(1)) const override;
+               const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors = Eigen::VectorXd::Ones(1),
+               const double& minimum_time_delta = std::numeric_limits<double>::epsilon()) const override;
 
 protected:
   double duration_extension_fraction_;

--- a/tesseract_time_parameterization/ruckig/src/ruckig_trajectory_smoothing.cpp
+++ b/tesseract_time_parameterization/ruckig/src/ruckig_trajectory_smoothing.cpp
@@ -73,7 +73,8 @@ bool RuckigTrajectorySmoothing::compute(TrajectoryContainer& trajectory,
                                         const Eigen::Ref<const Eigen::VectorXd>& max_jerk,
                                         const Eigen::Ref<const Eigen::VectorXd>& max_velocity_scaling_factors,
                                         const Eigen::Ref<const Eigen::VectorXd>& max_acceleration_scaling_factors,
-                                        const Eigen::Ref<const Eigen::VectorXd>& max_jerk_scaling_factors) const
+                                        const Eigen::Ref<const Eigen::VectorXd>& max_jerk_scaling_factors,
+                                        const double& /*minimum_time_delta*/) const
 {
   if (trajectory.size() < 2)
     return true;
@@ -208,7 +209,8 @@ bool RuckigTrajectorySmoothing::compute(TrajectoryContainer& trajectory,
                                         const Eigen::Ref<const Eigen::MatrixX2d>& jerk_limits,
                                         const Eigen::Ref<const Eigen::VectorXd>& /*velocity_scaling_factors*/,
                                         const Eigen::Ref<const Eigen::VectorXd>& /*acceleration_scaling_factors*/,
-                                        const Eigen::Ref<const Eigen::VectorXd>& /*jerk_scaling_factors*/) const
+                                        const Eigen::Ref<const Eigen::VectorXd>& /*jerk_scaling_factors*/,
+                                        const double& /*minimum_time_delta*/) const
 {
   if (trajectory.size() < 2)
     return true;

--- a/tesseract_time_parameterization/totg/include/tesseract_time_parameterization/totg/time_optimal_trajectory_generation.h
+++ b/tesseract_time_parameterization/totg/include/tesseract_time_parameterization/totg/time_optimal_trajectory_generation.h
@@ -67,7 +67,8 @@ public:
                const Eigen::Ref<const Eigen::MatrixX2d>& jerk_limits,
                const Eigen::Ref<const Eigen::VectorXd>& velocity_scaling_factors = Eigen::VectorXd::Ones(1),
                const Eigen::Ref<const Eigen::VectorXd>& acceleration_scaling_factors = Eigen::VectorXd::Ones(1),
-               const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors = Eigen::VectorXd::Ones(1)) const override;
+               const Eigen::Ref<const Eigen::VectorXd>& jerk_scaling_factors = Eigen::VectorXd::Ones(1),
+               const double& minimum_time_delta = std::numeric_limits<double>::epsilon()) const override;
 
 private:
   double path_tolerance_;

--- a/tesseract_time_parameterization/totg/src/time_optimal_trajectory_generation.cpp
+++ b/tesseract_time_parameterization/totg/src/time_optimal_trajectory_generation.cpp
@@ -67,7 +67,8 @@ bool TimeOptimalTrajectoryGeneration::compute(TrajectoryContainer& trajectory,
                                               const Eigen::Ref<const Eigen::MatrixX2d>& /*jerk_limits*/,
                                               const Eigen::Ref<const Eigen::VectorXd>& velocity_scaling_factors,
                                               const Eigen::Ref<const Eigen::VectorXd>& acceleration_scaling_factors,
-                                              const Eigen::Ref<const Eigen::VectorXd>& /*jerk_scaling_factors*/) const
+                                              const Eigen::Ref<const Eigen::VectorXd>& /*jerk_scaling_factors*/,
+                                              const double& /*minimum_time_delta*/) const
 {
   if (trajectory.empty())
     return true;


### PR DESCRIPTION
I ran into a situation where I needed to enforce that the differences between timestamps for consecutive trajectory points were all greater than some minimum threshold. Briefly, this is because some robot controllers can't execute trajectories with arbitrarily-fine time resolution and need to have (for example) a 1ms difference between each trajectory point.

A good way to resolve this while ensuring that the trajectory is still smooth is to apply this time delta threshold during the time parameterization stage. This lets us stretch out the trajectory between two waypoints if needed while ensuring that the robot's path for this trajectory segment follows the same positions but just at a slower speed.

I'm using ISP specifically so I only implemented this change there. I did add this parameter to the time parameterizer base class to allow implementing it elsewhere as well. Let me know if there's a better way to approach this, though.

I have to test this more thoroughly on my system and then update the branch to the latest state of `main`, so I'll keep this PR as a draft until I do both those things.