### PR TITLE
Add solver settings to fix state collision task

### DIFF
--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_collision_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_collision_profile.h
@@ -30,6 +30,8 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <memory>
 #include <vector>
+#include <trajopt/fwd.hpp>
+#include <trajopt_sco/optimizers.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_collision/core/types.h>
@@ -37,6 +39,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract_motion_planners/trajopt/trajopt_waypoint_config.h>
 #include <tesseract_common/fwd.h>
 #include <trajopt_common/collision_types.h>
+#include <trajopt_sco/osqp_interface.hpp>
 
 namespace YAML
 {
@@ -108,6 +111,15 @@ struct FixStateCollisionProfile : public tesseract_common::Profile
 
   /** @brief Coefficient for collision cost in TrajOpt optimization */
   trajopt_common::CollisionCoeffData collision_cost_coeff;
+
+  /** @brief Optimization parameters */
+  sco::BasicTrustRegionSQPParameters opt_params;
+
+  /** @brief OSQP settings */
+  OSQPSettings osqp_settings{};
+
+  /** @brief Update the OSQP workspace for subsequent optimizations, instead of recreating it each time */
+  bool update_workspace{ false };
 
 private:
   friend class boost::serialization::access;

--- a/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
@@ -169,6 +169,13 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
   pci.basic_info.manip = manip_info.manipulator;
   pci.basic_info.use_time = false;
 
+  // Apply solver settings
+  auto config = std::make_unique<sco::OSQPModelConfig>();
+  config->settings = profile.osqp_settings;
+  config->update_workspace = profile.update_workspace;
+  pci.basic_info.convex_solver_config = std::move(config);
+  pci.opt_info = profile.opt_params;
+
   // Create Kinematic Object
   pci.kin = pci.env->getJointGroup(pci.basic_info.manip);
 


### PR DESCRIPTION
More control over trajopt solver settings for fix state collision. I ran into a problem where I had to change some settings for it to converge, so I thought it would make sense just to expose them. If you don't touch these settings, I believe everything should stay unchanged.