### PR TITLE
Add missing opt_params serialization

### DIFF
--- a/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/cereal_serialization.h
+++ b/tesseract_motion_planners/trajopt/include/tesseract_motion_planners/trajopt/cereal_serialization.h
@@ -118,6 +118,7 @@ template <class Archive>
 void serialize(Archive& ar, TrajOptSolverProfile& obj)
 {
   ar(cereal::base_class<tesseract_common::Profile>(&obj));
+  ar(cereal::make_nvp("opt_params", obj.opt_params));
 }
 
 template <class Archive>


### PR DESCRIPTION
[See trajopt_ifopt](https://github.com/tesseract-robotics/tesseract_planning/blob/master/tesseract_motion_planners/trajopt_ifopt/include/tesseract_motion_planners/trajopt_ifopt/cereal_serialization.h#L123), where it is present.