### PR TITLE
Remove fixed indices from optimization

### DIFF
--- a/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_move_profile.cpp
+++ b/tesseract_motion_planners/trajopt_ifopt/src/profile/trajopt_ifopt_default_move_profile.cpp
@@ -203,10 +203,13 @@ TrajOptIfoptDefaultMoveProfile::create(const MoveInstructionPoly& move_instructi
 
     // Create var set
     info.node = std::make_unique<trajopt_ifopt::Node>("Node_" + std::to_string(index));
+    // Fix the variable bounds if the waypoint is fixed
+    auto var_bounds = info.fixed ? trajopt_ifopt::toBounds(jwp.getPosition(), jwp.getPosition()) : bounds;
     std::shared_ptr<const trajopt_ifopt::Var> var =
-        info.node->addVar("position", joint_names, jwp.getPosition(), bounds);
+        info.node->addVar("position", joint_names, jwp.getPosition(), var_bounds);
 
-    if (jwp.isConstrained())
+    // Only add cost/constraint if the waypoint is constrained and not fixed
+    if (jwp.isConstrained() && !info.fixed)
     {
       // Override cost tolerances if the profile specifies that they should be overrided.
       Eigen::VectorXd lower_tolerance_cost = jwp.getLowerTolerance();


### PR DESCRIPTION
I noticed Trajopt Ifopt adding a JointPos constraint to the optimization for constrained/fixed joint waypoints. Legacy Trajopt does not do this. Is this intentional? If not, this PR has a fix (suggested by Copilot, to be fair). What do you think, @Levi-Armstrong?