### PR TITLE
TOTG profile: Restore constructor with parameters

### DIFF
--- a/tesseract_time_parameterization/totg/include/tesseract_time_parameterization/totg/time_optimal_trajectory_generation_profiles.h
+++ b/tesseract_time_parameterization/totg/include/tesseract_time_parameterization/totg/time_optimal_trajectory_generation_profiles.h
@@ -41,6 +41,10 @@ struct TimeOptimalTrajectoryGenerationCompositeProfile : public tesseract_common
   using ConstPtr = std::shared_ptr<const TimeOptimalTrajectoryGenerationCompositeProfile>;
 
   TimeOptimalTrajectoryGenerationCompositeProfile();
+  TimeOptimalTrajectoryGenerationCompositeProfile(double max_velocity_scaling_factor,
+                                                  double max_acceleration_scaling_factor,
+                                                  double path_tolerance,
+                                                  double min_angle_change);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_time_parameterization/totg/src/time_optimal_trajectory_generation_profiles.cpp
+++ b/tesseract_time_parameterization/totg/src/time_optimal_trajectory_generation_profiles.cpp
@@ -33,6 +33,19 @@ TimeOptimalTrajectoryGenerationCompositeProfile::TimeOptimalTrajectoryGeneration
 {
 }
 
+TimeOptimalTrajectoryGenerationCompositeProfile::TimeOptimalTrajectoryGenerationCompositeProfile(
+    double max_velocity_scaling_factor,
+    double max_acceleration_scaling_factor,
+    double path_tolerance,
+    double min_angle_change)
+  : Profile(TimeOptimalTrajectoryGenerationCompositeProfile::getStaticKey())
+  , max_velocity_scaling_factor(max_velocity_scaling_factor)
+  , max_acceleration_scaling_factor(max_acceleration_scaling_factor)
+  , path_tolerance(path_tolerance)
+  , min_angle_change(min_angle_change)
+{
+}
+
 std::size_t TimeOptimalTrajectoryGenerationCompositeProfile::getStaticKey()
 {
   return std::type_index(typeid(TimeOptimalTrajectoryGenerationCompositeProfile)).hash_code();


### PR DESCRIPTION
Somehow this constructor got lost in the interface update