### PR TITLE
Fix missing include to cover use of shared_ptr and unique_ptr

### DIFF
--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
@@ -30,6 +30,7 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
 #include <map>
+#include <memory>
 #include <set>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 


### PR DESCRIPTION
This file was missing an `#include <memory>`, which should be added on the basis of IWYU because this file uses `shared_ptr` and `unique_ptr`.

I found this because I was defining a separate library containing custom plugin factories and changing the order of includes in my own code caused a build failure pointing here.