### PR TITLE
Implement the option to format result as output for SimplePlanner

### DIFF
--- a/tesseract_motion_planners/simple/src/interpolation.cpp
+++ b/tesseract_motion_planners/simple/src/interpolation.cpp
@@ -1326,6 +1326,7 @@ CompositeInstruction generateInterpolatedProgram(const CompositeInstruction& ins
   PlannerRequest request;
   request.instructions = instructions;
   request.env = env;
+  request.format_result_as_input = true;
 
   // Set up planner
   SimpleMotionPlanner planner("SimpleMotionPlannerTask");

--- a/tesseract_task_composer/planning/src/nodes/min_length_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/min_length_task.cpp
@@ -139,6 +139,7 @@ TaskComposerNodeInfo MinLengthTask::runImpl(TaskComposerContext& context,
     PlannerRequest request;
     request.instructions = ci;
     request.env = env;
+    request.format_result_as_input = true;
 
     // Set up planner
     SimpleMotionPlanner planner(ns_);


### PR DESCRIPTION
The SimplePlanner did ignore the format_result_as_input option and always returned the input format. This PR implements formatting as output.