### PR TITLE
Added Profiles constructors for YAML conversions

### DIFF
--- a/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/profile/ompl_profile.h
+++ b/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/profile/ompl_profile.h
@@ -31,6 +31,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <vector>
 #include <memory>
 #include <Eigen/Geometry>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/ompl/types.h>
@@ -41,6 +42,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/fwd.h>
 
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace ompl::geometric
 {
@@ -59,6 +61,7 @@ public:
   using ConstPtr = std::shared_ptr<const OMPLMoveProfile>;
 
   OMPLMoveProfile();
+  OMPLMoveProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/profile/ompl_real_vector_move_profile.h
+++ b/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/profile/ompl_real_vector_move_profile.h
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <functional>
 #include <Eigen/Geometry>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/ompl/profile/ompl_profile.h>
@@ -43,6 +44,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/fwd.h>
 #include <tesseract_kinematics/core/fwd.h>
 #include <tesseract_common/fwd.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace ompl::base
 {
@@ -67,6 +69,7 @@ public:
   using ConstPtr = std::shared_ptr<const OMPLRealVectorMoveProfile>;
 
   OMPLRealVectorMoveProfile();
+  OMPLRealVectorMoveProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /** @brief The OMPL parallel planner solver config */
   OMPLSolverConfig solver_config;

--- a/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/yaml_extensions.h
+++ b/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/yaml_extensions.h
@@ -1,0 +1,626 @@
+/**
+ * @file yaml_extensions.h
+ * @brief YAML Type conversions for OMPL types
+ *
+ * @author Samantha Smith
+ * @date July 29, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H
+#define TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <yaml-cpp/yaml.h>
+#include <set>
+#include <vector>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/plugin_info.h>
+#include <tesseract_motion_planners/ompl/ompl_solver_config.h>
+#include <tesseract_motion_planners/ompl/profile/ompl_real_vector_move_profile.h>
+#include <tesseract_motion_planners/ompl/ompl_planner_configurator.h>
+#include <tesseract_common/profile_plugin_factory.h>
+
+
+
+namespace YAML
+{
+//=========================== SBLConfigurator ===========================
+template <>
+struct convert<tesseract_planning::SBLConfigurator>
+{
+  static Node encode(const tesseract_planning::SBLConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::SBLConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== ESTConfigurator ===========================
+template <>
+struct convert<tesseract_planning::ESTConfigurator>
+{
+  static Node encode(const tesseract_planning::ESTConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["goal_bias"] = rhs.goal_bias;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::ESTConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["goal_bias"])
+      rhs.goal_bias = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== LBKPIECE1Configurator ===========================
+template <>
+struct convert<tesseract_planning::LBKPIECE1Configurator>
+{
+  static Node encode(const tesseract_planning::LBKPIECE1Configurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["border_fraction"] = rhs.border_fraction;
+    node["min_valid_path_fraction"] = rhs.min_valid_path_fraction;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::LBKPIECE1Configurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["border_fraction"])
+      rhs.border_fraction = n.as<double>();
+    if (const YAML::Node& n = node["min_valid_path_fraction"])
+      rhs.min_valid_path_fraction = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== BKPIECE1Configurator ===========================
+template <>
+struct convert<tesseract_planning::BKPIECE1Configurator>
+{
+  static Node encode(const tesseract_planning::BKPIECE1Configurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["border_fraction"] = rhs.border_fraction;
+    node["failed_expansion_score_factor"] = rhs.failed_expansion_score_factor;
+    node["min_valid_path_fraction"] = rhs.min_valid_path_fraction;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::BKPIECE1Configurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["border_fraction"])
+      rhs.border_fraction = n.as<double>();
+    if (const YAML::Node& n = node["min_valid_path_fraction"])
+      rhs.min_valid_path_fraction = n.as<double>();
+    if (const YAML::Node& n = node["failed_expansion_score_factor"])
+      rhs.failed_expansion_score_factor = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== KPIECE1Configurator ===========================
+template <>
+struct convert<tesseract_planning::KPIECE1Configurator>
+{
+  static Node encode(const tesseract_planning::KPIECE1Configurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["goal_bias"] = rhs.goal_bias;
+    node["border_fraction"] = rhs.border_fraction;
+    node["failed_expansion_score_factor"] = rhs.failed_expansion_score_factor;
+    node["min_valid_path_fraction"] = rhs.min_valid_path_fraction;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::KPIECE1Configurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["border_fraction"])
+      rhs.border_fraction = n.as<double>();
+    if (const YAML::Node& n = node["min_valid_path_fraction"])
+      rhs.min_valid_path_fraction = n.as<double>();
+    if (const YAML::Node& n = node["failed_expansion_score_factor"])
+      rhs.failed_expansion_score_factor = n.as<double>();
+    if (const YAML::Node& n = node["goal_bias"])
+      rhs.goal_bias = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== BiTRRTConfigurator ===========================
+template <>
+struct convert<tesseract_planning::BiTRRTConfigurator>
+{
+  static Node encode(const tesseract_planning::BiTRRTConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["temp_change_factor"] = rhs.temp_change_factor;
+    node["cost_threshold"] = rhs.cost_threshold;
+    node["init_temperature"] = rhs.init_temperature;
+    node["frontier_threshold"] = rhs.frontier_threshold;
+    node["frontier_node_ratio"] = rhs.frontier_node_ratio;
+
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::BiTRRTConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["temp_change_factor"])
+      rhs.temp_change_factor = n.as<double>();
+    if (const YAML::Node& n = node["cost_threshold"])
+      rhs.cost_threshold = n.as<double>();
+    if (const YAML::Node& n = node["init_temperature"])
+      rhs.init_temperature = n.as<double>();
+    if (const YAML::Node& n = node["frontier_threshold"])
+      rhs.frontier_threshold = n.as<double>();
+    if (const YAML::Node& n = node["frontier_node_ratio"])
+      rhs.frontier_node_ratio = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== RRTConfigurator ===========================
+template <>
+struct convert<tesseract_planning::RRTConfigurator>
+{
+  static Node encode(const tesseract_planning::RRTConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["goal_bias"] = rhs.goal_bias;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::RRTConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["goal_bias"])
+      rhs.goal_bias = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== RRTConnectConfigurator ===========================
+template <>
+struct convert<tesseract_planning::RRTConnectConfigurator>
+{
+  static Node encode(const tesseract_planning::RRTConnectConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::RRTConnectConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== RRTstarConfigurator ===========================
+template <>
+struct convert<tesseract_planning::RRTstarConfigurator>
+{
+  static Node encode(const tesseract_planning::RRTstarConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["goal_bias"] = rhs.goal_bias;
+    node["delay_collision_checking"] = rhs.delay_collision_checking;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::RRTstarConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["goal_bias"])
+      rhs.goal_bias = n.as<double>();
+    if (const YAML::Node& n = node["delay_collision_checking"])
+      rhs.delay_collision_checking = n.as<bool>();
+    return true;
+  }
+};
+
+//=========================== TRRTConfigurator ===========================
+template <>
+struct convert<tesseract_planning::TRRTConfigurator>
+{
+  static Node encode(const tesseract_planning::TRRTConfigurator& rhs)
+  {
+    Node node;
+    node["range"] = rhs.range;
+    node["goal_bias"] = rhs.goal_bias;
+    node["temp_change_factor"] = rhs.temp_change_factor;
+    node["init_temperature"] = rhs.init_temperature;
+    node["frontier_threshold"] = rhs.frontier_threshold;
+    node["frontier_node_ratio"] = rhs.frontier_node_ratio;
+
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::TRRTConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["range"])
+      rhs.range = n.as<double>();
+    if (const YAML::Node& n = node["goal_bias"])
+      rhs.goal_bias = n.as<double>();
+    if (const YAML::Node& n = node["temp_change_factor"])
+      rhs.temp_change_factor = n.as<double>();
+    if (const YAML::Node& n = node["init_temperature"])
+      rhs.init_temperature = n.as<double>();
+    if (const YAML::Node& n = node["frontier_threshold"])
+      rhs.frontier_threshold = n.as<double>();
+    if (const YAML::Node& n = node["frontier_node_ratio"])
+      rhs.frontier_node_ratio = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== PRMConfigurator ===========================
+template <>
+struct convert<tesseract_planning::PRMConfigurator>
+{
+  static Node encode(const tesseract_planning::PRMConfigurator& rhs)
+  {
+    Node node;
+    node["max_nearest_neighbors"] = rhs.max_nearest_neighbors;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::PRMConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["max_nearest_neighbors"])
+      rhs.max_nearest_neighbors = n.as<int>();
+    return true;
+  }
+};
+
+
+//=========================== PRMstarConfigurator ===========================
+template <>
+struct convert<tesseract_planning::PRMstarConfigurator>
+{
+  static Node encode(const tesseract_planning::PRMstarConfigurator& rhs)
+  {
+    Node node;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::PRMstarConfigurator& rhs)
+  {
+    // Check for required entries
+    return true;
+  }
+};
+
+//=========================== LazyPRMstarConfigurator ===========================
+template <>
+struct convert<tesseract_planning::LazyPRMstarConfigurator>
+{
+  static Node encode(const tesseract_planning::LazyPRMstarConfigurator& rhs)
+  {
+    Node node;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::LazyPRMstarConfigurator& rhs)
+  {
+    // Check for required entries
+    return true;
+  }
+};
+
+//=========================== SPARSConfigurator ===========================
+template <>
+struct convert<tesseract_planning::SPARSConfigurator>
+{
+  static Node encode(const tesseract_planning::SPARSConfigurator& rhs)
+  {
+    Node node;
+    node["max_failures"] = rhs.max_failures;
+    node["dense_delta_fraction"] = rhs.dense_delta_fraction;
+    node["sparse_delta_fraction"] = rhs.sparse_delta_fraction;
+    node["stretch_factor"] = rhs.stretch_factor;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::SPARSConfigurator& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["max_failures"])
+      rhs.max_failures = n.as<int>();
+    if (const YAML::Node& n = node["dense_delta_fraction"])
+      rhs.dense_delta_fraction = n.as<double>();
+    if (const YAML::Node& n = node["sparse_delta_fraction"])
+      rhs.sparse_delta_fraction = n.as<double>();
+    if (const YAML::Node& n = node["stretch_factor"])
+      rhs.stretch_factor = n.as<double>();
+    return true;
+  }
+};
+
+//=========================== OMPLPlannerConfigurator ===========================
+template <>
+struct convert<std::vector<std::shared_ptr<const tesseract_planning::OMPLPlannerConfigurator>>>
+{
+  static Node encode(const std::vector<std::shared_ptr<const tesseract_planning::OMPLPlannerConfigurator>>& rhs)
+  {
+    Node node;
+    for (const auto& ompl_configurator : rhs)
+    {
+      Node p_node;
+      bool valid_type = true;
+      tesseract_planning::OMPLPlannerType type = ompl_configurator->getType();
+
+      switch (type) {
+        case tesseract_planning::OMPLPlannerType::SBL:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::SBLConfigurator>(ompl_configurator);
+            p_node["SBLConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::EST:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::ESTConfigurator>(ompl_configurator);
+            p_node["ESTConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::LBKPIECE1:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::LBKPIECE1Configurator>(ompl_configurator);
+            p_node["LBKPIECE1Configurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::BKPIECE1:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::BKPIECE1Configurator>(ompl_configurator);
+            p_node["BKPIECE1Configurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::KPIECE1:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::KPIECE1Configurator>(ompl_configurator);
+            p_node["KPIECE1Configurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::BiTRRT:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::BiTRRTConfigurator>(ompl_configurator);
+            p_node["BiTRRTConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::RRT:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::RRTConfigurator>(ompl_configurator);
+            p_node["RRTConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::RRTConnect:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::RRTConnectConfigurator>(ompl_configurator);
+            p_node["RRTConnectConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::RRTstar:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::RRTstarConfigurator>(ompl_configurator);
+            p_node["RRTstarConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::TRRT:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::TRRTConfigurator>(ompl_configurator);
+            p_node["TRRTConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::PRM:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::PRMConfigurator>(ompl_configurator);
+            p_node["PRMConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::PRMstar:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::PRMstarConfigurator>(ompl_configurator);
+            p_node["PRMstarConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::LazyPRMstar:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::LazyPRMstarConfigurator>(ompl_configurator);
+            p_node["LazyPRMstarConfigurator"] = *planner;
+            break;
+          }
+        case tesseract_planning::OMPLPlannerType::SPARS:
+          {
+            auto planner = std::dynamic_pointer_cast<const tesseract_planning::SPARSConfigurator>(ompl_configurator);
+            p_node["SPARSConfigurator"] = *planner;
+            break;
+          }
+        default:
+          valid_type = false;
+          break;
+      }
+      node.push_back(p_node);
+    }
+
+    return node;
+  }
+
+  static bool decode(const Node& node, std::vector<std::shared_ptr<const tesseract_planning::OMPLPlannerConfigurator>>& rhs)
+  {
+    // Check for required entries
+    for (const auto& planner : node)
+    {
+      if (const YAML::Node& n = planner["SBLConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::SBLConfigurator>(n.as<tesseract_planning::SBLConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["ESTConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::ESTConfigurator>(n.as<tesseract_planning::ESTConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["LBKPIECE1Configurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::LBKPIECE1Configurator>(n.as<tesseract_planning::LBKPIECE1Configurator>())));
+      }
+      else if (const YAML::Node& n = planner["BKPIECE1Configurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::BKPIECE1Configurator>(n.as<tesseract_planning::BKPIECE1Configurator>())));
+      }
+      else if (const YAML::Node& n = planner["KPIECE1Configurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::KPIECE1Configurator>(n.as<tesseract_planning::KPIECE1Configurator>())));
+      }
+      else if (const YAML::Node& n = planner["BiTRRTConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::BiTRRTConfigurator>(n.as<tesseract_planning::BiTRRTConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["RRTConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::RRTConfigurator>(n.as<tesseract_planning::RRTConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["RRTConnectConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::RRTConnectConfigurator>(n.as<tesseract_planning::RRTConnectConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["RRTstarConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::RRTstarConfigurator>(n.as<tesseract_planning::RRTstarConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["TRRTConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::TRRTConfigurator>(n.as<tesseract_planning::TRRTConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["PRMConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::PRMConfigurator>(n.as<tesseract_planning::PRMConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["PRMstarConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::PRMstarConfigurator>(n.as<tesseract_planning::PRMstarConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["LazyPRMstarConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::LazyPRMstarConfigurator>(n.as<tesseract_planning::LazyPRMstarConfigurator>())));
+      }
+      else if (const YAML::Node& n = planner["SPARSConfigurator"]) 
+      {
+        rhs.push_back(std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::SPARSConfigurator>(n.as<tesseract_planning::SPARSConfigurator>())));
+      }
+    }
+
+    return true;
+  }
+};
+
+//=========================== OMPLSolverConfig ===========================
+template <>
+struct convert<tesseract_planning::OMPLSolverConfig>
+{
+  static Node encode(const tesseract_planning::OMPLSolverConfig& rhs)
+  {
+    Node node;
+
+    node["planning_time"] = rhs.planning_time;
+    node["max_solutions"] = rhs.max_solutions;
+    node["simplify"] = rhs.simplify;
+    node["optimize"] = rhs.optimize;
+    node["planners"] = rhs.planners;
+    
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::OMPLSolverConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["planning_time"])
+      rhs.planning_time = n.as<double>();
+    if (const YAML::Node& n = node["max_solutions"])
+      rhs.max_solutions = n.as<int>();
+    if (const YAML::Node& n = node["simplify"])
+      rhs.simplify = n.as<bool>();
+    if (const YAML::Node& n = node["optimize"])
+      rhs.optimize = n.as<bool>();
+    if (const YAML::Node& n = node["planners"])
+      rhs.planners = n.as<std::vector<std::shared_ptr<const tesseract_planning::OMPLPlannerConfigurator>>>();
+    return true;
+  }
+};
+
+}  // namespace YAML
+
+#endif  // TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H

--- a/tesseract_motion_planners/ompl/src/profile/ompl_profile.cpp
+++ b/tesseract_motion_planners/ompl/src/profile/ompl_profile.cpp
@@ -32,6 +32,9 @@
 namespace tesseract_planning
 {
 OMPLMoveProfile::OMPLMoveProfile() : Profile(OMPLMoveProfile::getStaticKey()) {}
+OMPLMoveProfile::OMPLMoveProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/) 
+  : OMPLMoveProfile::OMPLMoveProfile()
+{}
 
 std::size_t OMPLMoveProfile::getStaticKey() { return std::type_index(typeid(OMPLMoveProfile)).hash_code(); }
 

--- a/tesseract_motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
+++ b/tesseract_motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
@@ -55,6 +55,9 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/ompl/state_collision_validator.h>
 #include <tesseract_motion_planners/ompl/compound_state_validator.h>
 
+#include <tesseract_motion_planners/ompl/yaml_extensions.h>
+#include <tesseract_collision/core/yaml_extensions.h>
+
 #include <tesseract_kinematics/core/utils.h>
 #include <tesseract_kinematics/core/joint_group.h>
 #include <tesseract_kinematics/core/kinematic_group.h>
@@ -68,6 +71,26 @@ OMPLRealVectorMoveProfile::OMPLRealVectorMoveProfile()
 {
   solver_config.planners = { std::make_shared<const RRTConnectConfigurator>(),
                              std::make_shared<const RRTConnectConfigurator>() };
+}
+OMPLRealVectorMoveProfile::OMPLRealVectorMoveProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+: OMPLRealVectorMoveProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["solver_config"])
+      solver_config = n.as<tesseract_planning::OMPLSolverConfig>();
+
+    if (YAML::Node n = config["contact_manager_config"])
+      contact_manager_config = n.as<tesseract_collision::ContactManagerConfig>();
+      
+    if (YAML::Node n = config["collision_check_config"])
+      collision_check_config = n.as<tesseract_collision::CollisionCheckConfig>();
+
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("OMPLRealVectorMoveProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
 }
 
 std::unique_ptr<OMPLSolverConfig> OMPLRealVectorMoveProfile::createSolverConfig() const

--- a/tesseract_motion_planners/ompl/test/CMakeLists.txt
+++ b/tesseract_motion_planners/ompl/test/CMakeLists.txt
@@ -17,6 +17,24 @@ add_gtest_discover_tests(${PROJECT_NAME}_ompl_unit)
 add_dependencies(${PROJECT_NAME}_ompl_unit ${PROJECT_NAME}_ompl)
 add_dependencies(run_tests ${PROJECT_NAME}_ompl_unit)
 
+# OMPL YAML Unit tests
+add_executable(${PROJECT_NAME}_ompl_yaml_unit ompl_yaml_conversions_tests.cpp)
+target_link_libraries(${PROJECT_NAME}_ompl_yaml_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME}_ompl)
+target_compile_options(${PROJECT_NAME}_ompl_yaml_unit PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
+                                                         ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_compile_definitions(${PROJECT_NAME}_ompl_yaml_unit PRIVATE ${TESSERACT_COMPILE_DEFINITIONS})
+target_clang_tidy(${PROJECT_NAME}_ompl_yaml_unit ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_ompl_yaml_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}_ompl_yaml_unit
+  PRIVATE
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+add_gtest_discover_tests(${PROJECT_NAME}_ompl_yaml_unit)
+add_dependencies(${PROJECT_NAME}_ompl_yaml_unit ${PROJECT_NAME}_ompl)
+add_dependencies(run_tests ${PROJECT_NAME}_ompl_yaml_unit)
+
 # OMPL Constrained Planning Test/Example Program if(NOT OMPL_VERSION VERSION_LESS "1.4.0")
 # add_executable(${PROJECT_NAME}_ompl_constrained_unit ompl_constrained_planner_tests.cpp)
 # target_link_libraries(${PROJECT_NAME}_ompl_constrained_unit PRIVATE Boost::boost Boost::serialization Boost::system

--- a/tesseract_motion_planners/ompl/test/ompl_yaml_conversions_tests.cpp
+++ b/tesseract_motion_planners/ompl/test/ompl_yaml_conversions_tests.cpp
@@ -1,0 +1,764 @@
+/**
+ * @file ompl_yaml_conversions_tests.cpp
+ * @brief This contains unit test for the tesseract ompl planner yaml conversions
+ *
+ * @author Samantha Smith
+ * @date July 29, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <ompl/geometric/planners/sbl/SBL.h>
+#include <ompl/geometric/planners/est/EST.h>
+#include <ompl/geometric/planners/kpiece/LBKPIECE1.h>
+#include <ompl/geometric/planners/kpiece/BKPIECE1.h>
+#include <ompl/geometric/planners/kpiece/KPIECE1.h>
+#include <ompl/geometric/planners/rrt/RRT.h>
+#include <ompl/geometric/planners/rrt/RRTConnect.h>
+#include <ompl/geometric/planners/rrt/RRTstar.h>
+#include <ompl/geometric/planners/rrt/TRRT.h>
+#include <ompl/geometric/planners/prm/PRM.h>
+#include <ompl/geometric/planners/prm/PRMstar.h>
+#include <ompl/geometric/planners/prm/LazyPRMstar.h>
+#include <ompl/geometric/planners/prm/SPARS.h>
+
+#include <ompl/util/RandomNumbers.h>
+
+#include <functional>
+#include <cmath>
+#include <gtest/gtest.h>
+#include <console_bridge/console.h>
+#include <yaml-cpp/yaml.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/types.h>
+#include <tesseract_common/profile_dictionary.h>
+
+#include <tesseract_kinematics/core/joint_group.h>
+#include <tesseract_kinematics/core/kinematic_group.h>
+
+#include <tesseract_scene_graph/link.h>
+#include <tesseract_scene_graph/joint.h>
+
+#include <tesseract_environment/environment.h>
+#include <tesseract_environment/utils.h>
+#include <tesseract_environment/commands/add_link_command.h>
+
+#include <tesseract_motion_planners/ompl/ompl_motion_planner.h>
+#include <tesseract_motion_planners/ompl/ompl_planner_configurator.h>
+#include <tesseract_motion_planners/ompl/profile/ompl_real_vector_move_profile.h>
+
+#include <tesseract_motion_planners/core/types.h>
+#include <tesseract_motion_planners/core/utils.h>
+#include <tesseract_motion_planners/simple/interpolation.h>
+
+#include <tesseract_command_language/cartesian_waypoint.h>
+#include <tesseract_command_language/joint_waypoint.h>
+#include <tesseract_command_language/move_instruction.h>
+#include <tesseract_command_language/utils.h>
+
+#include <tesseract_motion_planners/ompl/yaml_extensions.h>
+
+using namespace tesseract_scene_graph;
+using namespace tesseract_collision;
+using namespace tesseract_environment;
+using namespace tesseract_geometry;
+using namespace tesseract_kinematics;
+using namespace tesseract_planning;
+
+class OMPLYAMLTestFixture : public ::testing::Test
+{
+public:
+  OMPLYAMLTestFixture() {}
+  using ::testing::Test::Test;
+};
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLSBLConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    SBLConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+  }
+
+  const std::string yaml_string = R"(range: 1.0
+                                    )";
+  {  // decode
+    SBLConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<SBLConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+  }
+
+  {  // encode
+    SBLConfigurator configurator;
+    configurator.range = 1.0;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<SBLConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLESTConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    ESTConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.goal_bias, 0.05);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    goal_bias: 0.04
+                                    )";
+  {  // decode
+    ESTConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<ESTConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.goal_bias, 0.04);
+  }
+
+  {  // encode
+    ESTConfigurator configurator;
+    configurator.range = 1.0;
+    configurator.goal_bias = 0.04;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<ESTConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["goal_bias"].as<double>(), 0.04);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLLBKPIECE1ConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    LBKPIECE1Configurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.border_fraction, 0.9);
+    EXPECT_EQ(configurator.min_valid_path_fraction, 0.5);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    border_fraction: 0.04
+                                    min_valid_path_fraction: 0.05
+                                    )";
+  {  // decode
+    LBKPIECE1Configurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<LBKPIECE1Configurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.border_fraction, 0.04);
+    EXPECT_EQ(configurator.min_valid_path_fraction, 0.05);
+
+  }
+
+  {  // encode
+    LBKPIECE1Configurator configurator;
+    configurator.range = 1.0;
+    configurator.border_fraction = 0.04;
+    configurator.min_valid_path_fraction = 0.05;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<LBKPIECE1Configurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["border_fraction"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["min_valid_path_fraction"].as<double>(), 0.05);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLBKPIECE1ConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    BKPIECE1Configurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.border_fraction, 0.9);
+    EXPECT_EQ(configurator.failed_expansion_score_factor, 0.5);
+    EXPECT_EQ(configurator.min_valid_path_fraction, 0.5);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    border_fraction: 0.04
+                                    failed_expansion_score_factor: 0.6
+                                    min_valid_path_fraction: 0.05
+                                    )";
+  {  // decode
+    BKPIECE1Configurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<BKPIECE1Configurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.border_fraction, 0.04);
+    EXPECT_EQ(configurator.failed_expansion_score_factor, 0.6);
+    EXPECT_EQ(configurator.min_valid_path_fraction, 0.05);
+
+  }
+
+  {  // encode
+    BKPIECE1Configurator configurator;
+    configurator.range = 1.0;
+    configurator.border_fraction = 0.04;
+    configurator.failed_expansion_score_factor = 0.6;
+    configurator.min_valid_path_fraction = 0.05;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<BKPIECE1Configurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["border_fraction"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["failed_expansion_score_factor"].as<double>(), 0.6);
+    EXPECT_EQ(output_n["min_valid_path_fraction"].as<double>(), 0.05);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLKPIECE1ConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    KPIECE1Configurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.goal_bias, 0.05);
+    EXPECT_EQ(configurator.border_fraction, 0.9);
+    EXPECT_EQ(configurator.failed_expansion_score_factor, 0.5);
+    EXPECT_EQ(configurator.min_valid_path_fraction, 0.5);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    goal_bias: 0.04
+                                    border_fraction: 0.04
+                                    failed_expansion_score_factor: 0.6
+                                    min_valid_path_fraction: 0.05
+                                    )";
+  {  // decode
+    KPIECE1Configurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<KPIECE1Configurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.goal_bias, 0.04);
+    EXPECT_EQ(configurator.border_fraction, 0.04);
+    EXPECT_EQ(configurator.failed_expansion_score_factor, 0.6);
+    EXPECT_EQ(configurator.min_valid_path_fraction, 0.05);
+
+  }
+
+  {  // encode
+    KPIECE1Configurator configurator;
+    configurator.range = 1.0;
+    configurator.goal_bias = 0.04;
+    configurator.border_fraction = 0.04;
+    configurator.failed_expansion_score_factor = 0.6;
+    configurator.min_valid_path_fraction = 0.05;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<KPIECE1Configurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["goal_bias"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["border_fraction"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["failed_expansion_score_factor"].as<double>(), 0.6);
+    EXPECT_EQ(output_n["min_valid_path_fraction"].as<double>(), 0.05);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLBiTRRTConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    BiTRRTConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.temp_change_factor, 0.1);
+    EXPECT_EQ(configurator.cost_threshold, std::numeric_limits<double>::infinity());
+    EXPECT_EQ(configurator.init_temperature, 100.0);
+    EXPECT_EQ(configurator.frontier_threshold, 0.0);
+    EXPECT_EQ(configurator.frontier_node_ratio, 0.1);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    temp_change_factor: 0.04
+                                    cost_threshold: 0.04
+                                    init_temperature: 0.6
+                                    frontier_threshold: 0.05
+                                    frontier_node_ratio: 0.5
+                                    )";
+  {  // decode
+    BiTRRTConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<BiTRRTConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.temp_change_factor, 0.04);
+    EXPECT_EQ(configurator.cost_threshold, 0.04);
+    EXPECT_EQ(configurator.init_temperature, 0.6);
+    EXPECT_EQ(configurator.frontier_threshold, 0.05);
+    EXPECT_EQ(configurator.frontier_node_ratio, 0.5);
+
+  }
+
+  {  // encode
+    BiTRRTConfigurator configurator;
+    configurator.range = 1.0;
+    configurator.temp_change_factor = 0.04;
+    configurator.cost_threshold = 0.04;
+    configurator.init_temperature = 0.6;
+    configurator.frontier_threshold = 0.05;
+    configurator.frontier_node_ratio = 0.5;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<BiTRRTConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["temp_change_factor"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["cost_threshold"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["init_temperature"].as<double>(), 0.6);
+    EXPECT_EQ(output_n["frontier_threshold"].as<double>(), 0.05);
+    EXPECT_EQ(output_n["frontier_node_ratio"].as<double>(), 0.5);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLRRTConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    RRTConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.goal_bias, 0.05);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    goal_bias: 0.04
+                                    )";
+  {  // decode
+    RRTConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<RRTConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.goal_bias, 0.04);
+  }
+
+  {  // encode
+    RRTConfigurator configurator;
+    configurator.range = 1.0;
+    configurator.goal_bias = 0.04;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<RRTConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["goal_bias"].as<double>(), 0.04);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLRRTConnectConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    RRTConnectConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+  }
+
+  const std::string yaml_string = R"(range: 1.0
+                                    )";
+  {  // decode
+    RRTConnectConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<RRTConnectConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+  }
+
+  {  // encode
+    RRTConnectConfigurator configurator;
+    configurator.range = 1.0;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<RRTConnectConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLRRTstarConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    RRTstarConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.goal_bias, 0.05);
+    EXPECT_EQ(configurator.delay_collision_checking, true);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    goal_bias: 0.04
+                                    delay_collision_checking: false
+                                    )";
+  {  // decode
+    RRTstarConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<RRTstarConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.goal_bias, 0.04);
+    EXPECT_EQ(configurator.delay_collision_checking, false);
+  }
+
+  {  // encode
+    RRTstarConfigurator configurator;
+    configurator.range = 1.0;
+    configurator.goal_bias = 0.04;
+    configurator.delay_collision_checking = false;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<RRTstarConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["goal_bias"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["delay_collision_checking"].as<bool>(), false);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLTRRTConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    TRRTConfigurator configurator;
+
+    EXPECT_EQ(configurator.range, 0);
+    EXPECT_EQ(configurator.temp_change_factor, 2.0);
+    EXPECT_EQ(configurator.goal_bias, 0.05);
+    EXPECT_EQ(configurator.init_temperature, 10e-6);
+    EXPECT_EQ(configurator.frontier_threshold, 0.0);
+    EXPECT_EQ(configurator.frontier_node_ratio, 0.1);
+  }
+
+  const std::string yaml_string = R"(
+                                    range: 1.0
+                                    goal_bias: 0.03
+                                    temp_change_factor: 0.04
+                                    init_temperature: 0.6
+                                    frontier_threshold: 0.05
+                                    frontier_node_ratio: 0.5
+                                    )";
+  {  // decode
+    TRRTConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<TRRTConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.range, 1.0);
+    EXPECT_EQ(configurator.goal_bias, 0.03);
+    EXPECT_EQ(configurator.temp_change_factor, 0.04);
+    EXPECT_EQ(configurator.init_temperature, 0.6);
+    EXPECT_EQ(configurator.frontier_threshold, 0.05);
+    EXPECT_EQ(configurator.frontier_node_ratio, 0.5);
+
+  }
+
+  {  // encode
+    TRRTConfigurator configurator;
+    configurator.range = 1.0;
+    configurator.goal_bias = 0.03;
+    configurator.temp_change_factor = 0.04;
+    configurator.init_temperature = 0.6;
+    configurator.frontier_threshold = 0.05;
+    configurator.frontier_node_ratio = 0.5;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<TRRTConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["range"].as<double>(), 1.0);
+    EXPECT_EQ(output_n["goal_bias"].as<double>(), 0.03);
+    EXPECT_EQ(output_n["goal_bias"].as<double>(), 0.03);
+    EXPECT_EQ(output_n["temp_change_factor"].as<double>(), 0.04);
+    EXPECT_EQ(output_n["init_temperature"].as<double>(), 0.6);
+    EXPECT_EQ(output_n["frontier_threshold"].as<double>(), 0.05);
+    EXPECT_EQ(output_n["frontier_node_ratio"].as<double>(), 0.5);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLPRMConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    PRMConfigurator configurator;
+
+    EXPECT_EQ(configurator.max_nearest_neighbors, 10);
+  }
+
+  const std::string yaml_string = R"(max_nearest_neighbors: 1
+                                    )";
+  {  // decode
+    PRMConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<PRMConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.max_nearest_neighbors, 1);
+  }
+
+  {  // encode
+    PRMConfigurator configurator;
+    configurator.max_nearest_neighbors = 1;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<PRMConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["max_nearest_neighbors"].as<int>(), 1);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLPRMstarConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    PRMstarConfigurator configurator;
+  }
+
+  const std::string yaml_string = R"()";
+  {  // decode
+    PRMstarConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<PRMstarConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+  }
+
+  {  // encode
+    PRMstarConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<PRMstarConfigurator>::encode(configurator);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLLazyPRMstarConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    LazyPRMstarConfigurator configurator;
+  }
+
+  const std::string yaml_string = R"()";
+  {  // decode
+    LazyPRMstarConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<LazyPRMstarConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+  }
+
+  {  // encode
+    LazyPRMstarConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<LazyPRMstarConfigurator>::encode(configurator);
+  }
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLSPARSConfiguratorConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    SPARSConfigurator configurator;
+
+    EXPECT_EQ(configurator.max_failures, 1000);
+    EXPECT_EQ(configurator.dense_delta_fraction, 0.001);
+    EXPECT_EQ(configurator.sparse_delta_fraction, 0.25);
+    EXPECT_EQ(configurator.stretch_factor, 3);
+
+  }
+
+  const std::string yaml_string = R"(
+                                     max_failures: 1
+                                     dense_delta_fraction: 0.5
+                                     sparse_delta_fraction: 0.4
+                                     stretch_factor: 0.3
+                                    )";
+  {  // decode
+    SPARSConfigurator configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<SPARSConfigurator>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.max_failures, 1);
+    EXPECT_EQ(configurator.dense_delta_fraction, 0.5);
+    EXPECT_EQ(configurator.sparse_delta_fraction, 0.4);
+    EXPECT_EQ(configurator.stretch_factor, 0.3);
+
+  }
+
+  {  // encode
+    SPARSConfigurator configurator;
+    configurator.max_failures = 1;
+    configurator.dense_delta_fraction = 0.5;
+    configurator.sparse_delta_fraction = 0.4;
+    configurator.stretch_factor = 0.3;
+
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<SPARSConfigurator>::encode(configurator);
+    EXPECT_EQ(output_n["max_failures"].as<int>(), 1);
+    EXPECT_EQ(output_n["dense_delta_fraction"].as<double>(), 0.5);
+    EXPECT_EQ(output_n["sparse_delta_fraction"].as<double>(), 0.4);
+    EXPECT_EQ(output_n["stretch_factor"].as<double>(), 0.3);
+  }
+}
+
+bool containsType(OMPLPlannerType type, std::vector<std::shared_ptr<const tesseract_planning::OMPLPlannerConfigurator>> planners)
+{
+  for (const auto& planner : planners) {
+    if (planner->getType() == type) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool containsPlanner(std::string planner_type, YAML::Node n) {
+  return std::any_of(
+                    n.begin(),
+                    n.end(),
+                    [planner_type](const YAML::Node& n) { return n[planner_type]; }
+                  );
+}
+
+TEST(OMPLYAMLTestFixture, OMPLYAMLOMPLSolverConfigConversionsUnit)  // NOLINT
+{
+  { // Constructor
+    OMPLSolverConfig configurator;
+
+    EXPECT_EQ(configurator.planning_time, 5.0);
+    EXPECT_EQ(configurator.max_solutions, 10);
+    EXPECT_EQ(configurator.simplify, false);
+    EXPECT_EQ(configurator.optimize, true);
+    EXPECT_EQ(configurator.planners.size(), 0);
+
+  }
+
+  const std::string yaml_string = R"(
+                                     planning_time: 2.0
+                                     max_solutions: 4
+                                     simplify: true
+                                     optimize: false
+                                     planners:
+                                       - SBLConfigurator: {}
+                                       - ESTConfigurator: {}
+                                       - LBKPIECE1Configurator: {}
+                                       - BKPIECE1Configurator: {}
+                                       - KPIECE1Configurator: {}
+                                       - BiTRRTConfigurator: {}
+                                       - RRTConfigurator: {}
+                                       - RRTConnectConfigurator: {}
+                                       - RRTstarConfigurator: {}
+                                       - TRRTConfigurator: {}
+                                       - PRMConfigurator: {}
+                                       - PRMstarConfigurator: {}
+                                       - LazyPRMstarConfigurator: {}
+                                       - SPARSConfigurator: {}
+                                    )";
+
+  {  // decode
+    OMPLSolverConfig configurator;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<OMPLSolverConfig>::decode(n, configurator);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(configurator.planning_time, 2.0);
+    EXPECT_EQ(configurator.max_solutions, 4);
+    EXPECT_EQ(configurator.simplify, true);
+    EXPECT_EQ(configurator.optimize, false);
+    EXPECT_EQ(containsType(OMPLPlannerType::SBL, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::EST, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::LBKPIECE1, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::BKPIECE1, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::KPIECE1, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::BiTRRT, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::RRT, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::RRTConnect, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::RRTstar, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::TRRT, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::PRM, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::PRMstar, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::LazyPRMstar, configurator.planners), true);
+    EXPECT_EQ(containsType(OMPLPlannerType::SPARS, configurator.planners), true);
+  }
+
+  {  // encode
+    OMPLSolverConfig configurator;
+    configurator.planning_time = 2.0;
+    configurator.max_solutions = 4;
+    configurator.simplify = true;
+    configurator.optimize = false;
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::SBLConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::ESTConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::LBKPIECE1Configurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::BKPIECE1Configurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::KPIECE1Configurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::BiTRRTConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::RRTConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::RRTConnectConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::RRTstarConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::TRRTConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::PRMConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::PRMstarConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::LazyPRMstarConfigurator>()));    
+    configurator.planners.push_back(
+        std::static_pointer_cast<const tesseract_planning::OMPLPlannerConfigurator>(
+            std::make_shared<tesseract_planning::SPARSConfigurator>()));    
+
+    YAML::Node n = YAML::Load(yaml_string);
+    YAML::Node output_n = YAML::convert<OMPLSolverConfig>::encode(configurator);
+    EXPECT_EQ(output_n["planning_time"].as<double>(), 2.0);
+    EXPECT_EQ(output_n["max_solutions"].as<int>(), 4);
+    EXPECT_EQ(output_n["simplify"].as<bool>(), true);
+    EXPECT_EQ(output_n["optimize"].as<bool>(), false);
+    EXPECT_TRUE(containsPlanner("SBLConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("ESTConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("LBKPIECE1Configurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("BKPIECE1Configurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("KPIECE1Configurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("BiTRRTConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("RRTConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("RRTConnectConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("RRTstarConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("TRRTConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("PRMConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("PRMstarConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("LazyPRMstarConfigurator", output_n["planners"]));
+    EXPECT_TRUE(containsPlanner("SPARSConfigurator", output_n["planners"]));
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/yaml_extensions.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/yaml_extensions.h
@@ -1,0 +1,168 @@
+/**
+ * @file yaml_extensions.h
+ * @brief YAML Type conversions
+ *
+ * @author Samantha Smith
+ * @date July 14, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_TASK_COMPOSER_CORE_YAML_EXTENSIONS_H
+#define TESSERACT_TASK_COMPOSER_CORE_YAML_EXTENSIONS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <yaml-cpp/yaml.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/yaml_extensions.h>
+#include <tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h>
+#include <tesseract_task_composer/planning/profiles/fix_state_collision_profile.h>
+
+
+namespace YAML
+{
+//=========================== Fix State Bounds Settings Enum ===========================
+template <>
+struct convert<tesseract_planning::FixStateBoundsProfile::Settings>
+{
+  static Node encode(const tesseract_planning::FixStateBoundsProfile::Settings& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<tesseract_planning::FixStateBoundsProfile::Settings, std::string> m = {
+      { tesseract_planning::FixStateBoundsProfile::Settings::START_ONLY, "START_ONLY" },
+      { tesseract_planning::FixStateBoundsProfile::Settings::END_ONLY, "END_ONLY" },
+      { tesseract_planning::FixStateBoundsProfile::Settings::ALL, "ALL" },
+      { tesseract_planning::FixStateBoundsProfile::Settings::DISABLED, "DISABLED" }
+    };
+    // LCOV_EXCL_STOP
+    return Node(m.at(rhs));
+  }
+
+  static bool decode(const Node& node, tesseract_planning::FixStateBoundsProfile::Settings& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<std::string, tesseract_planning::FixStateBoundsProfile::Settings> inv = {
+      { "START_ONLY", tesseract_planning::FixStateBoundsProfile::Settings::START_ONLY },
+      { "END_ONLY", tesseract_planning::FixStateBoundsProfile::Settings::END_ONLY },
+      { "ALL", tesseract_planning::FixStateBoundsProfile::Settings::ALL },
+      { "DISABLED", tesseract_planning::FixStateBoundsProfile::Settings::DISABLED }
+    };
+    // LCOV_EXCL_STOP
+
+    if (!node.IsScalar())
+      return false;
+
+    auto it = inv.find(node.Scalar());
+    if (it == inv.end())
+      return false;
+
+    rhs = it->second;
+    return true;
+  }
+};
+
+//=========================== Fix State Collision Settings Enum ===========================
+template <>
+struct convert<tesseract_planning::FixStateCollisionProfile::Settings>
+{
+  static Node encode(const tesseract_planning::FixStateCollisionProfile::Settings& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<tesseract_planning::FixStateCollisionProfile::Settings, std::string> m = {
+      { tesseract_planning::FixStateCollisionProfile::Settings::START_ONLY, "START_ONLY" },
+      { tesseract_planning::FixStateCollisionProfile::Settings::END_ONLY, "END_ONLY" },
+      { tesseract_planning::FixStateCollisionProfile::Settings::INTERMEDIATE_ONLY, "INTERMEDIATE_ONLY" },
+      { tesseract_planning::FixStateCollisionProfile::Settings::ALL, "ALL" },
+      { tesseract_planning::FixStateCollisionProfile::Settings::ALL_EXCEPT_START, "ALL_EXCEPT_START" },
+      { tesseract_planning::FixStateCollisionProfile::Settings::ALL_EXCEPT_END, "ALL_EXCEPT_END" },
+      { tesseract_planning::FixStateCollisionProfile::Settings::DISABLED, "DISABLED" }
+    };
+    // LCOV_EXCL_STOP
+    return Node(m.at(rhs));
+  }
+
+  static bool decode(const Node& node, tesseract_planning::FixStateCollisionProfile::Settings& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<std::string, tesseract_planning::FixStateCollisionProfile::Settings> inv = {
+      { "START_ONLY", tesseract_planning::FixStateCollisionProfile::Settings::START_ONLY },
+      { "END_ONLY", tesseract_planning::FixStateCollisionProfile::Settings::END_ONLY },
+      { "INTERMEDIATE_ONLY", tesseract_planning::FixStateCollisionProfile::Settings::INTERMEDIATE_ONLY },
+      { "ALL", tesseract_planning::FixStateCollisionProfile::Settings::ALL },
+      { "ALL_EXCEPT_START", tesseract_planning::FixStateCollisionProfile::Settings::ALL_EXCEPT_START },
+      { "ALL_EXCEPT_END", tesseract_planning::FixStateCollisionProfile::Settings::ALL_EXCEPT_END },
+      { "DISABLED", tesseract_planning::FixStateCollisionProfile::Settings::DISABLED }
+    };
+    // LCOV_EXCL_STOP
+
+    if (!node.IsScalar())
+      return false;
+
+    auto it = inv.find(node.Scalar());
+    if (it == inv.end())
+      return false;
+
+    rhs = it->second;
+    return true;
+  }
+};
+
+//=========================== Fix State Collision CorrectionMethod Enum ===========================
+template <>
+struct convert<tesseract_planning::FixStateCollisionProfile::CorrectionMethod>
+{
+  static Node encode(const tesseract_planning::FixStateCollisionProfile::CorrectionMethod& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<tesseract_planning::FixStateCollisionProfile::CorrectionMethod, std::string> m = {
+      { tesseract_planning::FixStateCollisionProfile::CorrectionMethod::NONE, "NONE" },
+      { tesseract_planning::FixStateCollisionProfile::CorrectionMethod::TRAJOPT, "TRAJOPT" },
+      { tesseract_planning::FixStateCollisionProfile::CorrectionMethod::RANDOM_SAMPLER, "RANDOM_SAMPLER" }
+    };
+    // LCOV_EXCL_STOP
+    return Node(m.at(rhs));
+  }
+
+  static bool decode(const Node& node, tesseract_planning::FixStateCollisionProfile::CorrectionMethod& rhs)
+  {
+    // LCOV_EXCL_START
+    static const std::map<std::string, tesseract_planning::FixStateCollisionProfile::CorrectionMethod> inv = {
+      { "NONE", tesseract_planning::FixStateCollisionProfile::CorrectionMethod::NONE },
+      { "TRAJOPT", tesseract_planning::FixStateCollisionProfile::CorrectionMethod::TRAJOPT },
+      { "RANDOM_SAMPLER", tesseract_planning::FixStateCollisionProfile::CorrectionMethod::RANDOM_SAMPLER }
+    };
+    // LCOV_EXCL_STOP
+
+    if (!node.IsScalar())
+      return false;
+
+    auto it = inv.find(node.Scalar());
+    if (it == inv.end())
+      return false;
+
+    rhs = it->second;
+    return true;
+  }
+};
+
+
+}  // namespace YAML
+
+#endif  // TESSERACT_TASK_COMPOSER_CORE_YAML_EXTENSIONS_H

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/contact_check_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/contact_check_profile.h
@@ -29,10 +29,12 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_collision/core/types.h>
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -43,6 +45,7 @@ struct ContactCheckProfile : public tesseract_common::Profile
 
   ContactCheckProfile();
   ContactCheckProfile(double longest_valid_segment_length, double contact_distance);
+  ContactCheckProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h
@@ -30,9 +30,11 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <limits>
 #include <memory>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -50,6 +52,7 @@ struct FixStateBoundsProfile : public tesseract_common::Profile
   };
 
   FixStateBoundsProfile(Settings mode = Settings::ALL);
+  FixStateBoundsProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_collision_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_collision_profile.h
@@ -30,10 +30,12 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <vector>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_collision/core/types.h>
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 #include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
 
 namespace tesseract_planning
@@ -63,6 +65,7 @@ struct FixStateCollisionProfile : public tesseract_common::Profile
   };
 
   FixStateCollisionProfile(Settings mode = Settings::ALL);
+  FixStateCollisionProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/kinematic_limits_check_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/kinematic_limits_check_profile.h
@@ -22,7 +22,9 @@
 #define TESSERACT_TASK_COMPOSER_PLANNING_PROFILES_KINEMATIC_LIMITS_CHECK_PROFILE_H
 
 #include <memory>
+#include <yaml-cpp/yaml.h>
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -32,6 +34,7 @@ struct KinematicLimitsCheckProfile : public tesseract_common::Profile
   using ConstPtr = std::shared_ptr<const KinematicLimitsCheckProfile>;
 
   KinematicLimitsCheckProfile(bool check_position = true, bool check_velocity = true, bool check_acceleration = true);
+  KinematicLimitsCheckProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/min_length_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/min_length_profile.h
@@ -31,9 +31,11 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -44,6 +46,7 @@ struct MinLengthProfile : public tesseract_common::Profile
 
   MinLengthProfile();
   MinLengthProfile(long min_length);
+  MinLengthProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/profile_switch_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/profile_switch_profile.h
@@ -27,9 +27,11 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -39,6 +41,7 @@ struct ProfileSwitchProfile : public tesseract_common::Profile
   using ConstPtr = std::shared_ptr<const ProfileSwitchProfile>;
 
   ProfileSwitchProfile(int return_value = 1);
+  ProfileSwitchProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/upsample_trajectory_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/upsample_trajectory_profile.h
@@ -28,9 +28,11 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/profile.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -41,6 +43,7 @@ struct UpsampleTrajectoryProfile : public tesseract_common::Profile
 
   UpsampleTrajectoryProfile();
   UpsampleTrajectoryProfile(double longest_valid_segment_length);
+  UpsampleTrajectoryProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/);
 
   /**
    * @brief A utility function for getting profile ID

--- a/tesseract_task_composer/planning/src/profiles/contact_check_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/contact_check_profile.cpp
@@ -34,6 +34,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/planning/profiles/contact_check_profile.h>
 #include <tesseract_collision/core/serialization.h>
+#include <tesseract_collision/core/yaml_extensions.h>
 
 namespace tesseract_planning
 {
@@ -51,6 +52,23 @@ ContactCheckProfile::ContactCheckProfile(double longest_valid_segment_length, do
   {
     CONSOLE_BRIDGE_logWarn("ContactCheckProfile: Invalid longest valid segment. Defaulting to 0.05");
     collision_check_config.longest_valid_segment_length = 0.05;
+  }
+}
+
+ContactCheckProfile::ContactCheckProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : ContactCheckProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["contact_manager_config"])
+      contact_manager_config = n.as<tesseract_collision::ContactManagerConfig>();
+
+    if (YAML::Node n = config["collision_check_config"])
+      collision_check_config = n.as<tesseract_collision::CollisionCheckConfig>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("ContactCheckProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
   }
 }
 

--- a/tesseract_task_composer/planning/src/profiles/fix_state_bounds_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/fix_state_bounds_profile.cpp
@@ -27,11 +27,32 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <typeindex>
+#include <tesseract_task_composer/core/yaml_extensions.h>
 
 namespace tesseract_planning
 {
 FixStateBoundsProfile::FixStateBoundsProfile(Settings mode) : Profile(FixStateBoundsProfile::getStaticKey()), mode(mode)
 {
+}
+
+FixStateBoundsProfile::FixStateBoundsProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : FixStateBoundsProfile()
+{   
+  try
+  {
+    if (YAML::Node n = config["mode"])
+      mode = n.as<Settings>();
+    if (YAML::Node n = config["max_deviation_global"])
+      max_deviation_global = n.as<double>();
+    if (YAML::Node n = config["upper_bounds_reduction"])
+      upper_bounds_reduction = n.as<double>();
+    if (YAML::Node n = config["lower_bounds_reduction"])
+      lower_bounds_reduction = n.as<double>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("FixStateBoundsProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
 }
 
 std::size_t FixStateBoundsProfile::getStaticKey() { return std::type_index(typeid(FixStateBoundsProfile)).hash_code(); }

--- a/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/fix_state_collision_profile.cpp
@@ -31,6 +31,8 @@
 #include <boost/serialization/vector.hpp>
 #include <tesseract_common/eigen_serialization.h>
 #include <typeindex>
+#include <tesseract_task_composer/core/yaml_extensions.h>
+#include <tesseract_collision/core/yaml_extensions.h>
 
 namespace tesseract_planning
 {
@@ -41,6 +43,30 @@ FixStateCollisionProfile::FixStateCollisionProfile(Settings mode)
   collision_check_config.type = tesseract_collision::CollisionEvaluatorType::DISCRETE;
   trajopt_joint_constraint_config.coeff = Eigen::VectorXd::Constant(1, 1, 1);
   trajopt_joint_cost_config.coeff = Eigen::VectorXd::Constant(1, 1, 5);
+}
+
+FixStateCollisionProfile::FixStateCollisionProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : FixStateCollisionProfile()
+{
+  try 
+  {
+    if (YAML::Node n = config["mode"])
+      mode = n.as<Settings>();
+    if (YAML::Node n = config["correction_workflow"])
+      correction_workflow = n.as<std::vector<CorrectionMethod>>();
+    if (YAML::Node n = config["jiggle_factor"])
+      jiggle_factor = n.as<double>();
+    if (YAML::Node n = config["contact_manager_config"])
+      contact_manager_config = n.as<tesseract_collision::ContactManagerConfig>();
+    if (YAML::Node n = config["collision_check_config"])
+      collision_check_config = n.as<tesseract_collision::CollisionCheckConfig>();
+    if (YAML::Node n = config["sampling_attempts"])
+      sampling_attempts = n.as<int>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("FixStateCollisionProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
 }
 
 std::size_t FixStateCollisionProfile::getStaticKey()

--- a/tesseract_task_composer/planning/src/profiles/kinematic_limits_check_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/kinematic_limits_check_profile.cpp
@@ -36,6 +36,25 @@ KinematicLimitsCheckProfile::KinematicLimitsCheckProfile(bool check_position,
 {
 }
 
+KinematicLimitsCheckProfile::KinematicLimitsCheckProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : KinematicLimitsCheckProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["check_position"])
+      check_position = n.as<bool>();
+    if (YAML::Node n = config["check_velocity"])
+      check_velocity = n.as<bool>();
+    if (YAML::Node n = config["check_acceleration"])
+      check_acceleration = n.as<bool>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("KinematicLimitsCheckProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+  
+}
+
 std::size_t KinematicLimitsCheckProfile::getStaticKey()
 {
   return std::type_index(typeid(KinematicLimitsCheckProfile)).hash_code();

--- a/tesseract_task_composer/planning/src/profiles/min_length_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/min_length_profile.cpp
@@ -37,6 +37,19 @@ MinLengthProfile::MinLengthProfile() : Profile(MinLengthProfile::getStaticKey())
 MinLengthProfile::MinLengthProfile(long min_length) : Profile(MinLengthProfile::getStaticKey()), min_length(min_length)
 {
 }
+MinLengthProfile::MinLengthProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : MinLengthProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["min_length"])
+      min_length = n.as<long>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("MinLengthProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
 
 std::size_t MinLengthProfile::getStaticKey() { return std::type_index(typeid(MinLengthProfile)).hash_code(); }
 

--- a/tesseract_task_composer/planning/src/profiles/profile_switch_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/profile_switch_profile.cpp
@@ -33,6 +33,19 @@ ProfileSwitchProfile::ProfileSwitchProfile(int return_value)
   : Profile(ProfileSwitchProfile::getStaticKey()), return_value(return_value)
 {
 }
+ProfileSwitchProfile::ProfileSwitchProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : ProfileSwitchProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["return_value"])
+      return_value = n.as<int>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("ProfileSwitchProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
 
 std::size_t ProfileSwitchProfile::getStaticKey() { return std::type_index(typeid(ProfileSwitchProfile)).hash_code(); }
 

--- a/tesseract_task_composer/planning/src/profiles/upsample_trajectory_profile.cpp
+++ b/tesseract_task_composer/planning/src/profiles/upsample_trajectory_profile.cpp
@@ -36,6 +36,19 @@ UpsampleTrajectoryProfile::UpsampleTrajectoryProfile(double longest_valid_segmen
   : Profile(UpsampleTrajectoryProfile::getStaticKey()), longest_valid_segment_length(longest_valid_segment_length)
 {
 }
+UpsampleTrajectoryProfile::UpsampleTrajectoryProfile(std::string name, const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
+  : UpsampleTrajectoryProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["longest_valid_segment_length"])
+      longest_valid_segment_length = n.as<double>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("UpsampleTrajectoryProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
 
 std::size_t UpsampleTrajectoryProfile::getStaticKey()
 {


### PR DESCRIPTION
This PR updates the constructors to enable them to be initialized from a YAML node for the following planning profiles:
- `ContactCheckProfile`
- `FixStateBoundsProfile`
- `FixStateCollisionProfile`
- `KinematicLimitsCheckProfile`
- `MinLengthProfile`
- `ProfileSwitchProfile`
- `UpsampleTrajectoryProfile`

This PR also adds in the YAML conversions for the types used in the OMPL profiles and constructors so they can be initialized from a YAML node as well.

Unit tests were also added to test the new constructors and YAML conversions.