### PR TITLE
actually set opt params for fix state collision task

### DIFF
--- a/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/fix_state_collision_task.cpp
@@ -324,6 +324,7 @@ bool moveWaypointFromCollisionTrajopt(WaypointPoly& waypoint,
 
   // Run trajopt optimization
   sco::BasicTrustRegionSQP opt(prob);
+  opt.setParameters(pci.opt_info);
   opt.initialize(trajToDblVec(prob->GetInitTraj()));
   opt.optimize();
   if (opt.results().status != sco::OptStatus::OPT_CONVERGED)


### PR DESCRIPTION
Previously the opt params weren't actually getting applied to the trajopt optimization.