### PR TITLE
Fix MSVC compiler error in TaskComposerPluginFactory

### DIFF
--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
@@ -100,8 +100,8 @@ public:
   ~TaskComposerPluginFactory();
   TaskComposerPluginFactory(const TaskComposerPluginFactory&) = delete;
   TaskComposerPluginFactory& operator=(const TaskComposerPluginFactory&) = delete;
-  TaskComposerPluginFactory(TaskComposerPluginFactory&&) noexcept = default;
-  TaskComposerPluginFactory& operator=(TaskComposerPluginFactory&&) noexcept = default;
+  TaskComposerPluginFactory(TaskComposerPluginFactory&&) noexcept;
+  TaskComposerPluginFactory& operator=(TaskComposerPluginFactory&&) noexcept;
 
   /**
    * @brief Load plugins from a configuration object

--- a/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
+++ b/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
@@ -98,6 +98,8 @@ TaskComposerPluginFactory::TaskComposerPluginFactory(const std::string& config,
 // This prevents it from being defined inline.
 // If not the forward declare of PluginLoader cause compiler error.
 TaskComposerPluginFactory::~TaskComposerPluginFactory() = default;
+TaskComposerPluginFactory::TaskComposerPluginFactory(TaskComposerPluginFactory&&) noexcept = default;
+TaskComposerPluginFactory& TaskComposerPluginFactory::operator=(TaskComposerPluginFactory&&) noexcept = default;
 
 void TaskComposerPluginFactory::loadConfig(const tesseract_common::TaskComposerPluginInfo& config)
 {


### PR DESCRIPTION
This PR fixes a "cannot delete incomplete type" error for `TaskComposerPluginFactory` when using MSVC.