### PR TITLE
Add trajopt joint configs for fix state collision task

### DIFF
--- a/tesseract_task_composer/planning/CMakeLists.txt
+++ b/tesseract_task_composer/planning/CMakeLists.txt
@@ -88,6 +88,7 @@ set(WINDOWS_DEPENDS
 if(tesseract_motion_planners_trajopt_FOUND)
   list(APPEND FACTORIES_SOURCE_FILES src/factories/planning_task_composer_trajopt_plugin_factory.cpp)
   list(APPEND FACTORIES_SOURCE_LINK_LIBRARIES tesseract::tesseract_motion_planners_trajopt)
+  list(APPEND LIB_SOURCE_LINK_LIBRARIES tesseract::tesseract_motion_planners_trajopt)
   list(APPEND LINUX_DEPENDS "${TESSERACT_PACKAGE_PREFIX}tesseract-motion-planners-trajopt")
   list(APPEND WINDOWS_DEPENDS "${TESSERACT_PACKAGE_PREFIX}tesseract-motion-planners-trajopt")
 endif()

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_collision_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_collision_profile.h
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_collision/core/types.h>
 #include <tesseract_common/profile.h>
+#include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
 
 namespace tesseract_planning
 {
@@ -87,6 +88,12 @@ struct FixStateCollisionProfile : public tesseract_common::Profile
 
   /** @brief Number of sampling attempts if TrajOpt correction fails*/
   int sampling_attempts{ 100 };
+
+  /** @brief The TrajOpt joint waypoint constraint config */
+  TrajOptJointWaypointConfig trajopt_joint_constraint_config;
+
+  /** @brief The TrajOpt joint waypoint cost config */
+  TrajOptJointWaypointConfig trajopt_joint_cost_config;
 
 private:
   friend class boost::serialization::access;

--- a/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
@@ -183,12 +183,55 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
     Eigen::VectorXd pos_tolerance = range * profile.jiggle_factor;
     Eigen::VectorXd neg_tolerance = range * -profile.jiggle_factor;
 
-    {  // Add Constraint
+    // Use trajopt_joint_constraint_config if enabled
+    if (profile.trajopt_joint_constraint_config.enabled)
+    {
       auto jp_cnt = std::make_shared<JointPosTermInfo>();
-      jp_cnt->coeffs = std::vector<double>(num_jnts, 1.0);
+      jp_cnt->coeffs = std::vector<double>(profile.trajopt_joint_constraint_config.coeff.data(),
+                                           profile.trajopt_joint_constraint_config.coeff.data() +
+                                               profile.trajopt_joint_constraint_config.coeff.size());
       jp_cnt->targets = std::vector<double>(start_pos.data(), start_pos.data() + start_pos.size());
-      jp_cnt->upper_tols = std::vector<double>(pos_tolerance.data(), pos_tolerance.data() + pos_tolerance.size());
-      jp_cnt->lower_tols = std::vector<double>(neg_tolerance.data(), neg_tolerance.data() + neg_tolerance.size());
+      if (profile.trajopt_joint_constraint_config.use_tolerance_override)
+      {
+        // Handle lower tolerance
+        if (profile.trajopt_joint_constraint_config.lower_tolerance.size() == 1)
+        {
+          jp_cnt->lower_tols =
+              std::vector<double>(start_pos.size(), profile.trajopt_joint_constraint_config.lower_tolerance[0]);
+        }
+        else if (profile.trajopt_joint_constraint_config.lower_tolerance.size() == start_pos.size())
+        {
+          jp_cnt->lower_tols = std::vector<double>(profile.trajopt_joint_constraint_config.lower_tolerance.data(),
+                                                   profile.trajopt_joint_constraint_config.lower_tolerance.data() +
+                                                       profile.trajopt_joint_constraint_config.lower_tolerance.size());
+        }
+        else
+        {
+          jp_cnt->lower_tols = std::vector<double>(neg_tolerance.data(), neg_tolerance.data() + neg_tolerance.size());
+        }
+
+        // Handle upper tolerance
+        if (profile.trajopt_joint_constraint_config.upper_tolerance.size() == 1)
+        {
+          jp_cnt->upper_tols =
+              std::vector<double>(start_pos.size(), profile.trajopt_joint_constraint_config.upper_tolerance[0]);
+        }
+        else if (profile.trajopt_joint_constraint_config.upper_tolerance.size() == start_pos.size())
+        {
+          jp_cnt->upper_tols = std::vector<double>(profile.trajopt_joint_constraint_config.upper_tolerance.data(),
+                                                   profile.trajopt_joint_constraint_config.upper_tolerance.data() +
+                                                       profile.trajopt_joint_constraint_config.upper_tolerance.size());
+        }
+        else
+        {
+          jp_cnt->upper_tols = std::vector<double>(pos_tolerance.data(), pos_tolerance.data() + pos_tolerance.size());
+        }
+      }
+      else
+      {
+        jp_cnt->lower_tols = std::vector<double>(neg_tolerance.data(), neg_tolerance.data() + neg_tolerance.size());
+        jp_cnt->upper_tols = std::vector<double>(pos_tolerance.data(), pos_tolerance.data() + pos_tolerance.size());
+      }
       jp_cnt->first_step = 0;
       jp_cnt->last_step = 0;
       jp_cnt->name = "joint_pos_cnt";
@@ -196,10 +239,50 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
       pci.cnt_infos.push_back(jp_cnt);
     }
 
-    {  // Add Costs
+    // Use trajopt_joint_cost_config if enabled
+    if (profile.trajopt_joint_cost_config.enabled)
+    {
       auto jp_cost = std::make_shared<JointPosTermInfo>();
-      jp_cost->coeffs = std::vector<double>(num_jnts, 5.0);
+      jp_cost->coeffs = std::vector<double>(profile.trajopt_joint_cost_config.coeff.data(),
+                                            profile.trajopt_joint_cost_config.coeff.data() +
+                                                profile.trajopt_joint_cost_config.coeff.size());
       jp_cost->targets = std::vector<double>(start_pos.data(), start_pos.data() + start_pos.size());
+      if (profile.trajopt_joint_cost_config.use_tolerance_override)
+      {
+        // Handle lower tolerance
+        if (profile.trajopt_joint_cost_config.lower_tolerance.size() == 1)
+        {
+          jp_cost->lower_tols =
+              std::vector<double>(start_pos.size(), profile.trajopt_joint_cost_config.lower_tolerance[0]);
+        }
+        else if (profile.trajopt_joint_cost_config.lower_tolerance.size() == start_pos.size())
+        {
+          jp_cost->lower_tols = std::vector<double>(profile.trajopt_joint_cost_config.lower_tolerance.data(),
+                                                    profile.trajopt_joint_cost_config.lower_tolerance.data() +
+                                                        profile.trajopt_joint_cost_config.lower_tolerance.size());
+        }
+        else
+        {
+          jp_cost->lower_tols = std::vector<double>(neg_tolerance.data(), neg_tolerance.data() + neg_tolerance.size());
+        }
+
+        // Handle upper tolerance
+        if (profile.trajopt_joint_cost_config.upper_tolerance.size() == 1)
+        {
+          jp_cost->upper_tols =
+              std::vector<double>(start_pos.size(), profile.trajopt_joint_cost_config.upper_tolerance[0]);
+        }
+        else if (profile.trajopt_joint_cost_config.upper_tolerance.size() == start_pos.size())
+        {
+          jp_cost->upper_tols = std::vector<double>(profile.trajopt_joint_cost_config.upper_tolerance.data(),
+                                                    profile.trajopt_joint_cost_config.upper_tolerance.data() +
+                                                        profile.trajopt_joint_cost_config.upper_tolerance.size());
+        }
+        else
+        {
+          jp_cost->upper_tols = std::vector<double>(pos_tolerance.data(), pos_tolerance.data() + pos_tolerance.size());
+        }
+      }
       jp_cost->first_step = 0;
       jp_cost->last_step = 0;
       jp_cost->name = "joint_pos_cost";

--- a/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
@@ -160,7 +160,6 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
     CONSOLE_BRIDGE_logError("MoveWaypointFromCollision error: %s", e.what());
     return false;
   }
-  auto num_jnts = static_cast<std::size_t>(start_pos.size());
 
   // Setup trajopt problem with basic info
   ProblemConstructionInfo pci(env);
@@ -196,8 +195,8 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
         // Handle lower tolerance
         if (profile.trajopt_joint_constraint_config.lower_tolerance.size() == 1)
         {
-          jp_cnt->lower_tols =
-              std::vector<double>(start_pos.size(), profile.trajopt_joint_constraint_config.lower_tolerance[0]);
+          jp_cnt->lower_tols = std::vector<double>(static_cast<std::size_t>(start_pos.size()),
+                                                   profile.trajopt_joint_constraint_config.lower_tolerance[0]);
         }
         else if (profile.trajopt_joint_constraint_config.lower_tolerance.size() == start_pos.size())
         {
@@ -213,8 +212,8 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
         // Handle upper tolerance
         if (profile.trajopt_joint_constraint_config.upper_tolerance.size() == 1)
         {
-          jp_cnt->upper_tols =
-              std::vector<double>(start_pos.size(), profile.trajopt_joint_constraint_config.upper_tolerance[0]);
+          jp_cnt->upper_tols = std::vector<double>(static_cast<std::size_t>(start_pos.size()),
+                                                   profile.trajopt_joint_constraint_config.upper_tolerance[0]);
         }
         else if (profile.trajopt_joint_constraint_config.upper_tolerance.size() == start_pos.size())
         {
@@ -252,8 +251,8 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
         // Handle lower tolerance
         if (profile.trajopt_joint_cost_config.lower_tolerance.size() == 1)
         {
-          jp_cost->lower_tols =
-              std::vector<double>(start_pos.size(), profile.trajopt_joint_cost_config.lower_tolerance[0]);
+          jp_cost->lower_tols = std::vector<double>(static_cast<std::size_t>(start_pos.size()),
+                                                    profile.trajopt_joint_cost_config.lower_tolerance[0]);
         }
         else if (profile.trajopt_joint_cost_config.lower_tolerance.size() == start_pos.size())
         {
@@ -269,8 +268,8 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
         // Handle upper tolerance
         if (profile.trajopt_joint_cost_config.upper_tolerance.size() == 1)
         {
-          jp_cost->upper_tols =
-              std::vector<double>(start_pos.size(), profile.trajopt_joint_cost_config.upper_tolerance[0]);
+          jp_cost->upper_tols = std::vector<double>(static_cast<std::size_t>(start_pos.size()),
+                                                    profile.trajopt_joint_cost_config.upper_tolerance[0]);
         }
         else if (profile.trajopt_joint_cost_config.upper_tolerance.size() == start_pos.size())
         {

--- a/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
@@ -39,6 +39,8 @@ FixStateCollisionProfile::FixStateCollisionProfile(Settings mode)
 {
   collision_check_config.contact_request.type = tesseract_collision::ContactTestType::FIRST;
   collision_check_config.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
+  trajopt_joint_constraint_config.coeff = Eigen::VectorXd::Constant(1, 1, 1);
+  trajopt_joint_cost_config.coeff = Eigen::VectorXd::Constant(1, 1, 5);
 }
 
 std::size_t FixStateCollisionProfile::getStaticKey()

--- a/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
@@ -55,6 +55,8 @@ void FixStateCollisionProfile::serialize(Archive& ar, const unsigned int /*versi
   ar& BOOST_SERIALIZATION_NVP(contact_manager_config);
   ar& BOOST_SERIALIZATION_NVP(collision_check_config);
   ar& BOOST_SERIALIZATION_NVP(sampling_attempts);
+  ar& BOOST_SERIALIZATION_NVP(trajopt_joint_constraint_config);
+  ar& BOOST_SERIALIZATION_NVP(trajopt_joint_cost_config);
 }
 
 }  // namespace tesseract_planning

--- a/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
@@ -29,6 +29,7 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/vector.hpp>
+#include <tesseract_common/eigen_serialization.h>
 #include <typeindex>
 
 namespace tesseract_planning


### PR DESCRIPTION
Previously the joint cost/constraint coefficients were hardcoded and the tolerance was hardcoded for all joints as the jiggle_factor. Also the tolerance only applied to the constraint and couldn't be applied to the cost. Also cost and constraints were always on for the joint waypoint. There are use cases where users are okay with the robot joint state moving more significantly, but they just want to find a somewhat close state out of collision. 