### PR TITLE
Update debian package CI job

### DIFF
--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -7,46 +7,30 @@ on:
 
   # allow manually starting this workflow
   workflow_dispatch:
+    inputs:
+      major_version:
+        description: 'Major Version'
+        required: true
+        type: string
+      minor_version:
+        description: 'Minor Version'
+        required: true
+        type: string
+      patch_version:
+        description: 'Patch Version'
+        required: true
+        type: string
 
 jobs:
-  get-tag:
-    # Pre-job to derive major/minor from the triggering ref name
-    runs-on: ubuntu-latest
-    outputs:
-      major: ${{ steps.extract_tag.outputs.major }}
-      minor: ${{ steps.extract_tag.outputs.minor }}
-    steps:
-      - name: Extract version from ref name
-        id: extract_tag
-        run: |
-          echo "Ref name: ${{ github.ref_name }}"
-
-          # Accept semantic versions like 1.2.3, v1.2.3, 1.2.3-rc.1, and 1.2.3+build.7
-          semver_regex='^v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
-          if [[ ! "${{ github.ref_name }}" =~ ${semver_regex} ]]; then
-            echo "Error: github.ref_name '${{ github.ref_name }}' is not a semantic version (expected examples: v1.2.3 or 1.2.3)."
-            exit 1
-          fi
-
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          echo "Major: $major"
-          echo "Minor: $minor"
-
-          # Set as output variables
-          echo "major=$major" >> "$GITHUB_OUTPUT"
-          echo "minor=$minor" >> "$GITHUB_OUTPUT"
-
   Debian:
     name: ${{ matrix.distro }}
-    needs: get-tag  # Make sure the 'ci' job waits for the 'get-tag' job to finish
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         distro: [jammy, noble]
     container:
-      image: ghcr.io/tesseract-robotics/trajopt:${{ matrix.distro }}-${{ needs.get-tag.outputs.major }}.${{ needs.get-tag.outputs.minor }}
+      image: ghcr.io/tesseract-robotics/trajopt:${{ matrix.distro }}-${{ github.event.inputs.major_version }}.${{ github.event.inputs.minor_version }}
       env:
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
@@ -56,6 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: target_ws/src
+          ref: ${{ github.event.inputs.major_version }}.${{ github.event.inputs.minor_version }}.${{ github.event.inputs.patch_version }}
 
       - name: Install Depends
         shell: bash

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -10,31 +10,32 @@ on:
 
 jobs:
   get-tag:
-    # Pre-job to fetch the latest tag
+    # Pre-job to derive major/minor from the triggering ref name
     runs-on: ubuntu-latest
     outputs:
       major: ${{ steps.extract_tag.outputs.major }}
       minor: ${{ steps.extract_tag.outputs.minor }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Ensure all history and tags are fetched
-
-      - name: Get latest tag
+      - name: Extract version from ref name
         id: extract_tag
         run: |
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "Latest tag: $latest_tag"
+          echo "Ref name: ${{ github.ref_name }}"
 
-          # Extract major and minor version from the tag
-          IFS='.' read -r major minor patch <<< "$latest_tag"
+          # Accept semantic versions like 1.2.3, v1.2.3, 1.2.3-rc.1, and 1.2.3+build.7
+          semver_regex='^v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "${{ github.ref_name }}" =~ ${semver_regex} ]]; then
+            echo "Error: github.ref_name '${{ github.ref_name }}' is not a semantic version (expected examples: v1.2.3 or 1.2.3)."
+            exit 1
+          fi
+
+          major="${BASH_REMATCH[1]}"
+          minor="${BASH_REMATCH[2]}"
           echo "Major: $major"
           echo "Minor: $minor"
 
           # Set as output variables
-          echo "::set-output name=major::$major"
-          echo "::set-output name=minor::$minor"
+          echo "major=$major" >> "$GITHUB_OUTPUT"
+          echo "minor=$minor" >> "$GITHUB_OUTPUT"
 
   Debian:
     name: ${{ matrix.distro }}


### PR DESCRIPTION
I'm trying to generate debians of previous tagged versions of this repository to add to the releases, and I'm running into the issue where the debian package build CI job identifies the latest tagged version (e.g., 0.35.0) as the platform on which to build the debians despite the workflow being invoked for a previous tag (e.g., 0.29.2). See [this workflow](https://github.com/tesseract-robotics/tesseract_planning/actions/runs/26647000341) as an example.

~~This PR updates the debian package CI job to pull the major and minor versions from the triggering git ref name rather than from the latest tag of the repository. This changes allows the workflow to be run on command for non-latest tags (e.g., to generate debians for existing releases). If this workflow is triggered by a git ref that is not a tag compatible with semantic versioning, the `get-tag` step will fail and report the error.~~

This PR updates the debian package CI job to get the target major, minor and patch versions from workflow dispatch text inputs provided by the user triggering the build. It then uses the major and minor versions to pull the correct Docker image for the build and specifies the full tag (`major.minor.patch`) as the repository ref to check out for the build