### PR TITLE
Correctly update input key rather than output key for raster task

### DIFF
--- a/tesseract_task_composer/planning/src/nodes/raster_motion_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/raster_motion_task.cpp
@@ -479,11 +479,8 @@ TaskComposerNodeInfo RasterMotionTask::runImpl(TaskComposerContext& context,
   auto from_start_pipeline_uuid = task_graph.addNode(std::move(from_start_results.node));
 
   const auto& first_raster_output_key = raster_tasks[0].second.second;
-  auto update_end_state_task = std::make_unique<UpdateEndStateTask>("UpdateEndStateTask",
-                                                                    from_start_results.input_key,
-                                                                    first_raster_output_key,
-                                                                    from_start_results.input_key,
-                                                                    false);
+  auto update_end_state_task = std::make_unique<UpdateEndStateTask>(
+      "UpdateEndStateTask", from_start_results.input_key, first_raster_output_key, from_start_results.input_key, false);
   auto update_end_state_uuid = task_graph.addNode(std::move(update_end_state_task));
 
   context.data_storage->setData(from_start_results.input_key, from_start_input);

--- a/tesseract_task_composer/planning/src/nodes/raster_motion_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/raster_motion_task.cpp
@@ -458,7 +458,7 @@ TaskComposerNodeInfo RasterMotionTask::runImpl(TaskComposerContext& context,
                                                                             transition_results.input_key,
                                                                             prev_output,
                                                                             next_output,
-                                                                            transition_results.output_key,
+                                                                            transition_results.input_key,
                                                                             false);
     auto transition_mux_uuid = task_graph.addNode(std::move(transition_mux_task));
 
@@ -482,7 +482,7 @@ TaskComposerNodeInfo RasterMotionTask::runImpl(TaskComposerContext& context,
   auto update_end_state_task = std::make_unique<UpdateEndStateTask>("UpdateEndStateTask",
                                                                     from_start_results.input_key,
                                                                     first_raster_output_key,
-                                                                    from_start_results.output_key,
+                                                                    from_start_results.input_key,
                                                                     false);
   auto update_end_state_uuid = task_graph.addNode(std::move(update_end_state_task));
 
@@ -508,7 +508,7 @@ TaskComposerNodeInfo RasterMotionTask::runImpl(TaskComposerContext& context,
 
   const auto& last_raster_output_key = raster_tasks.back().second.second;
   auto update_start_state_task = std::make_unique<UpdateStartStateTask>(
-      "UpdateStartStateTask", to_end_results.input_key, last_raster_output_key, to_end_results.output_key, false);
+      "UpdateStartStateTask", to_end_results.input_key, last_raster_output_key, to_end_results.input_key, false);
   auto update_start_state_uuid = task_graph.addNode(std::move(update_start_state_task));
 
   context.data_storage->setData(to_end_results.input_key, to_end_input);

--- a/tesseract_task_composer/planning/src/nodes/raster_only_motion_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/raster_only_motion_task.cpp
@@ -402,7 +402,7 @@ TaskComposerNodeInfo RasterOnlyMotionTask::runImpl(TaskComposerContext& context,
                                                                             transition_results.input_key,
                                                                             prev_output,
                                                                             next_output,
-                                                                            transition_results.output_key,
+                                                                            transition_results.input_key,
                                                                             false);
     auto transition_mux_uuid = task_graph.addNode(std::move(transition_mux_task));
 


### PR DESCRIPTION
I think the UpdateEndStateTask, UpdateStartStateTask, and UpdateStartAndEndStateTask tasks were all being incorrectly created in the raster_motion_task and raster_only_mostion_task source files. Previously, the UpdateXTasks would output the output key of the freespace tasks, meaning their changes would not actually get applied to the input of the upcoming subgraph. This issue is masked if all input/outputs use the same keys.

## Before:
![Screenshot from 2025-07-01 12-58-14](https://github.com/user-attachments/assets/68a0b017-a854-469b-bc5a-6e12ec412631)

## After:
![Screenshot from 2025-07-01 13-18-00](https://github.com/user-attachments/assets/3c4cde6c-8b74-4bc5-a9ef-f4009cfa19dc)
