### PR TITLE
Fix missing export in kinematic_limits_check_task.h

### DIFF
--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/nodes/kinematic_limits_check_task.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/nodes/kinematic_limits_check_task.h
@@ -33,7 +33,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 namespace tesseract_planning
 {
 class TaskComposerPluginFactory;
-class KinematicLimitsCheckTask : public TaskComposerTask
+class TESSERACT_TASK_COMPOSER_PLANNING_NODES_EXPORT KinematicLimitsCheckTask : public TaskComposerTask
 {
 public:
   // Requried


### PR DESCRIPTION
The `KinematicsLimitsCheckTask` class was missing the Windows DLL export `TESSERACT_TASK_COMPOSER_PLANNING_NODES_EXPORT`.