### PR TITLE
Fix TrajOptIfoptOSQPSolverProfile constructors

### DIFF
--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h
@@ -31,7 +31,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <OsqpEigen/Settings.hpp>
 #include <trajopt_sqp/fwd.h>
-#include <trajopt_sqp/types.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
@@ -56,8 +55,10 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptIfoptOSQPSolverProfile>;
 
   TrajOptIfoptOSQPSolverProfile();
-  TrajOptIfoptOSQPSolverProfile(TrajOptIfoptOSQPSolverProfile&&) = default;
-  TrajOptIfoptOSQPSolverProfile& operator=(TrajOptIfoptOSQPSolverProfile&&) = default;
+  TrajOptIfoptOSQPSolverProfile(TrajOptIfoptOSQPSolverProfile&& other) noexcept;
+  TrajOptIfoptOSQPSolverProfile& operator=(TrajOptIfoptOSQPSolverProfile&& other) noexcept;
+
+  ~TrajOptIfoptOSQPSolverProfile() override = default;
 
   // Delete because OsqpEigen::Settings stores raw pointer
   TrajOptIfoptOSQPSolverProfile(const TrajOptIfoptOSQPSolverProfile&) = delete;
@@ -65,9 +66,6 @@ public:
 
   /** @brief The OSQP convex solver settings to use */
   OsqpEigen::Settings qp_settings;
-
-  /** @brief Optimization parameters */
-  trajopt_sqp::SQPParameters opt_params{};
 
   std::unique_ptr<trajopt_sqp::TrustRegionSQPSolver> create(bool verbose = false) const override;
 

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h
@@ -33,6 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
 #include <trajopt_ifopt/fwd.h>
 #include <trajopt_sqp/fwd.h>
+#include <trajopt_sqp/types.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/fwd.h>
@@ -121,6 +122,9 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptIfoptSolverProfile>;
 
   TrajOptIfoptSolverProfile();
+
+  /** @brief Optimization parameters */
+  trajopt_sqp::SQPParameters opt_params{};
 
   virtual std::unique_ptr<trajopt_sqp::TrustRegionSQPSolver> create(bool verbose = false) const = 0;
 

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_osqp_solver_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_osqp_solver_profile.cpp
@@ -67,29 +67,6 @@ void serialize(Archive& ar, OsqpEigen::Settings& osqp_eigen_settings, const unsi
   ar& boost::serialization::make_nvp("warm_start", settings.warm_start);
   ar& boost::serialization::make_nvp("time_limit", settings.time_limit);
 }
-
-template <class Archive>
-void serialize(Archive& ar, trajopt_sqp::SQPParameters& params, const unsigned int /*version*/)
-{
-  ar& boost::serialization::make_nvp("improve_ratio_threshold", params.improve_ratio_threshold);
-  ar& boost::serialization::make_nvp("min_trust_box_size", params.min_trust_box_size);
-  ar& boost::serialization::make_nvp("min_approx_improve", params.min_approx_improve);
-  ar& boost::serialization::make_nvp("min_approx_improve_frac", params.min_approx_improve_frac);
-  ar& boost::serialization::make_nvp("max_iter", params.max_iterations);
-  ar& boost::serialization::make_nvp("trust_shrink_ratio", params.trust_shrink_ratio);
-  ar& boost::serialization::make_nvp("trust_expand_ratio", params.trust_expand_ratio);
-  ar& boost::serialization::make_nvp("cnt_tolerance", params.cnt_tolerance);
-  ar& boost::serialization::make_nvp("max_merit_coeff_increases", params.max_merit_coeff_increases);
-  ar& boost::serialization::make_nvp("max_qp_solver_failures", params.max_qp_solver_failures);
-  ar& boost::serialization::make_nvp("merit_coeff_increase_ratio", params.merit_coeff_increase_ratio);
-  ar& boost::serialization::make_nvp("max_time", params.max_time);
-  ar& boost::serialization::make_nvp("initial_merit_error_coeff", params.initial_merit_error_coeff);
-  ar& boost::serialization::make_nvp("inflate_constraints_individually", params.inflate_constraints_individually);
-  ar& boost::serialization::make_nvp("trust_box_size", params.initial_trust_box_size);
-  ar& boost::serialization::make_nvp("log_results", params.log_results);
-  ar& boost::serialization::make_nvp("log_dir", params.log_dir);
-  // ar& boost::serialization::make_nvp("num_threads", params.num_threads);
-}
 }  // namespace boost::serialization
 
 namespace tesseract_planning
@@ -103,6 +80,25 @@ TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile()
   qp_settings.setMaxIteration(8192);
   qp_settings.setAbsoluteTolerance(1e-4);
   qp_settings.setRelativeTolerance(1e-6);
+}
+
+TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile(TrajOptIfoptOSQPSolverProfile&& other) noexcept
+  : TrajOptIfoptSolverProfile(std::move(other))
+{
+  // Handle qp_settings (contains raw pointer)
+  copyOSQPEigenSettings(qp_settings, other.qp_settings);
+}
+
+TrajOptIfoptOSQPSolverProfile& TrajOptIfoptOSQPSolverProfile::operator=(TrajOptIfoptOSQPSolverProfile&& other) noexcept
+{
+  if (this != &other)
+  {
+    TrajOptIfoptSolverProfile::operator=(std::move(other));
+
+    // Handle qp_settings (contains raw pointer)
+    copyOSQPEigenSettings(qp_settings, other.qp_settings);
+  }
+  return *this;
 }
 
 std::unique_ptr<trajopt_sqp::TrustRegionSQPSolver> TrajOptIfoptOSQPSolverProfile::create(bool verbose) const
@@ -138,13 +134,11 @@ void TrajOptIfoptOSQPSolverProfile::serialize(Archive& ar, const unsigned int /*
 {
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(TrajOptIfoptSolverProfile);
   ar& BOOST_SERIALIZATION_NVP(qp_settings);
-  ar& BOOST_SERIALIZATION_NVP(opt_params);
 }
 
 }  // namespace tesseract_planning
 
 #include <tesseract_common/serialization.h>
 TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(OsqpEigen::Settings)
-TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(trajopt_sqp::SQPParameters)
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptIfoptOSQPSolverProfile)
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptIfoptOSQPSolverProfile)

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_profile.cpp
@@ -28,6 +28,32 @@
 #include <boost/serialization/nvp.hpp>
 #include <typeindex>
 
+namespace boost::serialization
+{
+template <class Archive>
+void serialize(Archive& ar, trajopt_sqp::SQPParameters& params, const unsigned int /*version*/)
+{
+  ar& boost::serialization::make_nvp("improve_ratio_threshold", params.improve_ratio_threshold);
+  ar& boost::serialization::make_nvp("min_trust_box_size", params.min_trust_box_size);
+  ar& boost::serialization::make_nvp("min_approx_improve", params.min_approx_improve);
+  ar& boost::serialization::make_nvp("min_approx_improve_frac", params.min_approx_improve_frac);
+  ar& boost::serialization::make_nvp("max_iter", params.max_iterations);
+  ar& boost::serialization::make_nvp("trust_shrink_ratio", params.trust_shrink_ratio);
+  ar& boost::serialization::make_nvp("trust_expand_ratio", params.trust_expand_ratio);
+  ar& boost::serialization::make_nvp("cnt_tolerance", params.cnt_tolerance);
+  ar& boost::serialization::make_nvp("max_merit_coeff_increases", params.max_merit_coeff_increases);
+  ar& boost::serialization::make_nvp("max_qp_solver_failures", params.max_qp_solver_failures);
+  ar& boost::serialization::make_nvp("merit_coeff_increase_ratio", params.merit_coeff_increase_ratio);
+  ar& boost::serialization::make_nvp("max_time", params.max_time);
+  ar& boost::serialization::make_nvp("initial_merit_error_coeff", params.initial_merit_error_coeff);
+  ar& boost::serialization::make_nvp("inflate_constraints_individually", params.inflate_constraints_individually);
+  ar& boost::serialization::make_nvp("trust_box_size", params.initial_trust_box_size);
+  ar& boost::serialization::make_nvp("log_results", params.log_results);
+  ar& boost::serialization::make_nvp("log_dir", params.log_dir);
+  // ar& boost::serialization::make_nvp("num_threads", params.num_threads);
+}
+}  // namespace boost::serialization
+
 namespace tesseract_planning
 {
 TrajOptIfoptPlanProfile::TrajOptIfoptPlanProfile() : Profile(TrajOptIfoptPlanProfile::getStaticKey()) {}
@@ -67,6 +93,7 @@ template <class Archive>
 void TrajOptIfoptSolverProfile::serialize(Archive& ar, const unsigned int /*version*/)
 {
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(Profile);
+  ar& BOOST_SERIALIZATION_NVP(opt_params);
 }
 
 }  // namespace tesseract_planning
@@ -76,5 +103,6 @@ TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptIfoptPlanPro
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptIfoptPlanProfile)
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptIfoptCompositeProfile)
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptIfoptCompositeProfile)
+TESSERACT_SERIALIZE_FREE_ARCHIVES_INSTANTIATE(trajopt_sqp::SQPParameters)
 TESSERACT_SERIALIZE_ARCHIVES_INSTANTIATE(tesseract_planning::TrajOptIfoptSolverProfile)
 BOOST_CLASS_EXPORT_IMPLEMENT(tesseract_planning::TrajOptIfoptSolverProfile)


### PR DESCRIPTION
The default move and move assign constructors of TrajOptIfoptOSQPSolverProfile caused a "double free or corruption (!prev)" crash on destruction of the class if it had been moved, for instance through serialization. This PR fixes this.

I also moved opt_params to the TrajOptIfoptSolverProfile class to match the structure of TrajOptSolverProfile/TrajOpOSQPSolverProfile.