### PR TITLE
Additional Profile constructors YAML initialization and YAML conversions

### DIFF
--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_move_profile.h
@@ -29,6 +29,11 @@
 
 #include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class SimplePlannerFixedSizeAssignMoveProfile : public SimplePlannerMoveProfile
@@ -43,6 +48,7 @@ public:
    * @param linear_steps The number of steps to use for linear instruction
    */
   SimplePlannerFixedSizeAssignMoveProfile(int freespace_steps = 10, int linear_steps = 10);
+  SimplePlannerFixedSizeAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_no_ik_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_no_ik_move_profile.h
@@ -29,6 +29,11 @@
 
 #include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class SimplePlannerFixedSizeAssignNoIKMoveProfile : public SimplePlannerMoveProfile
@@ -43,7 +48,7 @@ public:
    * @param linear_steps The number of steps to use for linear instruction
    */
   SimplePlannerFixedSizeAssignNoIKMoveProfile(int freespace_steps = 10, int linear_steps = 10);
-
+  SimplePlannerFixedSizeAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,
                                             const MoveInstructionPoly& base_instruction,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_fixed_size_move_profile.h
@@ -28,6 +28,11 @@
 
 #include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class SimplePlannerFixedSizeMoveProfile : public SimplePlannerMoveProfile
@@ -42,7 +47,7 @@ public:
    * @param linear_steps The number of steps to use for linear instruction
    */
   SimplePlannerFixedSizeMoveProfile(int freespace_steps = 10, int linear_steps = 10);
-
+  SimplePlannerFixedSizeMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,
                                             const MoveInstructionPoly& base_instruction,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_move_profile.h
@@ -34,6 +34,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class SimplePlannerLVSAssignMoveProfile : public SimplePlannerMoveProfile
@@ -52,6 +57,8 @@ public:
                                     double rotation_longest_valid_segment_length = 5 * M_PI / 180,
                                     int min_steps = 1,
                                     int max_steps = std::numeric_limits<int>::max());
+
+  SimplePlannerLVSAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_no_ik_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_no_ik_move_profile.h
@@ -34,6 +34,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class SimplePlannerLVSAssignNoIKMoveProfile : public SimplePlannerMoveProfile
@@ -52,6 +57,8 @@ public:
                                         double rotation_longest_valid_segment_length = 5 * M_PI / 180,
                                         int min_steps = 1,
                                         int max_steps = std::numeric_limits<int>::max());
+
+  SimplePlannerLVSAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);                                      
 
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_move_profile.h
@@ -34,6 +34,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/simple/profile/simple_planner_profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class SimplePlannerLVSMoveProfile : public SimplePlannerMoveProfile
@@ -55,6 +60,8 @@ public:
                               double rotation_longest_valid_segment_length = 5 * M_PI / 180,
                               int min_steps = 1,
                               int max_steps = std::numeric_limits<int>::max());
+
+  SimplePlannerLVSMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);                            
 
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_no_ik_move_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_lvs_no_ik_move_profile.h
@@ -57,6 +57,8 @@ public:
                                   int min_steps = 1,
                                   int max_steps = std::numeric_limits<int>::max());
 
+  SimplePlannerLVSNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);                                
+
   std::vector<MoveInstructionPoly> generate(const MoveInstructionPoly& prev_instruction,
                                             const MoveInstructionPoly& prev_seed,
                                             const MoveInstructionPoly& base_instruction,

--- a/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
+++ b/tesseract_motion_planners/simple/include/tesseract_motion_planners/simple/profile/simple_planner_profile.h
@@ -38,6 +38,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/core/fwd.h>
 #include <tesseract_common/profile.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 /**
@@ -52,6 +57,8 @@ public:
 
   SimplePlannerMoveProfile();
 
+  SimplePlannerMoveProfile(const YAML::Node& /*config*/, const tesseract_common::ProfilePluginFactory& plugin_factory);
+  
   /**
    * @brief A utility function for getting profile ID
    * @return The profile ID used when storing in profile dictionary

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_move_profile.cpp
@@ -39,12 +39,23 @@
 #include <tesseract_command_language/poly/waypoint_poly.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
 SimplePlannerFixedSizeAssignMoveProfile::SimplePlannerFixedSizeAssignMoveProfile(int freespace_steps, int linear_steps)
   : freespace_steps(freespace_steps), linear_steps(linear_steps)
 {
+}
+
+SimplePlannerFixedSizeAssignMoveProfile::SimplePlannerFixedSizeAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerFixedSizeAssignMoveProfile()
+{
+  if (YAML::Node n = config["freespace_steps"]) 
+    freespace_steps = n.as<int>();
+  if (YAML::Node n = config["linear_steps"])
+    linear_steps = n.as<int>();
 }
 
 std::vector<MoveInstructionPoly>

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_move_profile.cpp
@@ -49,7 +49,7 @@ SimplePlannerFixedSizeAssignMoveProfile::SimplePlannerFixedSizeAssignMoveProfile
 {
 }
 
-SimplePlannerFixedSizeAssignMoveProfile::SimplePlannerFixedSizeAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerFixedSizeAssignMoveProfile::SimplePlannerFixedSizeAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerFixedSizeAssignMoveProfile()
 {
   if (YAML::Node n = config["freespace_steps"]) 

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_no_ik_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_no_ik_move_profile.cpp
@@ -47,7 +47,7 @@ SimplePlannerFixedSizeAssignNoIKMoveProfile::SimplePlannerFixedSizeAssignNoIKMov
 {
 }
 
-SimplePlannerFixedSizeAssignNoIKMoveProfile::SimplePlannerFixedSizeAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerFixedSizeAssignNoIKMoveProfile::SimplePlannerFixedSizeAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerFixedSizeAssignNoIKMoveProfile()
 {
   if (YAML::Node n = config["freespace_steps"]) 

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_no_ik_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_assign_no_ik_move_profile.cpp
@@ -36,6 +36,8 @@
 #include <tesseract_command_language/poly/move_instruction_poly.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -43,6 +45,15 @@ SimplePlannerFixedSizeAssignNoIKMoveProfile::SimplePlannerFixedSizeAssignNoIKMov
                                                                                          int linear_steps)
   : freespace_steps(freespace_steps), linear_steps(linear_steps)
 {
+}
+
+SimplePlannerFixedSizeAssignNoIKMoveProfile::SimplePlannerFixedSizeAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerFixedSizeAssignNoIKMoveProfile()
+{
+  if (YAML::Node n = config["freespace_steps"]) 
+    freespace_steps = n.as<int>();
+  if (YAML::Node n = config["linear_steps"])
+    linear_steps = n.as<int>();
 }
 
 std::vector<MoveInstructionPoly> SimplePlannerFixedSizeAssignNoIKMoveProfile::generate(

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_move_profile.cpp
@@ -34,6 +34,8 @@
 #include <tesseract_command_language/poly/move_instruction_poly.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -41,6 +43,16 @@ SimplePlannerFixedSizeMoveProfile::SimplePlannerFixedSizeMoveProfile(int freespa
   : freespace_steps(freespace_steps), linear_steps(linear_steps)
 {
 }
+
+SimplePlannerFixedSizeMoveProfile::SimplePlannerFixedSizeMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerFixedSizeMoveProfile()
+{
+  if (YAML::Node n = config["freespace_steps"]) 
+    freespace_steps = n.as<int>();
+  if (YAML::Node n = config["linear_steps"])
+    linear_steps = n.as<int>();
+}
+
 
 std::vector<MoveInstructionPoly>
 SimplePlannerFixedSizeMoveProfile::generate(const MoveInstructionPoly& prev_instruction,

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_fixed_size_move_profile.cpp
@@ -44,7 +44,7 @@ SimplePlannerFixedSizeMoveProfile::SimplePlannerFixedSizeMoveProfile(int freespa
 {
 }
 
-SimplePlannerFixedSizeMoveProfile::SimplePlannerFixedSizeMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerFixedSizeMoveProfile::SimplePlannerFixedSizeMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerFixedSizeMoveProfile()
 {
   if (YAML::Node n = config["freespace_steps"]) 

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_move_profile.cpp
@@ -52,7 +52,7 @@ SimplePlannerLVSAssignMoveProfile::SimplePlannerLVSAssignMoveProfile(double stat
 {
 }
 
-SimplePlannerLVSAssignMoveProfile::SimplePlannerLVSAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerLVSAssignMoveProfile::SimplePlannerLVSAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerLVSAssignMoveProfile()
 {  
   if (YAML::Node n = config["state_longest_valid_segment_length"])

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_move_profile.cpp
@@ -34,6 +34,8 @@
 #include <tesseract_motion_planners/core/types.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -48,6 +50,21 @@ SimplePlannerLVSAssignMoveProfile::SimplePlannerLVSAssignMoveProfile(double stat
   , min_steps(min_steps)
   , max_steps(max_steps)
 {
+}
+
+SimplePlannerLVSAssignMoveProfile::SimplePlannerLVSAssignMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerLVSAssignMoveProfile()
+{  
+  if (YAML::Node n = config["state_longest_valid_segment_length"])
+    state_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["translation_longest_valid_segment_length"])
+    translation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["rotation_longest_valid_segment_length"])
+    rotation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["min_steps"]) 
+    min_steps = n.as<int>();
+  if (YAML::Node n = config["max_steps"])
+    max_steps = n.as<int>();
 }
 
 std::vector<MoveInstructionPoly>

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_no_ik_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_no_ik_move_profile.cpp
@@ -53,7 +53,7 @@ SimplePlannerLVSAssignNoIKMoveProfile::SimplePlannerLVSAssignNoIKMoveProfile(
 {
 }
 
-SimplePlannerLVSAssignNoIKMoveProfile::SimplePlannerLVSAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerLVSAssignNoIKMoveProfile::SimplePlannerLVSAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerLVSAssignNoIKMoveProfile()
 {  
   if (YAML::Node n = config["state_longest_valid_segment_length"])

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_no_ik_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_assign_no_ik_move_profile.cpp
@@ -34,6 +34,8 @@
 #include <tesseract_motion_planners/core/types.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -49,6 +51,21 @@ SimplePlannerLVSAssignNoIKMoveProfile::SimplePlannerLVSAssignNoIKMoveProfile(
   , min_steps(min_steps)
   , max_steps(max_steps)
 {
+}
+
+SimplePlannerLVSAssignNoIKMoveProfile::SimplePlannerLVSAssignNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerLVSAssignNoIKMoveProfile()
+{  
+  if (YAML::Node n = config["state_longest_valid_segment_length"])
+    state_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["translation_longest_valid_segment_length"])
+    translation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["rotation_longest_valid_segment_length"])
+    rotation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["min_steps"]) 
+    min_steps = n.as<int>();
+  if (YAML::Node n = config["max_steps"])
+    max_steps = n.as<int>();
 }
 
 std::vector<MoveInstructionPoly>

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_move_profile.cpp
@@ -34,6 +34,8 @@
 #include <tesseract_command_language/poly/move_instruction_poly.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -49,6 +51,22 @@ SimplePlannerLVSMoveProfile::SimplePlannerLVSMoveProfile(double state_longest_va
   , max_steps(max_steps)
 {
 }
+
+SimplePlannerLVSMoveProfile::SimplePlannerLVSMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerLVSMoveProfile()
+{  
+  if (YAML::Node n = config["state_longest_valid_segment_length"])
+    state_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["translation_longest_valid_segment_length"])
+    translation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["rotation_longest_valid_segment_length"])
+    rotation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["min_steps"]) 
+    min_steps = n.as<int>();
+  if (YAML::Node n = config["max_steps"])
+    max_steps = n.as<int>();
+}
+
 
 std::vector<MoveInstructionPoly>
 SimplePlannerLVSMoveProfile::generate(const MoveInstructionPoly& prev_instruction,

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_move_profile.cpp
@@ -52,7 +52,7 @@ SimplePlannerLVSMoveProfile::SimplePlannerLVSMoveProfile(double state_longest_va
 {
 }
 
-SimplePlannerLVSMoveProfile::SimplePlannerLVSMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerLVSMoveProfile::SimplePlannerLVSMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerLVSMoveProfile()
 {  
   if (YAML::Node n = config["state_longest_valid_segment_length"])

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_no_ik_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_no_ik_move_profile.cpp
@@ -52,7 +52,7 @@ SimplePlannerLVSNoIKMoveProfile::SimplePlannerLVSNoIKMoveProfile(double state_lo
 {
 }
 
-SimplePlannerLVSNoIKMoveProfile::SimplePlannerLVSNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerLVSNoIKMoveProfile::SimplePlannerLVSNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerLVSNoIKMoveProfile()
 {  
   if (YAML::Node n = config["state_longest_valid_segment_length"])

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_no_ik_move_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_lvs_no_ik_move_profile.cpp
@@ -34,6 +34,8 @@
 #include <tesseract_command_language/poly/move_instruction_poly.h>
 
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
@@ -48,6 +50,21 @@ SimplePlannerLVSNoIKMoveProfile::SimplePlannerLVSNoIKMoveProfile(double state_lo
   , min_steps(min_steps)
   , max_steps(max_steps)
 {
+}
+
+SimplePlannerLVSNoIKMoveProfile::SimplePlannerLVSNoIKMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerLVSNoIKMoveProfile()
+{  
+  if (YAML::Node n = config["state_longest_valid_segment_length"])
+    state_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["translation_longest_valid_segment_length"])
+    translation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["rotation_longest_valid_segment_length"])
+    rotation_longest_valid_segment_length = n.as<double>();
+  if (YAML::Node n = config["min_steps"]) 
+    min_steps = n.as<int>();
+  if (YAML::Node n = config["max_steps"])
+    max_steps = n.as<int>();
 }
 
 std::vector<MoveInstructionPoly>

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_profile.cpp
@@ -27,10 +27,16 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <typeindex>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
 
 namespace tesseract_planning
 {
 SimplePlannerMoveProfile::SimplePlannerMoveProfile() : Profile(SimplePlannerMoveProfile::getStaticKey()) {}
+SimplePlannerMoveProfile::SimplePlannerMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: SimplePlannerMoveProfile()
+{ 
+}
 
 std::size_t SimplePlannerMoveProfile::getStaticKey()
 {

--- a/tesseract_motion_planners/simple/src/profile/simple_planner_profile.cpp
+++ b/tesseract_motion_planners/simple/src/profile/simple_planner_profile.cpp
@@ -33,7 +33,7 @@
 namespace tesseract_planning
 {
 SimplePlannerMoveProfile::SimplePlannerMoveProfile() : Profile(SimplePlannerMoveProfile::getStaticKey()) {}
-SimplePlannerMoveProfile::SimplePlannerMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+SimplePlannerMoveProfile::SimplePlannerMoveProfile(const YAML::Node& /*config*/, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : SimplePlannerMoveProfile()
 { 
 }

--- a/tesseract_motion_planners/simple/test/CMakeLists.txt
+++ b/tesseract_motion_planners/simple/test/CMakeLists.txt
@@ -26,3 +26,4 @@ add_gtest(${PROJECT_NAME}_simple_planner_lvs_assign_move_unit simple_planner_lvs
 add_gtest(${PROJECT_NAME}_simple_planner_lvs_assign_no_ik_move_unit simple_planner_lvs_assign_no_ik_move_unit.cpp)
 add_gtest(${PROJECT_NAME}_simple_planner_lvs_move_unit simple_planner_lvs_move_unit.cpp)
 add_gtest(${PROJECT_NAME}_simple_planner_lvs_no_ik_move_unit simple_planner_lvs_no_ik_move_unit.cpp)
+add_gtest(${PROJECT_NAME}_simple_planner_yaml_conversions simple_planner_yaml_conversions_unit.cpp)

--- a/tesseract_motion_planners/simple/test/simple_planner_yaml_conversions_unit.cpp
+++ b/tesseract_motion_planners/simple/test/simple_planner_yaml_conversions_unit.cpp
@@ -1,0 +1,267 @@
+/**
+ * @file simple_planner_yaml_conversions_tests.cpp
+ * @brief This contains unit test for the tesseract simple planner yaml constructors
+ *
+ * @author Samantha Smith
+ * @date August 25, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "simple_planner_test_utils.hpp"
+#include <tesseract_common/profile_plugin_factory.h>
+
+#include <tesseract_common/types.h>
+#include <tesseract_motion_planners/core/types.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_move_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_fixed_size_assign_no_ik_move_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_fixed_size_move_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_move_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_assign_no_ik_move_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_move_profile.h>
+#include <tesseract_motion_planners/simple/profile/simple_planner_lvs_no_ik_move_profile.h>
+
+#include <tesseract_command_language/joint_waypoint.h>
+#include <tesseract_command_language/cartesian_waypoint.h>
+#include <tesseract_command_language/move_instruction.h>
+#include <yaml-cpp/yaml.h>
+
+using namespace tesseract_planning;
+
+class TesseractPlanningSimplePlannerYAMLConversionsUnit : public TesseractPlanningSimplePlannerUnit
+{
+};
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerFixedSizeAssignMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        freespace_steps: 6
+                                        linear_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerFixedSizeAssignMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_EQ(profile.freespace_steps, 6);
+    EXPECT_EQ(profile.linear_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerFixedSizeAssignMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_EQ(profile.freespace_steps, 10);
+    EXPECT_EQ(profile.linear_steps, 10);
+  }
+}
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerFixedSizeAssignNoIKMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        freespace_steps: 6
+                                        linear_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerFixedSizeAssignNoIKMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_EQ(profile.freespace_steps, 6);
+    EXPECT_EQ(profile.linear_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerFixedSizeAssignNoIKMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_EQ(profile.freespace_steps, 10);
+    EXPECT_EQ(profile.linear_steps, 10);
+  }
+}
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerFixedSizeMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        freespace_steps: 6
+                                        linear_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerFixedSizeMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_EQ(profile.freespace_steps, 6);
+    EXPECT_EQ(profile.linear_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerFixedSizeMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_EQ(profile.freespace_steps, 10);
+    EXPECT_EQ(profile.linear_steps, 10);
+  }
+}
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerLVSAssignMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        state_longest_valid_segment_length: 0.5
+                                        translation_longest_valid_segment_length: 0.2
+                                        rotation_longest_valid_segment_length: 0.4
+                                        min_steps: 6
+                                        max_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSAssignMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 0.5, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.2, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 0.4, 1e-6);
+    EXPECT_EQ(profile.min_steps, 6);
+    EXPECT_EQ(profile.max_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSAssignMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.1, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_EQ(profile.min_steps, 1);
+    EXPECT_EQ(profile.max_steps, std::numeric_limits<int>::max());
+  }
+}
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerLVSAssignNoIKMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        state_longest_valid_segment_length: 0.5
+                                        translation_longest_valid_segment_length: 0.2
+                                        rotation_longest_valid_segment_length: 0.4
+                                        min_steps: 6
+                                        max_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSAssignNoIKMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 0.5, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.2, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 0.4, 1e-6);
+    EXPECT_EQ(profile.min_steps, 6);
+    EXPECT_EQ(profile.max_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSAssignNoIKMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.1, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_EQ(profile.min_steps, 1);
+    EXPECT_EQ(profile.max_steps, std::numeric_limits<int>::max());
+  }
+}
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerLVSMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        state_longest_valid_segment_length: 0.5
+                                        translation_longest_valid_segment_length: 0.2
+                                        rotation_longest_valid_segment_length: 0.4
+                                        min_steps: 6
+                                        max_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 0.5, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.2, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 0.4, 1e-6);
+    EXPECT_EQ(profile.min_steps, 6);
+    EXPECT_EQ(profile.max_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.1, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_EQ(profile.min_steps, 1);
+    EXPECT_EQ(profile.max_steps, std::numeric_limits<int>::max());
+  }
+}
+
+TEST_F(TesseractPlanningSimplePlannerYAMLConversionsUnit, SimplePlannerLVSNoIKMoveProfileYAML)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        state_longest_valid_segment_length: 0.5
+                                        translation_longest_valid_segment_length: 0.2
+                                        rotation_longest_valid_segment_length: 0.4
+                                        min_steps: 6
+                                        max_steps: 5
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSNoIKMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 0.5, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.2, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 0.4, 1e-6);
+    EXPECT_EQ(profile.min_steps, 6);
+    EXPECT_EQ(profile.max_steps, 5);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    SimplePlannerLVSNoIKMoveProfile profile(n["config"], plugin_factory);
+    EXPECT_NEAR(profile.state_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_NEAR(profile.translation_longest_valid_segment_length, 0.1, 1e-6);
+    EXPECT_NEAR(profile.rotation_longest_valid_segment_length, 5 * M_PI / 180, 1e-6);
+    EXPECT_EQ(profile.min_steps, 1);
+    EXPECT_EQ(profile.max_steps, std::numeric_limits<int>::max());
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h
@@ -40,6 +40,11 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_collision/core/fwd.h>
 #include <tesseract_collision/core/types.h>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace tesseract_planning
 {
 class TrajOptDefaultCompositeProfile : public TrajOptCompositeProfile
@@ -49,6 +54,8 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptDefaultCompositeProfile>;
 
   TrajOptDefaultCompositeProfile() = default;
+
+  TrajOptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   /** @brief Configuration info for collisions that are modeled as costs */
   trajopt_common::TrajOptCollisionConfig collision_cost_config;

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_default_move_profile.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_default_move_profile.h
@@ -35,6 +35,13 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
 #include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+
+namespace YAML
+{
+class Node;
+}
 
 namespace tesseract_planning
 {
@@ -45,6 +52,7 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptDefaultMoveProfile>;
 
   TrajOptDefaultMoveProfile();
+  TrajOptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   TrajOptCartesianWaypointConfig cartesian_cost_config;
   TrajOptCartesianWaypointConfig cartesian_constraint_config;

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_osqp_solver_profile.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_osqp_solver_profile.h
@@ -29,11 +29,19 @@
 #include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
 #include <trajopt_sco/osqp_interface.hpp>
 
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+
 namespace boost::serialization
 {
 template <class Archive>
 void serialize(Archive& ar, OSQPSettings& settings, const unsigned int version);  // NOLINT
 }  // namespace boost::serialization
+
+namespace YAML
+{
+class Node;
+}
 
 namespace tesseract_planning
 {
@@ -45,6 +53,8 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptOSQPSolverProfile>;
 
   TrajOptOSQPSolverProfile();
+  TrajOptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
+
 
   OSQPSettings settings{};
 

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_profile.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/profile/trajopt_profile.h
@@ -41,6 +41,14 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_command_language/fwd.h>
 #include <tesseract_common/profile.h>
 
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+
+namespace YAML
+{
+class Node;
+}
+
 namespace boost::serialization
 {
 template <class Archive>
@@ -71,6 +79,8 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptMoveProfile>;
 
   TrajOptMoveProfile();
+
+  TrajOptMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   virtual TrajOptWaypointInfo create(const MoveInstructionPoly& move_instruction,
                                      const tesseract_common::ManipulatorInfo& composite_manip_info,

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/yaml_extensions.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/yaml_extensions.h
@@ -131,14 +131,14 @@ struct convert<trajopt_common::TrajOptCollisionConfig>
 template <>
 struct convert<trajopt_common::CollisionCoeffData>
 {
-  static Node encode(const trajopt_common::CollisionCoeffData& rhs)
+  static Node encode(const trajopt_common::CollisionCoeffData& /*rhs*/)
   {
     Node node;
     // only contains private variables
     return node;
   }
 
-  static bool decode(const Node& node, trajopt_common::CollisionCoeffData& rhs)
+  static bool decode(const Node& node, trajopt_common::CollisionCoeffData& /*rhs*/)
   {
     // Check for required entries
     return true;

--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/yaml_extensions.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/yaml_extensions.h
@@ -1,0 +1,215 @@
+/**
+ * @file yaml_extensions.h
+ * @brief YAML Type conversions for trajopt types
+ *
+ * @author Samantha Smith
+ * @date August 5, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H
+#define TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <yaml-cpp/yaml.h>
+#include <set>
+#include <vector>
+#include <osqp.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/plugin_info.h>
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+
+#include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
+#include <tesseract_motion_planners/trajopt/profile/trajopt_profile.h>
+#include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
+#include <tesseract_motion_planners/trajopt/trajopt_utils.h>
+#include <tesseract_motion_planners/core/utils.h>
+
+#include <trajopt_sco/osqp_interface.hpp>
+
+
+
+namespace YAML
+{
+//=========================== Eigen::VectorXd ===========================
+
+template <>
+struct convert<Eigen::VectorXd>
+{
+  static Node encode(const Eigen::VectorXd& rhs)
+  {
+    Node node;
+    for (int i = 0; i < rhs.size(); ++i)
+      node.push_back(rhs(i));
+    return node;
+  }
+
+  static bool decode(const Node& node, Eigen::VectorXd& rhs)
+  {
+    if (!node.IsSequence())
+      return false;
+
+    rhs.resize(node.size());
+    for (std::size_t i = 0; i < node.size(); ++i)
+      rhs(static_cast<Eigen::Index>(i)) = node[i].as<double>();
+
+    return true;
+  }
+};
+
+//=========================== Eigen::Matrix<Scalar, Rows, 1> ===========================
+template <typename Scalar, int Rows>
+struct convert<Eigen::Matrix<Scalar, Rows, 1>>
+{
+  static Node encode(const Eigen::Matrix<Scalar, Rows, 1>& rhs)
+  {
+    Node node;
+    for (int i = 0; i < rhs.rows(); ++i)
+      node.push_back(rhs(i));
+    return node;
+  }
+
+  static bool decode(const Node& node, Eigen::Matrix<Scalar, Rows, 1>& rhs)
+  {
+    if (!node.IsSequence() || node.size() != static_cast<std::size_t>(Rows))
+      return false;
+
+    for (int i = 0; i < Rows; ++i)
+      rhs(i) = node[i].as<Scalar>();
+
+    return true;
+  }
+};
+
+//=========================== TrajOptCollisionConfig ===========================
+template <>
+struct convert<trajopt_common::TrajOptCollisionConfig>
+{
+  static Node encode(const trajopt_common::TrajOptCollisionConfig& rhs)
+  {
+    Node node;
+    node["collision_coeff_data"] = rhs.collision_coeff_data;
+    node["collision_margin_buffer"] = rhs.collision_margin_buffer;
+    node["max_num_cnt"] = rhs.max_num_cnt;
+    return node;
+  }
+
+  static bool decode(const Node& node, trajopt_common::TrajOptCollisionConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["collision_coeff_data"])
+      rhs.collision_coeff_data = n.as<trajopt_common::CollisionCoeffData>();
+    if (const YAML::Node& n = node["collision_margin_buffer"])
+      rhs.collision_margin_buffer = n.as<double>();
+    if (const YAML::Node& n = node["max_num_cnt"])
+      rhs.max_num_cnt = n.as<int>();
+    return true;
+  }
+};
+
+//=========================== CollisionCoeffData ===========================
+template <>
+struct convert<trajopt_common::CollisionCoeffData>
+{
+  static Node encode(const trajopt_common::CollisionCoeffData& rhs)
+  {
+    Node node;
+    // only contains private variables
+    return node;
+  }
+
+  static bool decode(const Node& node, trajopt_common::CollisionCoeffData& rhs)
+  {
+    // Check for required entries
+    return true;
+  }
+};
+
+//=========================== TrajOptCartesianWaypointConfig ===========================
+template <>
+struct convert<tesseract_planning::TrajOptCartesianWaypointConfig>
+{
+  static Node encode(const tesseract_planning::TrajOptCartesianWaypointConfig& rhs)
+  {
+    Node node;
+    node["enabled"] = rhs.enabled;
+    node["use_tolerance_override"] = rhs.use_tolerance_override;
+    node["lower_tolerance"] = rhs.lower_tolerance;
+    node["upper_tolerance"] = rhs.upper_tolerance;
+    node["coeff"] = rhs.coeff;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::TrajOptCartesianWaypointConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["enabled"])
+      rhs.enabled = n.as<bool>();
+    if (const YAML::Node& n = node["use_tolerance_override"])
+      rhs.use_tolerance_override = n.as<bool>();
+    if (const YAML::Node& n = node["lower_tolerance"])
+      rhs.lower_tolerance = n.as<Eigen::Matrix<double, 6, 1>>();
+    if (const YAML::Node& n = node["upper_tolerance"])
+      rhs.upper_tolerance = n.as<Eigen::Matrix<double, 6, 1>>();
+    if (const YAML::Node& n = node["coeff"])
+      rhs.coeff = n.as<Eigen::Matrix<double, 6, 1>>();
+    return true;
+  }
+};
+
+//=========================== TrajOptJointWaypointConfig ===========================
+template <>
+struct convert<tesseract_planning::TrajOptJointWaypointConfig>
+{
+  static Node encode(const tesseract_planning::TrajOptJointWaypointConfig& rhs)
+  {
+    Node node;
+    node["enabled"] = rhs.enabled;
+    node["use_tolerance_override"] = rhs.use_tolerance_override;
+    node["lower_tolerance"] = rhs.lower_tolerance;
+    node["upper_tolerance"] = rhs.upper_tolerance;
+    node["coeff"] = rhs.coeff;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::TrajOptJointWaypointConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["enabled"])
+      rhs.enabled = n.as<bool>();
+    if (const YAML::Node& n = node["use_tolerance_override"])
+      rhs.use_tolerance_override = n.as<bool>();
+    if (const YAML::Node& n = node["lower_tolerance"])
+      rhs.lower_tolerance = n.as<Eigen::VectorXd>();
+    if (const YAML::Node& n = node["upper_tolerance"])
+      rhs.upper_tolerance = n.as<Eigen::VectorXd>();
+    if (const YAML::Node& n = node["coeff"])
+      rhs.coeff = n.as<Eigen::VectorXd>();
+    return true;
+  }
+};
+
+
+}  // namespace YAML
+
+#endif  // TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_default_composite_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_default_composite_profile.cpp
@@ -57,7 +57,7 @@ namespace tesseract_planning
 {
 
 
-TrajOptDefaultCompositeProfile::TrajOptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptDefaultCompositeProfile::TrajOptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptDefaultCompositeProfile()
 {
   try

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_default_composite_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_default_composite_profile.cpp
@@ -31,6 +31,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/shared_ptr.hpp>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt/profile/trajopt_default_composite_profile.h>
@@ -47,13 +48,57 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_kinematics/core/joint_group.h>
 #include <tesseract_environment/environment.h>
 #include <trajopt_common/utils.hpp>
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_motion_planners/trajopt/yaml_extensions.h>
 
 static const double LONGEST_VALID_SEGMENT_FRACTION_DEFAULT = 0.01;
 
 namespace tesseract_planning
 {
-TrajOptTermInfos
-TrajOptDefaultCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
+
+
+TrajOptDefaultCompositeProfile::TrajOptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptDefaultCompositeProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["collision_cost_config"])
+      collision_cost_config = n.as<trajopt_common::TrajOptCollisionConfig>();
+
+    if (YAML::Node n = config["collision_constraint_config"])
+      collision_constraint_config = n.as<trajopt_common::TrajOptCollisionConfig>();
+
+    if (YAML::Node n = config["smooth_velocities"])
+      smooth_velocities = n.as<bool>();
+
+    if (YAML::Node n = config["velocity_coeff"])
+      velocity_coeff = n.as<Eigen::VectorXd>();
+
+    if (YAML::Node n = config["smooth_accelerations"])
+      smooth_accelerations = n.as<bool>();
+
+    if (YAML::Node n = config["acceleration_coeff"])
+      acceleration_coeff = n.as<Eigen::VectorXd>();
+
+    if (YAML::Node n = config["smooth_jerks"])
+      smooth_jerks = n.as<bool>();
+
+    if (YAML::Node n = config["jerk_coeff"])
+      jerk_coeff = n.as<Eigen::VectorXd>();
+
+    if (YAML::Node n = config["avoid_singularity"])
+      avoid_singularity = n.as<bool>();
+
+    if (YAML::Node n = config["avoid_singularity_coeff"])
+      avoid_singularity_coeff = n.as<double>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("TrajOptDefaultCompositeProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
+
+TrajOptTermInfos TrajOptDefaultCompositeProfile::create(const tesseract_common::ManipulatorInfo& composite_manip_info,
                                        const std::shared_ptr<const tesseract_environment::Environment>& env,
                                        const std::vector<int>& fixed_indices,
                                        int start_index,

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_default_move_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_default_move_profile.cpp
@@ -56,7 +56,7 @@ TrajOptDefaultMoveProfile::TrajOptDefaultMoveProfile()
   joint_cost_config.enabled = false;
 }
 
-TrajOptDefaultMoveProfile::TrajOptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptDefaultMoveProfile::TrajOptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptDefaultMoveProfile()
 {
   try

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_default_move_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_default_move_profile.cpp
@@ -29,6 +29,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/algorithm/string.hpp>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt/trajopt_utils.h>
@@ -45,13 +46,38 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_common/manipulator_info.h>
 #include <tesseract_kinematics/core/joint_group.h>
 #include <tesseract_environment/environment.h>
-
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_motion_planners/trajopt/yaml_extensions.h>
 namespace tesseract_planning
 {
 TrajOptDefaultMoveProfile::TrajOptDefaultMoveProfile()
 {
   cartesian_cost_config.enabled = false;
   joint_cost_config.enabled = false;
+}
+
+TrajOptDefaultMoveProfile::TrajOptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptDefaultMoveProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["cartesian_cost_config"])
+      cartesian_cost_config = n.as<tesseract_planning::TrajOptCartesianWaypointConfig>();
+
+    if (YAML::Node n = config["cartesian_constraint_config"])
+      cartesian_constraint_config = n.as<tesseract_planning::TrajOptCartesianWaypointConfig>();
+    
+      if (YAML::Node n = config["joint_cost_config"])
+      joint_cost_config = n.as<tesseract_planning::TrajOptJointWaypointConfig>();
+
+    if (YAML::Node n = config["joint_constraint_config"])
+      joint_constraint_config = n.as<tesseract_planning::TrajOptJointWaypointConfig>();
+
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("TrajOptDefaultCompositeProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
 }
 
 TrajOptWaypointInfo

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_osqp_solver_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_osqp_solver_profile.cpp
@@ -29,7 +29,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <trajopt/problem_description.hpp>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_motion_planners/trajopt/yaml_extensions.h>
 
 #include <tesseract_motion_planners/trajopt/profile/trajopt_osqp_solver_profile.h>
 
@@ -66,6 +69,20 @@ void serialize(Archive& ar, OSQPSettings& settings, const unsigned int /*version
 namespace tesseract_planning
 {
 TrajOptOSQPSolverProfile::TrajOptOSQPSolverProfile() { sco::OSQPModelConfig::setDefaultOSQPSettings(settings); }
+
+TrajOptOSQPSolverProfile::TrajOptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptOSQPSolverProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["update_workspace"])
+      update_workspace = n.as<bool>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("TrajOptDefaultCompositeProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
 
 sco::ModelType TrajOptOSQPSolverProfile::getSolverType() const { return sco::ModelType::OSQP; }
 

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_osqp_solver_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_osqp_solver_profile.cpp
@@ -70,7 +70,7 @@ namespace tesseract_planning
 {
 TrajOptOSQPSolverProfile::TrajOptOSQPSolverProfile() { sco::OSQPModelConfig::setDefaultOSQPSettings(settings); }
 
-TrajOptOSQPSolverProfile::TrajOptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptOSQPSolverProfile::TrajOptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptOSQPSolverProfile()
 {
   try

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_profile.cpp
@@ -59,7 +59,7 @@ void serialize(Archive& ar, sco::BasicTrustRegionSQPParameters& params, const un
 namespace tesseract_planning
 {
 TrajOptMoveProfile::TrajOptMoveProfile() : Profile(TrajOptMoveProfile::getStaticKey()) {}
-TrajOptMoveProfile::TrajOptMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptMoveProfile::TrajOptMoveProfile(const YAML::Node& /*config*/, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptMoveProfile()
 {
 }

--- a/tesseract_motion_planners/trajopt/src/profile/trajopt_profile.cpp
+++ b/tesseract_motion_planners/trajopt/src/profile/trajopt_profile.cpp
@@ -27,7 +27,9 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <typeindex>
+#include <yaml-cpp/yaml.h>
 
+#include <tesseract_common/profile_plugin_factory.h>
 namespace boost::serialization
 {
 template <class Archive>
@@ -57,6 +59,10 @@ void serialize(Archive& ar, sco::BasicTrustRegionSQPParameters& params, const un
 namespace tesseract_planning
 {
 TrajOptMoveProfile::TrajOptMoveProfile() : Profile(TrajOptMoveProfile::getStaticKey()) {}
+TrajOptMoveProfile::TrajOptMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptMoveProfile()
+{
+}
 
 std::size_t TrajOptMoveProfile::getStaticKey() { return std::type_index(typeid(TrajOptMoveProfile)).hash_code(); }
 

--- a/tesseract_motion_planners/trajopt/test/CMakeLists.txt
+++ b/tesseract_motion_planners/trajopt/test/CMakeLists.txt
@@ -14,5 +14,22 @@ target_code_coverage(
   EXCLUDE ${COVERAGE_EXCLUDE}
   ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
 add_gtest_discover_tests(${PROJECT_NAME}_trajopt_unit)
-add_dependencies(${PROJECT_NAME}_trajopt_unit ${PROJECT_NAME}_trajopt)
-add_dependencies(run_tests ${PROJECT_NAME}_trajopt_unit)
+
+
+add_executable(${PROJECT_NAME}_trajopt_yaml_unit trajopt_planner_yaml_conversions_tests.cpp)
+target_link_libraries(${PROJECT_NAME}_trajopt_yaml_unit PRIVATE GTest::GTest GTest::Main ${PROJECT_NAME}_trajopt)
+target_compile_options(${PROJECT_NAME}_trajopt_yaml_unit PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE}
+                                                            ${TESSERACT_COMPILE_OPTIONS_PUBLIC})
+target_compile_definitions(${PROJECT_NAME}_trajopt_yaml_unit PRIVATE ${TESSERACT_COMPILE_DEFINITIONS})
+target_clang_tidy(${PROJECT_NAME}_trajopt_yaml_unit ENABLE ${TESSERACT_ENABLE_CLANG_TIDY})
+target_cxx_version(${PROJECT_NAME}_trajopt_yaml_unit PRIVATE VERSION ${TESSERACT_CXX_VERSION})
+target_code_coverage(
+  ${PROJECT_NAME}_trajopt_yaml_unit
+  PRIVATE
+  ALL
+  EXCLUDE ${COVERAGE_EXCLUDE}
+  ENABLE ${TESSERACT_ENABLE_CODE_COVERAGE})
+add_gtest_discover_tests(${PROJECT_NAME}_trajopt_yaml_unit)
+
+add_dependencies(${PROJECT_NAME}_trajopt_unit ${PROJECT_NAME}_trajopt_yaml_unit ${PROJECT_NAME}_trajopt)
+add_dependencies(run_tests ${PROJECT_NAME}_trajopt_unit ${PROJECT_NAME}_trajopt_yaml_unit)

--- a/tesseract_motion_planners/trajopt/test/trajopt_planner_yaml_conversions_tests.cpp
+++ b/tesseract_motion_planners/trajopt/test/trajopt_planner_yaml_conversions_tests.cpp
@@ -1,0 +1,347 @@
+/**
+ * @file trajopt_planner_yaml_conversions_tests.cpp
+ * @brief This contains unit test for the tesseract trajopt planner yaml constructors
+ *
+ * @author Samantha Smith
+ * @date August 25, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tesseract_common/profile_plugin_factory.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <gtest/gtest.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/types.h>
+#include <tesseract_motion_planners/core/types.h>
+
+#include <tesseract_command_language/joint_waypoint.h>
+#include <tesseract_command_language/cartesian_waypoint.h>
+#include <tesseract_command_language/move_instruction.h>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_motion_planners/trajopt/yaml_extensions.h>
+
+#include <tesseract_motion_planners/trajopt/profile/trajopt_default_move_profile.h>
+
+#include <tesseract_motion_planners/trajopt/profile/trajopt_osqp_solver_profile.h>
+
+
+
+using namespace tesseract_planning;
+using namespace trajopt_common;
+
+class TesseractPlanningTrajoptYAMLConversionsUnit : public ::testing::Test
+{};
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, EigenVectorFixedSizeYAMLConversion)  // NOLINT
+{
+  { // Encode test
+    Eigen::Matrix<double, 3, 1> vec;
+    vec << 1.1, 2.2, 3.3;
+
+    YAML::Node node = YAML::convert<Eigen::Matrix<double, 3, 1>>::encode(vec);
+
+    ASSERT_TRUE(node.IsSequence());
+    EXPECT_EQ(node.size(), 3);
+    EXPECT_NEAR(node[0].as<double>(), 1.1, 1e-6);
+    EXPECT_NEAR(node[1].as<double>(), 2.2, 1e-6);
+    EXPECT_NEAR(node[2].as<double>(), 3.3, 1e-6);
+  }
+
+  { // Decode test
+    const std::string yaml_string = R"(
+      - 4.4
+      - 5.5
+      - 6.6
+    )";
+
+    YAML::Node node = YAML::Load(yaml_string);
+
+    Eigen::Matrix<double, 3, 1> vec;
+    bool success = YAML::convert<Eigen::Matrix<double, 3, 1>>::decode(node, vec);
+
+    EXPECT_TRUE(success);
+    EXPECT_NEAR(vec(0), 4.4, 1e-6);
+    EXPECT_NEAR(vec(1), 5.5, 1e-6);
+    EXPECT_NEAR(vec(2), 6.6, 1e-6);
+  }
+}
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, TrajOptCollisionConfigYAMLConversion)  // NOLINT
+{
+  const std::string yaml_string = R"(config:
+                                      collision_margin_buffer: 0.5
+                                      max_num_cnt: 5
+                                )";
+  { // decode
+
+    TrajOptCollisionConfig config;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<TrajOptCollisionConfig>::decode(n["config"], config);
+    EXPECT_TRUE(success);
+    EXPECT_NEAR(config.collision_margin_buffer, 0.5, 1e-6);
+    EXPECT_EQ(config.max_num_cnt, 5);
+  }
+
+  { // encode
+    TrajOptCollisionConfig config;
+    config.collision_margin_buffer = 0.5;
+    config.max_num_cnt = 5;
+    YAML::Node output_n = YAML::convert<TrajOptCollisionConfig>::encode(config);
+    EXPECT_NEAR(output_n["collision_margin_buffer"].as<double>(), 0.5, 1e-6);
+    EXPECT_EQ(output_n["max_num_cnt"].as<int>(), 5);
+  }
+}
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, TrajOptCartesianWaypointConfigYAMLConversion)  // NOLINT
+{
+  const std::string yaml_string = R"(config:
+                                      enabled: false
+                                      use_tolerance_override: true
+                                      lower_tolerance:
+                                        - 1.0
+                                        - 2.0
+                                        - 3.0
+                                        - 4.0
+                                        - 5.0
+                                        - 6.0
+                                      upper_tolerance:
+                                        - 1.0
+                                        - 2.0
+                                        - 3.0
+                                        - 4.0
+                                        - 5.0
+                                        - 6.0
+                                      coeff:
+                                        - 1.0
+                                        - 2.0
+                                        - 3.0
+                                        - 4.0
+                                        - 5.0
+                                        - 6.0
+                                )";
+  
+  { // decode
+
+    TrajOptCartesianWaypointConfig config;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<TrajOptCartesianWaypointConfig>::decode(n["config"], config);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(config.enabled, false);
+    EXPECT_EQ(config.use_tolerance_override, true);
+    for (int i = 0; i < 6; i ++) {
+      EXPECT_NEAR(config.lower_tolerance[i], (double)(i+1), 1e-6);
+      EXPECT_NEAR(config.upper_tolerance[i], (double)(i+1), 1e-6);
+      EXPECT_NEAR(config.coeff[i], (double)(i+1), 1e-6);
+    }
+  }
+
+  { // encode
+    TrajOptCartesianWaypointConfig config;
+    config.enabled = false;
+    config.use_tolerance_override = true;
+    config.lower_tolerance = Eigen::VectorXd::Ones(6);
+    config.upper_tolerance = Eigen::VectorXd::Ones(6);
+    config.coeff = Eigen::VectorXd::Ones(6);
+    YAML::Node output_n = YAML::convert<TrajOptCartesianWaypointConfig>::encode(config);
+    EXPECT_EQ(output_n["enabled"].as<bool>(), false);
+    EXPECT_EQ(output_n["use_tolerance_override"].as<bool>(), true);
+    YAML::Node lower_tol_node = output_n["lower_tolerance"];
+    YAML::Node upper_tol_node = output_n["upper_tolerance"];
+    YAML::Node coeff_node = output_n["coeff"];
+
+    ASSERT_EQ(lower_tol_node.size(), 6);
+    ASSERT_EQ(upper_tol_node.size(), 6);
+    ASSERT_EQ(coeff_node.size(), 6);
+
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_NEAR(config.lower_tolerance[i], lower_tol_node[i].as<double>(), 1e-6);
+      EXPECT_NEAR(config.upper_tolerance[i], upper_tol_node[i].as<double>(), 1e-6);
+      EXPECT_NEAR(config.coeff[i], coeff_node[i].as<double>(), 1e-6);
+    }
+  }
+}
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, TrajOptJointWaypointConfigYAMLConversion)  // NOLINT
+{
+  const std::string yaml_string = R"(config:
+                                      enabled: false
+                                      use_tolerance_override: true
+                                      lower_tolerance:
+                                        - 1.0
+                                        - 2.0
+                                        - 3.0
+                                        - 4.0
+                                        - 5.0
+                                        - 6.0
+                                      upper_tolerance:
+                                        - 1.0
+                                        - 2.0
+                                        - 3.0
+                                        - 4.0
+                                        - 5.0
+                                        - 6.0
+                                      coeff:
+                                        - 1.0
+                                        - 2.0
+                                        - 3.0
+                                        - 4.0
+                                        - 5.0
+                                        - 6.0
+                                )";
+  
+  { // decode
+
+    TrajOptJointWaypointConfig config;
+    YAML::Node n = YAML::Load(yaml_string);
+    auto success = YAML::convert<TrajOptJointWaypointConfig>::decode(n["config"], config);
+    EXPECT_TRUE(success);
+    EXPECT_EQ(config.enabled, false);
+    EXPECT_EQ(config.use_tolerance_override, true);
+    for (int i = 0; i < 6; i ++) {
+      EXPECT_NEAR(config.lower_tolerance[i], (double)(i+1), 1e-6);
+      EXPECT_NEAR(config.upper_tolerance[i], (double)(i+1), 1e-6);
+      EXPECT_NEAR(config.coeff[i], (double)(i+1), 1e-6);
+    }
+  }
+
+  { // encode
+    TrajOptJointWaypointConfig config;
+    config.enabled = false;
+    config.use_tolerance_override = true;
+    config.lower_tolerance = Eigen::VectorXd::Ones(6);
+    config.upper_tolerance = Eigen::VectorXd::Ones(6);
+    config.coeff = Eigen::VectorXd::Ones(6);
+    YAML::Node output_n = YAML::convert<TrajOptJointWaypointConfig>::encode(config);
+    EXPECT_EQ(output_n["enabled"].as<bool>(), false);
+    EXPECT_EQ(output_n["use_tolerance_override"].as<bool>(), true);
+    YAML::Node lower_tol_node = output_n["lower_tolerance"];
+    YAML::Node upper_tol_node = output_n["upper_tolerance"];
+    YAML::Node coeff_node = output_n["coeff"];
+
+    ASSERT_EQ(lower_tol_node.size(), 6);
+    ASSERT_EQ(upper_tol_node.size(), 6);
+    ASSERT_EQ(coeff_node.size(), 6);
+
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_NEAR(config.lower_tolerance[i], lower_tol_node[i].as<double>(), 1e-6);
+      EXPECT_NEAR(config.upper_tolerance[i], upper_tol_node[i].as<double>(), 1e-6);
+      EXPECT_NEAR(config.coeff[i], coeff_node[i].as<double>(), 1e-6);
+    }
+  }
+}
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, TrajOptDefaultCompositeProfileYAMLConversion)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    TrajOptDefaultCompositeProfile profile(n["config"], plugin_factory);
+    TrajOptDefaultCompositeProfile def_constructor;
+    EXPECT_EQ(profile.smooth_velocities, def_constructor.smooth_velocities);
+    EXPECT_EQ(profile.smooth_accelerations, def_constructor.smooth_accelerations);
+    EXPECT_EQ(profile.smooth_jerks, def_constructor.smooth_jerks);
+    EXPECT_EQ(profile.avoid_singularity, def_constructor.avoid_singularity);
+  }
+
+    { // Constructor
+    const std::string yaml_string = R"(config:
+                                        smooth_velocities: false
+                                        smooth_accelerations: true
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    TrajOptDefaultCompositeProfile profile(n["config"], plugin_factory);
+    TrajOptDefaultCompositeProfile def_constructor;
+    EXPECT_EQ(profile.smooth_velocities, false);
+    EXPECT_EQ(profile.smooth_accelerations, true);
+    EXPECT_EQ(profile.smooth_jerks, def_constructor.smooth_jerks);
+    EXPECT_EQ(profile.avoid_singularity, def_constructor.avoid_singularity);
+  }
+}
+
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, TrajOptDefaultMoveProfileYAMLConversion)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    TrajOptDefaultMoveProfile profile(n["config"], plugin_factory);
+    TrajOptDefaultMoveProfile def_constructor;
+    EXPECT_EQ(profile.cartesian_cost_config.enabled, def_constructor.cartesian_cost_config.enabled);
+    EXPECT_EQ(profile.cartesian_constraint_config.enabled, def_constructor.cartesian_constraint_config.enabled);
+    EXPECT_EQ(profile.joint_cost_config.enabled, def_constructor.joint_cost_config.enabled);
+    EXPECT_EQ(profile.joint_constraint_config.enabled, def_constructor.joint_constraint_config.enabled);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        cartesian_cost_config:
+                                          enabled: true
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    TrajOptDefaultMoveProfile profile(n["config"], plugin_factory);
+    TrajOptDefaultMoveProfile def_constructor;
+    EXPECT_EQ(profile.cartesian_cost_config.enabled, true);
+    EXPECT_EQ(profile.cartesian_constraint_config.enabled, def_constructor.cartesian_constraint_config.enabled);
+    EXPECT_EQ(profile.joint_cost_config.enabled, def_constructor.joint_cost_config.enabled);
+    EXPECT_EQ(profile.joint_constraint_config.enabled, def_constructor.joint_constraint_config.enabled);
+  }
+
+}
+
+TEST_F(TesseractPlanningTrajoptYAMLConversionsUnit, TrajOptOSQPSolverProfileYAMLConversion)  // NOLINT
+{
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    TrajOptOSQPSolverProfile profile(n["config"], plugin_factory);
+    TrajOptOSQPSolverProfile def_constructor;
+    EXPECT_EQ(profile.update_workspace, def_constructor.update_workspace);
+    EXPECT_EQ(profile.settings.rho, def_constructor.settings.rho);
+  }
+
+  { // Constructor
+    const std::string yaml_string = R"(config:
+                                        update_workspace: false
+                                    )";
+    YAML::Node n = YAML::Load(yaml_string);
+    tesseract_common::ProfilePluginFactory plugin_factory;
+    TrajOptOSQPSolverProfile profile(n["config"], plugin_factory);
+    TrajOptOSQPSolverProfile def_constructor;
+    EXPECT_EQ(profile.update_workspace, false);
+    EXPECT_EQ(profile.settings.rho, def_constructor.settings.rho);
+  }
+
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_composite_profile.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_composite_profile.h
@@ -32,8 +32,14 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
 #include <trajopt_common/collision_types.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
-
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
+
+namespace YAML
+{
+class Node;
+}
 
 namespace tesseract_planning
 {
@@ -41,6 +47,7 @@ class TrajOptIfoptDefaultCompositeProfile : public TrajOptIfoptCompositeProfile
 {
 public:
   TrajOptIfoptDefaultCompositeProfile() = default;
+  TrajOptIfoptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   /** @brief Configuration info for collisions that are modeled as costs */
   trajopt_common::TrajOptCollisionConfig collision_cost_config;

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_move_profile.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_move_profile.h
@@ -34,6 +34,14 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
 #include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_waypoint_config.h>
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+
+namespace YAML
+{
+class Node;
+}
+
 
 namespace tesseract_planning
 {
@@ -44,6 +52,8 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptIfoptDefaultMoveProfile>;
 
   TrajOptIfoptDefaultMoveProfile();
+  TrajOptIfoptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
+
 
   TrajOptIfoptCartesianWaypointConfig cartesian_cost_config;
   TrajOptIfoptCartesianWaypointConfig cartesian_constraint_config;

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h
@@ -32,6 +32,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <OsqpEigen/Settings.hpp>
 #include <trajopt_sqp/fwd.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
 
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
 
@@ -45,6 +47,12 @@ void serialize(Archive& ar, trajopt_sqp::SQPParameters& params, const unsigned i
 
 }  // namespace boost::serialization
 
+namespace YAML
+{
+class Node;
+}
+
+
 namespace tesseract_planning
 {
 /** @brief The contains the default solver parameters available for setting up TrajOpt */
@@ -55,6 +63,7 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptIfoptOSQPSolverProfile>;
 
   TrajOptIfoptOSQPSolverProfile();
+  TrajOptIfoptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
   TrajOptIfoptOSQPSolverProfile(TrajOptIfoptOSQPSolverProfile&&) = default;
   TrajOptIfoptOSQPSolverProfile& operator=(TrajOptIfoptOSQPSolverProfile&&) = default;
 

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h
@@ -40,10 +40,16 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_environment/fwd.h>
 #include <tesseract_command_language/fwd.h>
 #include <tesseract_common/profile.h>
-
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
 namespace ifopt
 {
 class ConstraintSet;
+}
+
+namespace YAML
+{
+class Node;
 }
 
 namespace tesseract_planning
@@ -72,6 +78,7 @@ public:
   using ConstPtr = std::shared_ptr<const TrajOptIfoptMoveProfile>;
 
   TrajOptIfoptMoveProfile();
+  TrajOptIfoptMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory);
 
   virtual TrajOptIfoptWaypointInfo create(const MoveInstructionPoly& move_instruction,
                                           const tesseract_common::ManipulatorInfo& composite_manip_info,

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/yaml_extensions.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/yaml_extensions.h
@@ -131,14 +131,14 @@ struct convert<trajopt_common::TrajOptCollisionConfig>
 template <>
 struct convert<trajopt_common::CollisionCoeffData>
 {
-  static Node encode(const trajopt_common::CollisionCoeffData& rhs)
+  static Node encode(const trajopt_common::CollisionCoeffData& /*rhs*/)
   {
     Node node;
     // only contains private variables
     return node;
   }
 
-  static bool decode(const Node& node, trajopt_common::CollisionCoeffData& rhs)
+  static bool decode(const Node& node, trajopt_common::CollisionCoeffData& /*rhs*/)
   {
     // Check for required entries
     return true;

--- a/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/yaml_extensions.h
+++ b/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/yaml_extensions.h
@@ -1,0 +1,215 @@
+/**
+ * @file yaml_extensions.h
+ * @brief YAML Type conversions for trajopt_ifopt types
+ *
+ * @author Samantha Smith
+ * @date August 5, 2025
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2025, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H
+#define TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H
+
+#include <tesseract_common/macros.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <yaml-cpp/yaml.h>
+#include <set>
+#include <vector>
+#include <osqp.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
+
+#include <tesseract_common/plugin_info.h>
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_collision/core/fwd.h>
+#include <tesseract_collision/core/types.h>
+#include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_profile.h>
+#include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_waypoint_config.h>
+#include <tesseract_motion_planners/core/utils.h>
+#include <trajopt_common/collision_types.h>
+
+
+
+
+
+
+namespace YAML
+{
+
+//=========================== Eigen::VectorXd ===========================
+
+template <>
+struct convert<Eigen::VectorXd>
+{
+  static Node encode(const Eigen::VectorXd& rhs)
+  {
+    Node node;
+    for (int i = 0; i < rhs.size(); ++i)
+      node.push_back(rhs(i));
+    return node;
+  }
+
+  static bool decode(const Node& node, Eigen::VectorXd& rhs)
+  {
+    if (!node.IsSequence())
+      return false;
+
+    rhs.resize(node.size());
+    for (std::size_t i = 0; i < node.size(); ++i)
+      rhs(static_cast<Eigen::Index>(i)) = node[i].as<double>();
+
+    return true;
+  }
+};
+
+//=========================== Eigen::Matrix<Scalar, Rows, 1> ===========================
+template <typename Scalar, int Rows>
+struct convert<Eigen::Matrix<Scalar, Rows, 1>>
+{
+  static Node encode(const Eigen::Matrix<Scalar, Rows, 1>& rhs)
+  {
+    Node node;
+    for (int i = 0; i < rhs.rows(); ++i)
+      node.push_back(rhs(i));
+    return node;
+  }
+
+  static bool decode(const Node& node, Eigen::Matrix<Scalar, Rows, 1>& rhs)
+  {
+    if (!node.IsSequence() || node.size() != static_cast<std::size_t>(Rows))
+      return false;
+
+    for (int i = 0; i < Rows; ++i)
+      rhs(i) = node[i].as<Scalar>();
+
+    return true;
+  }
+};
+
+//=========================== TrajOptCollisionConfig ===========================
+template <>
+struct convert<trajopt_common::TrajOptCollisionConfig>
+{
+  static Node encode(const trajopt_common::TrajOptCollisionConfig& rhs)
+  {
+    Node node;
+    node["collision_coeff_data"] = rhs.collision_coeff_data;
+    node["collision_margin_buffer"] = rhs.collision_margin_buffer;
+    node["max_num_cnt"] = rhs.max_num_cnt;
+    return node;
+  }
+
+  static bool decode(const Node& node, trajopt_common::TrajOptCollisionConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["collision_coeff_data"])
+      rhs.collision_coeff_data = n.as<trajopt_common::CollisionCoeffData>();
+    if (const YAML::Node& n = node["collision_margin_buffer"])
+      rhs.collision_margin_buffer = n.as<double>();
+    if (const YAML::Node& n = node["max_num_cnt"])
+      rhs.max_num_cnt = n.as<int>();
+    return true;
+  }
+};
+
+//=========================== CollisionCoeffData ===========================
+template <>
+struct convert<trajopt_common::CollisionCoeffData>
+{
+  static Node encode(const trajopt_common::CollisionCoeffData& rhs)
+  {
+    Node node;
+    // only contains private variables
+    return node;
+  }
+
+  static bool decode(const Node& node, trajopt_common::CollisionCoeffData& rhs)
+  {
+    // Check for required entries
+    return true;
+  }
+};
+
+//=========================== TrajOptCartesianWaypointConfig ===========================
+template <>
+struct convert<tesseract_planning::TrajOptIfoptCartesianWaypointConfig>
+{
+  static Node encode(const tesseract_planning::TrajOptIfoptCartesianWaypointConfig& rhs)
+  {
+    Node node;
+    node["enabled"] = rhs.enabled;
+    node["use_tolerance_override"] = rhs.use_tolerance_override;
+    node["lower_tolerance"] = rhs.lower_tolerance;
+    node["upper_tolerance"] = rhs.upper_tolerance;
+    node["coeff"] = rhs.coeff;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::TrajOptIfoptCartesianWaypointConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["enabled"])
+      rhs.enabled = n.as<bool>();
+    if (const YAML::Node& n = node["use_tolerance_override"])
+      rhs.use_tolerance_override = n.as<bool>();
+    if (const YAML::Node& n = node["lower_tolerance"])
+      rhs.lower_tolerance = n.as<Eigen::Matrix<double, 6, 1>>();
+    if (const YAML::Node& n = node["upper_tolerance"])
+      rhs.upper_tolerance = n.as<Eigen::Matrix<double, 6, 1>>();
+    if (const YAML::Node& n = node["coeff"])
+      rhs.coeff = n.as<Eigen::Matrix<double, 6, 1>>();
+    return true;
+  }
+};
+
+//=========================== TrajOptIfoptJointWaypointConfig ===========================
+template <>
+struct convert<tesseract_planning::TrajOptIfoptJointWaypointConfig>
+{
+  static Node encode(const tesseract_planning::TrajOptIfoptJointWaypointConfig& rhs)
+  {
+    Node node;
+    node["enabled"] = rhs.enabled;
+    node["use_tolerance_override"] = rhs.use_tolerance_override;
+    node["lower_tolerance"] = rhs.lower_tolerance;
+    node["upper_tolerance"] = rhs.upper_tolerance;
+    node["coeff"] = rhs.coeff;
+    return node;
+  }
+
+  static bool decode(const Node& node, tesseract_planning::TrajOptIfoptJointWaypointConfig& rhs)
+  {
+    // Check for required entries
+    if (const YAML::Node& n = node["enabled"])
+      rhs.enabled = n.as<bool>();
+    if (const YAML::Node& n = node["use_tolerance_override"])
+      rhs.use_tolerance_override = n.as<bool>();
+    if (const YAML::Node& n = node["lower_tolerance"])
+      rhs.lower_tolerance = n.as<Eigen::VectorXd>();
+    if (const YAML::Node& n = node["upper_tolerance"])
+      rhs.upper_tolerance = n.as<Eigen::VectorXd>();
+    if (const YAML::Node& n = node["coeff"])
+      rhs.coeff = n.as<Eigen::VectorXd>();
+    return true;
+  }
+};
+
+
+}  // namespace YAML
+
+#endif  // TESSERACT_MOTION_PLANNING_YAML_EXTENSIONS_H

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_composite_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_composite_profile.cpp
@@ -47,7 +47,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {
-TrajOptIfoptDefaultCompositeProfile::TrajOptIfoptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory) 
+TrajOptIfoptDefaultCompositeProfile::TrajOptIfoptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/) 
 : TrajOptIfoptDefaultCompositeProfile()
 {
   try

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_composite_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_composite_profile.cpp
@@ -32,6 +32,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/shared_ptr.hpp>
+#include <yaml-cpp/yaml.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_composite_profile.h>
@@ -40,9 +41,48 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_common/manipulator_info.h>
 #include <tesseract_common/eigen_serialization.h>
 #include <tesseract_collision/core/serialization.h>
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_motion_planners/trajopt_ifopt/yaml_extensions.h>
+
 
 namespace tesseract_planning
 {
+TrajOptIfoptDefaultCompositeProfile::TrajOptIfoptDefaultCompositeProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory) 
+: TrajOptIfoptDefaultCompositeProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["collision_cost_config"])
+      collision_cost_config = n.as<trajopt_common::TrajOptCollisionConfig>();
+
+    if (YAML::Node n = config["collision_constraint_config"])
+      collision_constraint_config = n.as<trajopt_common::TrajOptCollisionConfig>();
+
+    if (YAML::Node n = config["smooth_velocities"])
+      smooth_velocities = n.as<bool>();
+
+    if (YAML::Node n = config["velocity_coeff"])
+      velocity_coeff = n.as<Eigen::VectorXd>();
+
+    if (YAML::Node n = config["smooth_accelerations"])
+      smooth_accelerations = n.as<bool>();
+
+    if (YAML::Node n = config["acceleration_coeff"])
+      acceleration_coeff = n.as<Eigen::VectorXd>();
+
+    if (YAML::Node n = config["smooth_jerks"])
+      smooth_jerks = n.as<bool>();
+
+    if (YAML::Node n = config["jerk_coeff"])
+      jerk_coeff = n.as<Eigen::VectorXd>();
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("TrajOptDefaultCompositeProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
+
+  
 TrajOptIfoptTermInfos TrajOptIfoptDefaultCompositeProfile::create(
     const tesseract_common::ManipulatorInfo& composite_manip_info,
     const std::shared_ptr<const tesseract_environment::Environment>& env,

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_move_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_move_profile.cpp
@@ -30,6 +30,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <trajopt_ifopt/variable_sets/joint_position_variable.h>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <yaml-cpp/yaml.h>
+
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_default_move_profile.h>
@@ -50,6 +52,10 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/eigen_serialization.h>
 
+#include <tesseract_common/profile_plugin_factory.h>
+#include <tesseract_motion_planners/trajopt_ifopt/yaml_extensions.h>
+
+
 namespace tesseract_planning
 {
 TrajOptIfoptDefaultMoveProfile::TrajOptIfoptDefaultMoveProfile()
@@ -57,6 +63,31 @@ TrajOptIfoptDefaultMoveProfile::TrajOptIfoptDefaultMoveProfile()
   cartesian_cost_config.enabled = false;
   joint_cost_config.enabled = false;
 }
+
+TrajOptIfoptDefaultMoveProfile::TrajOptIfoptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptIfoptDefaultMoveProfile()
+{
+  try
+  {
+    if (YAML::Node n = config["cartesian_cost_config"])
+      cartesian_cost_config = n.as<tesseract_planning::TrajOptIfoptCartesianWaypointConfig>();
+
+    if (YAML::Node n = config["cartesian_constraint_config"])
+      cartesian_constraint_config = n.as<tesseract_planning::TrajOptIfoptCartesianWaypointConfig>();
+    
+      if (YAML::Node n = config["joint_cost_config"])
+      joint_cost_config = n.as<tesseract_planning::TrajOptIfoptJointWaypointConfig>();
+
+    if (YAML::Node n = config["joint_constraint_config"])
+      joint_constraint_config = n.as<tesseract_planning::TrajOptIfoptJointWaypointConfig>();
+
+  }
+  catch (const std::exception& e)
+  {
+    throw std::runtime_error("TrajOptDefaultCompositeProfile: Failed to parse yaml config! Details: " + std::string(e.what()));
+  }
+}
+
 
 TrajOptIfoptWaypointInfo
 TrajOptIfoptDefaultMoveProfile::create(const MoveInstructionPoly& move_instruction,

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_move_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_move_profile.cpp
@@ -64,7 +64,7 @@ TrajOptIfoptDefaultMoveProfile::TrajOptIfoptDefaultMoveProfile()
   joint_cost_config.enabled = false;
 }
 
-TrajOptIfoptDefaultMoveProfile::TrajOptIfoptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptIfoptDefaultMoveProfile::TrajOptIfoptDefaultMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptIfoptDefaultMoveProfile()
 {
   try

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_osqp_solver_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_osqp_solver_profile.cpp
@@ -33,10 +33,14 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/unique_ptr.hpp>
+#include <yaml-cpp/yaml.h>
+
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/trajopt_ifopt/profile/trajopt_ifopt_osqp_solver_profile.h>
 #include <tesseract_motion_planners/trajopt_ifopt/trajopt_ifopt_utils.h>
+#include <tesseract_common/profile_plugin_factory.h>
+
 
 namespace boost::serialization
 {
@@ -81,6 +85,11 @@ TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile()
   qp_settings->setMaxIteration(8192);
   qp_settings->setAbsoluteTolerance(1e-4);
   qp_settings->setRelativeTolerance(1e-6);
+}
+
+TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptIfoptOSQPSolverProfile()
+{
 }
 
 std::unique_ptr<trajopt_sqp::TrustRegionSQPSolver> TrajOptIfoptOSQPSolverProfile::create(bool verbose) const

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_osqp_solver_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_osqp_solver_profile.cpp
@@ -87,7 +87,7 @@ TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile()
   qp_settings->setRelativeTolerance(1e-6);
 }
 
-TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptIfoptOSQPSolverProfile::TrajOptIfoptOSQPSolverProfile(const YAML::Node& /*config*/, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptIfoptOSQPSolverProfile()
 {
 }

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_profile.cpp
@@ -27,6 +27,9 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <typeindex>
+#include <yaml-cpp/yaml.h>
+#include <tesseract_common/profile_plugin_factory.h>
+
 
 namespace boost::serialization
 {
@@ -57,6 +60,10 @@ void serialize(Archive& ar, trajopt_sqp::SQPParameters& params, const unsigned i
 namespace tesseract_planning
 {
 TrajOptIfoptMoveProfile::TrajOptIfoptMoveProfile() : Profile(TrajOptIfoptMoveProfile::getStaticKey()) {}
+TrajOptIfoptMoveProfile::TrajOptIfoptMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+: TrajOptIfoptMoveProfile()
+{
+}
 
 std::size_t TrajOptIfoptMoveProfile::getStaticKey()
 {

--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_profile.cpp
@@ -60,7 +60,7 @@ void serialize(Archive& ar, trajopt_sqp::SQPParameters& params, const unsigned i
 namespace tesseract_planning
 {
 TrajOptIfoptMoveProfile::TrajOptIfoptMoveProfile() : Profile(TrajOptIfoptMoveProfile::getStaticKey()) {}
-TrajOptIfoptMoveProfile::TrajOptIfoptMoveProfile(const YAML::Node& config, const tesseract_common::ProfilePluginFactory& plugin_factory)
+TrajOptIfoptMoveProfile::TrajOptIfoptMoveProfile(const YAML::Node& /*config*/, const tesseract_common::ProfilePluginFactory& /*plugin_factory*/)
 : TrajOptIfoptMoveProfile()
 {
 }


### PR DESCRIPTION
This PR updates the constructors to enable them to be initialized from a YAML node for the `simple`, `trajopt`, and `trajopt_ifopt` planners.

This PR also adds in the YAML conversions for the types used in these profiles and constructors so they can be initialized from a YAML node as well.

Unit tests were also added to test the new constructors and YAML conversions.