### PR TITLE
Task composer factory update

### DIFF
--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
@@ -72,6 +72,8 @@ public:
                                                    const YAML::Node& config,
                                                    const TaskComposerPluginFactory& plugin_factory) const = 0;
 
+  virtual std::unique_ptr<TaskComposerNode> create() const = 0;
+
 protected:
   static std::string getSection();
   friend class boost_plugin_loader::PluginLoader;
@@ -88,6 +90,8 @@ public:
   virtual ~TaskComposerExecutorFactory() = default;
 
   virtual std::unique_ptr<TaskComposerExecutor> create(const std::string& name, const YAML::Node& config) const = 0;
+
+  virtual std::unique_ptr<TaskComposerExecutor> create() const = 0;
 
 protected:
   static std::string getSection();

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory.h
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <map>
 #include <memory>
 #include <set>
+#include <vector>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/fwd.h>
@@ -310,6 +311,16 @@ public:
    * @return The plugin information config yaml node/
    */
   YAML::Node getConfig() const;
+
+  /**
+   * @brief Returns a list of available task composer node plugins
+   */
+  std::vector<std::string> getAvailableTaskComposerNodePlugins() const;
+
+  /**
+   * @brief Returns a list of available task composer executor plugins
+   */
+  std::vector<std::string> getAvailableTaskComposerExecutorPlugins() const;
 
 private:
   struct Implementation;

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory_utils.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_plugin_factory_utils.h
@@ -40,6 +40,8 @@ public:
   {
     return std::make_unique<TaskType>(name, config, plugin_factory);
   }
+
+  std::unique_ptr<TaskComposerNode> create() const override { return std::make_unique<TaskType>(); }
 };
 
 template <typename ExecutorType>
@@ -50,6 +52,8 @@ public:
   {
     return std::make_unique<ExecutorType>(name, config);
   }
+
+  std::unique_ptr<TaskComposerExecutor> create() const override { return std::make_unique<ExecutorType>(); }
 };
 }  // namespace tesseract_planning
 

--- a/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
+++ b/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
@@ -434,4 +434,15 @@ YAML::Node TaskComposerPluginFactory::getConfig() const
 
   return config;
 }
+
+std::vector<std::string> TaskComposerPluginFactory::getAvailableTaskComposerNodePlugins() const
+{
+  return impl_->plugin_loader.getAvailablePlugins("TaskNode");
+}
+
+std::vector<std::string> TaskComposerPluginFactory::getAvailableTaskComposerExecutorPlugins() const
+{
+  return impl_->plugin_loader.getAvailablePlugins("TaskExec");
+}
+
 }  // namespace tesseract_planning

--- a/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
+++ b/tesseract_task_composer/core/src/task_composer_plugin_factory.cpp
@@ -282,17 +282,42 @@ std::string TaskComposerPluginFactory::getDefaultTaskComposerNodePlugin() const
 std::unique_ptr<TaskComposerExecutor>
 TaskComposerPluginFactory::createTaskComposerExecutor(const std::string& name) const
 {
-  const auto& executor_plugin_info = impl_->executor_plugin_info;
-  auto cm_it = executor_plugin_info.plugins.find(name);
-  if (cm_it == executor_plugin_info.plugins.end())
+  try
   {
-    CONSOLE_BRIDGE_logWarn("TaskComposerPluginFactory, tried to get task composer executor '%s' that does not "
-                           "exist!",
-                           name.c_str());
+    // Check if the input name has associated plugin information
+    const auto& executor_plugin_info = impl_->executor_plugin_info;
+    auto cm_it = executor_plugin_info.plugins.find(name);
+    if (cm_it != executor_plugin_info.plugins.end())
+      return createTaskComposerExecutor(name, cm_it->second);
+
+    // Check if a plugin factory has already been loaded for the input plugin name
+    auto& executor_factories = impl_->executor_factories;
+    auto it = executor_factories.find(name);
+    if (it != executor_factories.end())
+    {
+      // Default create a task composer node from the plugin since no configuration information exists
+      return it->second->create();
+    }
+
+    // Load the plugin since one has not already been loaded
+    auto plugin = impl_->plugin_loader.instantiate<TaskComposerExecutorFactory>(name);
+    if (plugin == nullptr)
+    {
+      CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s'", name.c_str());
+      return nullptr;
+    }
+
+    // Store the plugin internally to keep the plugin in scope for the lifetime of this factory object
+    executor_factories[name] = plugin;
+
+    // Default create a task composer node from the plugin since no configuration information exists
+    return plugin->create();
+  }
+  catch (const std::exception& e)
+  {
+    CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s', Details: %s", name.c_str(), e.what());
     return nullptr;
   }
-
-  return createTaskComposerExecutor(name, cm_it->second);
 }
 
 std::unique_ptr<TaskComposerExecutor>
@@ -324,17 +349,42 @@ TaskComposerPluginFactory::createTaskComposerExecutor(const std::string& name,
 
 std::unique_ptr<TaskComposerNode> TaskComposerPluginFactory::createTaskComposerNode(const std::string& name) const
 {
-  const auto& task_plugin_info = impl_->task_plugin_info;
-  auto cm_it = task_plugin_info.plugins.find(name);
-  if (cm_it == task_plugin_info.plugins.end())
+  try
   {
-    CONSOLE_BRIDGE_logWarn("TaskComposerPluginFactory, tried to get task composer node '%s' that does not "
-                           "exist!",
-                           name.c_str());
+    // Check if the input name has associated plugin information
+    const auto& task_plugin_info = impl_->task_plugin_info;
+    auto cm_it = task_plugin_info.plugins.find(name);
+    if (cm_it != task_plugin_info.plugins.end())
+      return createTaskComposerNode(name, cm_it->second);
+
+    // Check if a plugin factory has already been loaded for the input plugin name
+    auto& node_factories = impl_->node_factories;
+    auto it = node_factories.find(name);
+    if (it != node_factories.end())
+    {
+      // Default create a task composer node from the plugin since no configuration information exists
+      return it->second->create();
+    }
+
+    // Load the plugin since one has not already been loaded
+    auto plugin = impl_->plugin_loader.instantiate<TaskComposerNodeFactory>(name);
+    if (plugin == nullptr)
+    {
+      CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s'", name.c_str());
+      return nullptr;
+    }
+
+    // Store the plugin internally to keep the plugin in scope for the lifetime of this factory object
+    node_factories[name] = plugin;
+
+    // Default create a task composer node from the plugin since no configuration information exists
+    return plugin->create();
+  }
+  catch (const std::exception& e)
+  {
+    CONSOLE_BRIDGE_logWarn("Failed to load symbol '%s', Details: %s", name.c_str(), e.what());
     return nullptr;
   }
-
-  return createTaskComposerNode(name, cm_it->second);
 }
 
 std::unique_ptr<TaskComposerNode>


### PR DESCRIPTION
This PR updates the task composer plugin factory class to:
- provide access to the names of all the known plugins.
- default-construct task and executor plugins
- load task and executor plugins when only the name is provided (i.e., no configuration information).
    - Previously, the plugin factory class would return an error if no configuration information had been given to the factory. With this change, the plugin gets default-constructed if no plugin information is provided.