### PR TITLE
Add task composer task return value override

### DIFF
--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_node.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_node.h
@@ -69,7 +69,8 @@ public:
   TaskComposerNode(std::string name = "TaskComposerNode",
                    TaskComposerNodeType type = TaskComposerNodeType::NODE,
                    TaskComposerNodePorts ports = TaskComposerNodePorts(),
-                   bool conditional = false);
+                   bool conditional = false,
+                   int return_value_override = -1);
   explicit TaskComposerNode(std::string name,
                             TaskComposerNodeType type,
                             TaskComposerNodePorts ports,
@@ -214,6 +215,13 @@ protected:
 
   /** @brief The nodes ports definition */
   TaskComposerNodePorts ports_;
+
+  /**
+   * @brief Value with which to override the return value nominally provided by runImpl() in the TaskComposerNodeInfo.
+   * @details The return value provided by runImpl() will be overriden with this value when it is >= 0.
+   * This value can be set to force a task to behave in a specific way (e.g., for debugging or unit tests).
+   */
+  int return_value_override_{ -1 };
 
   /** @brief Indicate if task triggers abort */
   bool trigger_abort_{ false };

--- a/tesseract_task_composer/core/src/task_composer_node.cpp
+++ b/tesseract_task_composer/core/src/task_composer_node.cpp
@@ -131,7 +131,7 @@ int TaskComposerNode::run(TaskComposerContext& context, OptionalTaskComposerExec
     {
       results.return_value = return_value_override_;
       results.status_message += " (Return value overridden to " + std::to_string(return_value_override_) + ")";
-      results.color = "yellow";
+      results.color = "cyan";
     }
   }
   catch (const std::exception& e)

--- a/tesseract_task_composer/core/src/task_composer_node.cpp
+++ b/tesseract_task_composer/core/src/task_composer_node.cpp
@@ -44,7 +44,8 @@ namespace tesseract_planning
 TaskComposerNode::TaskComposerNode(std::string name,
                                    TaskComposerNodeType type,
                                    TaskComposerNodePorts ports,
-                                   bool conditional)
+                                   bool conditional,
+                                   int return_value_override)
   : name_(std::move(name))
   , ns_(name_)
   , type_(type)
@@ -53,6 +54,7 @@ TaskComposerNode::TaskComposerNode(std::string name,
   , parent_uuid_str_(boost::uuids::to_string(parent_uuid_))
   , conditional_(conditional)
   , ports_(std::move(ports))
+  , return_value_override_(return_value_override)
 {
 }
 
@@ -84,6 +86,9 @@ TaskComposerNode::TaskComposerNode(std::string name,
 
       output_keys_ = n.as<TaskComposerKeys>();
     }
+
+    if (YAML::Node n = config["return_value_override"])
+      return_value_override_ = n.as<int>();
   }
   catch (const std::exception& e)
   {
@@ -122,6 +127,12 @@ int TaskComposerNode::run(TaskComposerContext& context, OptionalTaskComposerExec
   try
   {
     results = runImpl(context, executor);
+    if (return_value_override_ >= 0)
+    {
+      results.return_value = return_value_override_;
+      results.status_message += " (Return value overridden to " + std::to_string(return_value_override_) + ")";
+      results.color = "yellow";
+    }
   }
   catch (const std::exception& e)
   {


### PR DESCRIPTION
This PR provides a means to override the return value of a task. This can be useful for debugging (e.g., forcing a task composer graph to take a specific path) and potentially for unit testing (for the same reason).