### PR TITLE
Restore Cereal template registration in compiled cpp files instead of…

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -22,5 +22,5 @@ jobs:
           ./.run-clang-format
           if [ $? -ge 1 ]; then return 1; fi
           output=$(git diff)
-          echo $output
+          echo "$output"
           if [ -n "$output" ]; then exit 1; else exit 0; fi

--- a/.github/workflows/conda/recipe/build.sh
+++ b/.github/workflows/conda/recipe/build.sh
@@ -4,6 +4,10 @@ set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     TCMALLOC_LIB_PATH="$PREFIX/lib/libtcmalloc_minimal.dylib"
+    # conda's clang adds -fvisibility-inlines-hidden, hiding Cereal's visibility("default")
+    # registration singleton; with Mach-O's two-level namespace each dylib gets its own registry
+    # and consumers throw "unregistered polymorphic type". Strip it so the registry is shared.
+    export CXXFLAGS="${CXXFLAGS//-fvisibility-inlines-hidden/}"
 else
     TCMALLOC_LIB_PATH="$PREFIX/lib/libtcmalloc_minimal.so"
 fi

--- a/command_language/CMakeLists.txt
+++ b/command_language/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(
   src/joint_waypoint.cpp
   src/utils.cpp)
 add_library(tesseract::command_language ALIAS command_language)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(command_language PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(command_language PROPERTIES OUTPUT_NAME tesseract_command_language)
 target_link_libraries(
   command_language

--- a/command_language/CMakeLists.txt
+++ b/command_language/CMakeLists.txt
@@ -21,8 +21,8 @@ add_library(
   src/joint_waypoint.cpp
   src/utils.cpp)
 add_library(tesseract::command_language ALIAS command_language)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(command_language PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(command_language PROPERTIES OUTPUT_NAME tesseract_command_language)

--- a/command_language/include/tesseract/command_language/cereal_serialization.h
+++ b/command_language/include/tesseract/command_language/cereal_serialization.h
@@ -223,9 +223,9 @@ void serialize(Archive& ar, WaitInstruction& obj)
 
 }  // namespace tesseract::command_language
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/command_language/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_command_language_cereal)

--- a/command_language/include/tesseract/command_language/cereal_serialization.h
+++ b/command_language/include/tesseract/command_language/cereal_serialization.h
@@ -223,6 +223,12 @@ void serialize(Archive& ar, WaitInstruction& obj)
 
 }  // namespace tesseract::command_language
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/command_language/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_command_language_cereal)
+#endif
 
 #endif  // TESSERACT_COMMAND_LANGUAGE_CEREAL_SERIALIZATION_H

--- a/command_language/src/cereal_serialization.cpp
+++ b/command_language/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/command_language/cereal_serialization.h>
+#include <tesseract/command_language/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_command_language_cereal)

--- a/motion_planners/descartes/CMakeLists.txt
+++ b/motion_planners/descartes/CMakeLists.txt
@@ -12,8 +12,8 @@ add_library(
   src/profile/descartes_default_move_profile.cpp
   src/profile/descartes_ladder_graph_solver_profile.cpp)
 add_library(tesseract::motion_planners_descartes ALIAS motion_planners_descartes)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(motion_planners_descartes PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(motion_planners_descartes PROPERTIES OUTPUT_NAME tesseract_motion_planners_descartes)

--- a/motion_planners/descartes/CMakeLists.txt
+++ b/motion_planners/descartes/CMakeLists.txt
@@ -12,6 +12,10 @@ add_library(
   src/profile/descartes_default_move_profile.cpp
   src/profile/descartes_ladder_graph_solver_profile.cpp)
 add_library(tesseract::motion_planners_descartes ALIAS motion_planners_descartes)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(motion_planners_descartes PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(motion_planners_descartes PROPERTIES OUTPUT_NAME tesseract_motion_planners_descartes)
 target_link_libraries(
   motion_planners_descartes

--- a/motion_planners/descartes/include/tesseract/motion_planners/descartes/cereal_serialization.h
+++ b/motion_planners/descartes/include/tesseract/motion_planners/descartes/cereal_serialization.h
@@ -55,6 +55,12 @@ void serialize(Archive& ar, DescartesDefaultMoveProfile<FloatType>& obj)
 
 }  // namespace tesseract::motion_planners
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/motion_planners/descartes/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_descartes_cereal)
+#endif
 
 #endif  // TESSERACT_MOTION_PLANNERS_DESCARTES_CEREAL_SERIALIZATION_H

--- a/motion_planners/descartes/include/tesseract/motion_planners/descartes/cereal_serialization.h
+++ b/motion_planners/descartes/include/tesseract/motion_planners/descartes/cereal_serialization.h
@@ -55,9 +55,9 @@ void serialize(Archive& ar, DescartesDefaultMoveProfile<FloatType>& obj)
 
 }  // namespace tesseract::motion_planners
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/motion_planners/descartes/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_descartes_cereal)

--- a/motion_planners/descartes/src/cereal_serialization.cpp
+++ b/motion_planners/descartes/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/motion_planners/descartes/cereal_serialization.h>
+#include <tesseract/motion_planners/descartes/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_motion_planners_descartes_cereal)

--- a/motion_planners/ompl/CMakeLists.txt
+++ b/motion_planners/ompl/CMakeLists.txt
@@ -20,6 +20,10 @@ set(OMPL_SRC
 message(AUTHOR_WARNING "OMPL INCLUDE DIRS: ${OMPL_INCLUDE_DIRS}")
 add_library(motion_planners_ompl ${OMPL_SRC})
 add_library(tesseract::motion_planners_ompl ALIAS motion_planners_ompl)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(motion_planners_ompl PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(motion_planners_ompl PROPERTIES OUTPUT_NAME tesseract_motion_planners_ompl)
 target_link_libraries(
   motion_planners_ompl

--- a/motion_planners/ompl/CMakeLists.txt
+++ b/motion_planners/ompl/CMakeLists.txt
@@ -20,8 +20,8 @@ set(OMPL_SRC
 message(AUTHOR_WARNING "OMPL INCLUDE DIRS: ${OMPL_INCLUDE_DIRS}")
 add_library(motion_planners_ompl ${OMPL_SRC})
 add_library(tesseract::motion_planners_ompl ALIAS motion_planners_ompl)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(motion_planners_ompl PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(motion_planners_ompl PROPERTIES OUTPUT_NAME tesseract_motion_planners_ompl)

--- a/motion_planners/ompl/include/tesseract/motion_planners/ompl/cereal_serialization.h
+++ b/motion_planners/ompl/include/tesseract/motion_planners/ompl/cereal_serialization.h
@@ -167,6 +167,12 @@ void serialize(Archive& ar, OMPLRealVectorMoveProfile& obj)
 }
 }  // namespace tesseract::motion_planners
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/motion_planners/ompl/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_ompl_cereal)
+#endif
 
 #endif  // TESSERACT_MOTION_PLANNERS_OMPL_CEREAL_SERIALIZATION_H

--- a/motion_planners/ompl/include/tesseract/motion_planners/ompl/cereal_serialization.h
+++ b/motion_planners/ompl/include/tesseract/motion_planners/ompl/cereal_serialization.h
@@ -167,9 +167,9 @@ void serialize(Archive& ar, OMPLRealVectorMoveProfile& obj)
 }
 }  // namespace tesseract::motion_planners
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/motion_planners/ompl/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_ompl_cereal)

--- a/motion_planners/ompl/src/cereal_serialization.cpp
+++ b/motion_planners/ompl/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/motion_planners/ompl/cereal_serialization.h>
+#include <tesseract/motion_planners/ompl/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_motion_planners_ompl_cereal)

--- a/motion_planners/simple/CMakeLists.txt
+++ b/motion_planners/simple/CMakeLists.txt
@@ -11,8 +11,8 @@ add_library(
   src/profile/simple_planner_lvs_move_profile.cpp
   src/profile/simple_planner_profile.cpp)
 add_library(tesseract::motion_planners_simple ALIAS motion_planners_simple)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(motion_planners_simple PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(motion_planners_simple PROPERTIES OUTPUT_NAME tesseract_motion_planners_simple)

--- a/motion_planners/simple/CMakeLists.txt
+++ b/motion_planners/simple/CMakeLists.txt
@@ -11,6 +11,10 @@ add_library(
   src/profile/simple_planner_lvs_move_profile.cpp
   src/profile/simple_planner_profile.cpp)
 add_library(tesseract::motion_planners_simple ALIAS motion_planners_simple)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(motion_planners_simple PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(motion_planners_simple PROPERTIES OUTPUT_NAME tesseract_motion_planners_simple)
 target_link_libraries(motion_planners_simple PUBLIC tesseract::motion_planners Boost::boost cereal::cereal)
 target_compile_options(motion_planners_simple PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})

--- a/motion_planners/simple/include/tesseract/motion_planners/simple/cereal_serialization.h
+++ b/motion_planners/simple/include/tesseract/motion_planners/simple/cereal_serialization.h
@@ -98,9 +98,9 @@ void serialize(Archive& ar, SimplePlannerLVSNoIKMoveProfile& obj)
 }
 }  // namespace tesseract::motion_planners
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/motion_planners/simple/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_simple_cereal)

--- a/motion_planners/simple/include/tesseract/motion_planners/simple/cereal_serialization.h
+++ b/motion_planners/simple/include/tesseract/motion_planners/simple/cereal_serialization.h
@@ -13,6 +13,7 @@
 #include <tesseract/common/cereal_serialization.h>
 
 #include <cereal/cereal.hpp>
+#include <cereal/types/polymorphic.hpp>
 
 namespace tesseract::motion_planners
 {
@@ -97,6 +98,12 @@ void serialize(Archive& ar, SimplePlannerLVSNoIKMoveProfile& obj)
 }
 }  // namespace tesseract::motion_planners
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/motion_planners/simple/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_simple_cereal)
+#endif
 
 #endif  // TESSERACT_MOTION_PLANNERS_SIMPLE_CEREAL_SERIALIZATION_H

--- a/motion_planners/simple/src/cereal_serialization.cpp
+++ b/motion_planners/simple/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/motion_planners/simple/cereal_serialization.h>
+#include <tesseract/motion_planners/simple/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_motion_planners_simple_cereal)

--- a/motion_planners/trajopt/CMakeLists.txt
+++ b/motion_planners/trajopt/CMakeLists.txt
@@ -13,6 +13,10 @@ add_library(
   src/profile/trajopt_default_composite_profile.cpp
   src/profile/trajopt_osqp_solver_profile.cpp)
 add_library(tesseract::motion_planners_trajopt ALIAS motion_planners_trajopt)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(motion_planners_trajopt PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(motion_planners_trajopt PROPERTIES OUTPUT_NAME tesseract_motion_planners_trajopt)
 target_link_libraries(
   motion_planners_trajopt

--- a/motion_planners/trajopt/CMakeLists.txt
+++ b/motion_planners/trajopt/CMakeLists.txt
@@ -13,8 +13,8 @@ add_library(
   src/profile/trajopt_default_composite_profile.cpp
   src/profile/trajopt_osqp_solver_profile.cpp)
 add_library(tesseract::motion_planners_trajopt ALIAS motion_planners_trajopt)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(motion_planners_trajopt PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(motion_planners_trajopt PROPERTIES OUTPUT_NAME tesseract_motion_planners_trajopt)

--- a/motion_planners/trajopt/include/tesseract/motion_planners/trajopt/cereal_serialization.h
+++ b/motion_planners/trajopt/include/tesseract/motion_planners/trajopt/cereal_serialization.h
@@ -157,9 +157,9 @@ void serialize(Archive& ar, TrajOptOSQPSolverProfile& obj)
 
 }  // namespace tesseract::motion_planners
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/motion_planners/trajopt/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_trajopt_cereal)

--- a/motion_planners/trajopt/include/tesseract/motion_planners/trajopt/cereal_serialization.h
+++ b/motion_planners/trajopt/include/tesseract/motion_planners/trajopt/cereal_serialization.h
@@ -157,6 +157,12 @@ void serialize(Archive& ar, TrajOptOSQPSolverProfile& obj)
 
 }  // namespace tesseract::motion_planners
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/motion_planners/trajopt/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_trajopt_cereal)
+#endif
 
 #endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_CEREAL_SERIALIZATION_H

--- a/motion_planners/trajopt/src/cereal_serialization.cpp
+++ b/motion_planners/trajopt/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/motion_planners/trajopt/cereal_serialization.h>
+#include <tesseract/motion_planners/trajopt/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_motion_planners_trajopt_cereal)

--- a/motion_planners/trajopt_ifopt/CMakeLists.txt
+++ b/motion_planners/trajopt_ifopt/CMakeLists.txt
@@ -12,6 +12,10 @@ add_library(
   src/profile/trajopt_ifopt_default_composite_profile.cpp
   src/profile/trajopt_ifopt_osqp_solver_profile.cpp)
 add_library(tesseract::motion_planners_trajopt_ifopt ALIAS motion_planners_trajopt_ifopt)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(motion_planners_trajopt_ifopt PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(motion_planners_trajopt_ifopt PROPERTIES OUTPUT_NAME tesseract_motion_planners_trajopt_ifopt)
 target_link_libraries(
   motion_planners_trajopt_ifopt

--- a/motion_planners/trajopt_ifopt/CMakeLists.txt
+++ b/motion_planners/trajopt_ifopt/CMakeLists.txt
@@ -12,8 +12,8 @@ add_library(
   src/profile/trajopt_ifopt_default_composite_profile.cpp
   src/profile/trajopt_ifopt_osqp_solver_profile.cpp)
 add_library(tesseract::motion_planners_trajopt_ifopt ALIAS motion_planners_trajopt_ifopt)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(motion_planners_trajopt_ifopt PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(motion_planners_trajopt_ifopt PROPERTIES OUTPUT_NAME tesseract_motion_planners_trajopt_ifopt)

--- a/motion_planners/trajopt_ifopt/include/tesseract/motion_planners/trajopt_ifopt/cereal_serialization.h
+++ b/motion_planners/trajopt_ifopt/include/tesseract/motion_planners/trajopt_ifopt/cereal_serialization.h
@@ -156,9 +156,9 @@ void serialize(Archive& ar, TrajOptIfoptOSQPSolverProfile& obj)
 
 }  // namespace tesseract::motion_planners
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/motion_planners/trajopt_ifopt/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_trajopt_ifopt_cereal)

--- a/motion_planners/trajopt_ifopt/include/tesseract/motion_planners/trajopt_ifopt/cereal_serialization.h
+++ b/motion_planners/trajopt_ifopt/include/tesseract/motion_planners/trajopt_ifopt/cereal_serialization.h
@@ -156,6 +156,12 @@ void serialize(Archive& ar, TrajOptIfoptOSQPSolverProfile& obj)
 
 }  // namespace tesseract::motion_planners
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/motion_planners/trajopt_ifopt/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_motion_planners_trajopt_ifopt_cereal)
+#endif
 
 #endif  // TESSERACT_MOTION_PLANNERS_TRAJOPT_IFOPT_CEREAL_SERIALIZATION_H

--- a/motion_planners/trajopt_ifopt/src/cereal_serialization.cpp
+++ b/motion_planners/trajopt_ifopt/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/motion_planners/trajopt_ifopt/cereal_serialization.h>
+#include <tesseract/motion_planners/trajopt_ifopt/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_motion_planners_trajopt_ifopt_cereal)

--- a/task_composer/core/CMakeLists.txt
+++ b/task_composer/core/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(
   src/task_composer_task.cpp
   src/yaml_utils.cpp)
 add_library(tesseract::task_composer ALIAS task_composer)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(task_composer PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(task_composer PROPERTIES OUTPUT_NAME tesseract_task_composer)
 
 target_link_libraries(

--- a/task_composer/core/CMakeLists.txt
+++ b/task_composer/core/CMakeLists.txt
@@ -21,8 +21,8 @@ add_library(
   src/task_composer_task.cpp
   src/yaml_utils.cpp)
 add_library(tesseract::task_composer ALIAS task_composer)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(task_composer PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(task_composer PROPERTIES OUTPUT_NAME tesseract_task_composer)

--- a/task_composer/core/include/tesseract/task_composer/cereal_serialization.h
+++ b/task_composer/core/include/tesseract/task_composer/cereal_serialization.h
@@ -104,9 +104,9 @@ void serialize(Archive& ar, TaskComposerLog& obj)
 
 }  // namespace tesseract::task_composer
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/task_composer/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_task_composer_core_cereal)

--- a/task_composer/core/include/tesseract/task_composer/cereal_serialization.h
+++ b/task_composer/core/include/tesseract/task_composer/cereal_serialization.h
@@ -104,6 +104,12 @@ void serialize(Archive& ar, TaskComposerLog& obj)
 
 }  // namespace tesseract::task_composer
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/task_composer/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_task_composer_core_cereal)
+#endif
 
 #endif  // TESSERACT_TASK_COMPOSER_CEREAL_SERIALIZATION_H

--- a/task_composer/core/src/cereal_serialization.cpp
+++ b/task_composer/core/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/task_composer/cereal_serialization.h>
+#include <tesseract/task_composer/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_task_composer_core_cereal)

--- a/task_composer/planning/CMakeLists.txt
+++ b/task_composer/planning/CMakeLists.txt
@@ -124,8 +124,8 @@ endif()
 
 add_library(task_composer_planning_nodes ${LIB_SOURCE_FILES})
 add_library(tesseract::task_composer_planning_nodes ALIAS task_composer_planning_nodes)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(task_composer_planning_nodes PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(task_composer_planning_nodes PROPERTIES OUTPUT_NAME tesseract_task_composer_planning_nodes)

--- a/task_composer/planning/CMakeLists.txt
+++ b/task_composer/planning/CMakeLists.txt
@@ -124,6 +124,10 @@ endif()
 
 add_library(task_composer_planning_nodes ${LIB_SOURCE_FILES})
 add_library(tesseract::task_composer_planning_nodes ALIAS task_composer_planning_nodes)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(task_composer_planning_nodes PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(task_composer_planning_nodes PROPERTIES OUTPUT_NAME tesseract_task_composer_planning_nodes)
 target_link_libraries(task_composer_planning_nodes PUBLIC ${LIB_SOURCE_LINK_LIBRARIES})
 target_compile_options(task_composer_planning_nodes PRIVATE ${TESSERACT_COMPILE_OPTIONS_PRIVATE})

--- a/task_composer/planning/include/tesseract/task_composer/planning/cereal_serialization.h
+++ b/task_composer/planning/include/tesseract/task_composer/planning/cereal_serialization.h
@@ -88,6 +88,12 @@ void serialize(Archive& ar, UpsampleTrajectoryProfile& obj)
 
 }  // namespace tesseract::task_composer
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/task_composer/planning/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_task_composer_planning_cereal)
+#endif
 
 #endif  // TESSERACT_TASK_COMPOSER_PLANNING_CEREAL_SERIALIZATION_H

--- a/task_composer/planning/include/tesseract/task_composer/planning/cereal_serialization.h
+++ b/task_composer/planning/include/tesseract/task_composer/planning/cereal_serialization.h
@@ -88,9 +88,9 @@ void serialize(Archive& ar, UpsampleTrajectoryProfile& obj)
 
 }  // namespace tesseract::task_composer
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/task_composer/planning/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_task_composer_planning_cereal)

--- a/task_composer/planning/src/cereal_serialization.cpp
+++ b/task_composer/planning/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/task_composer/planning/cereal_serialization.h>
+#include <tesseract/task_composer/planning/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_task_composer_planning_cereal)

--- a/time_parameterization/isp/CMakeLists.txt
+++ b/time_parameterization/isp/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_library(time_parameterization_isp src/iterative_spline_parameterization.cpp
                                       src/iterative_spline_parameterization_profiles.cpp)
 add_library(tesseract::time_parameterization_isp ALIAS time_parameterization_isp)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(time_parameterization_isp PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(time_parameterization_isp PROPERTIES OUTPUT_NAME tesseract_time_parameterization_isp)
 target_link_libraries(time_parameterization_isp PUBLIC tesseract::time_parameterization cereal::cereal)
 target_include_directories(time_parameterization_isp PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/time_parameterization/isp/CMakeLists.txt
+++ b/time_parameterization/isp/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(time_parameterization_isp src/iterative_spline_parameterization.cpp
                                       src/iterative_spline_parameterization_profiles.cpp)
 add_library(tesseract::time_parameterization_isp ALIAS time_parameterization_isp)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(time_parameterization_isp PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(time_parameterization_isp PROPERTIES OUTPUT_NAME tesseract_time_parameterization_isp)

--- a/time_parameterization/isp/include/tesseract/time_parameterization/isp/cereal_serialization.h
+++ b/time_parameterization/isp/include/tesseract/time_parameterization/isp/cereal_serialization.h
@@ -33,6 +33,12 @@ void serialize(Archive& ar, IterativeSplineParameterizationMoveProfile& obj)
 
 }  // namespace tesseract::time_parameterization
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/time_parameterization/isp/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_isp_cereal)
+#endif
 
 #endif  // TESSERACT_TIME_PARAMETERIZATION_ITERATIVE_SPLINE_PARAMETERIZATION_CEREAL_SERIALIZATION_H

--- a/time_parameterization/isp/include/tesseract/time_parameterization/isp/cereal_serialization.h
+++ b/time_parameterization/isp/include/tesseract/time_parameterization/isp/cereal_serialization.h
@@ -33,9 +33,9 @@ void serialize(Archive& ar, IterativeSplineParameterizationMoveProfile& obj)
 
 }  // namespace tesseract::time_parameterization
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/time_parameterization/isp/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_isp_cereal)

--- a/time_parameterization/isp/src/cereal_serialization.cpp
+++ b/time_parameterization/isp/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/time_parameterization/isp/cereal_serialization.h>
+#include <tesseract/time_parameterization/isp/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_time_parameterization_isp_cereal)

--- a/time_parameterization/kdl/CMakeLists.txt
+++ b/time_parameterization/kdl/CMakeLists.txt
@@ -2,6 +2,10 @@ find_package(tesseract REQUIRED COMPONENTS kinematics_kdl)
 add_library(time_parameterization_kdl src/constant_tcp_speed_parameterization.cpp
                                       src/constant_tcp_speed_parameterization_profiles.cpp)
 add_library(tesseract::time_parameterization_kdl ALIAS time_parameterization_kdl)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(time_parameterization_kdl PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(time_parameterization_kdl PROPERTIES OUTPUT_NAME tesseract_time_parameterization_kdl)
 target_link_libraries(time_parameterization_kdl PUBLIC tesseract::time_parameterization cereal::cereal)
 target_link_libraries(time_parameterization_kdl PRIVATE tesseract::kinematics_kdl)

--- a/time_parameterization/kdl/CMakeLists.txt
+++ b/time_parameterization/kdl/CMakeLists.txt
@@ -2,8 +2,8 @@ find_package(tesseract REQUIRED COMPONENTS kinematics_kdl)
 add_library(time_parameterization_kdl src/constant_tcp_speed_parameterization.cpp
                                       src/constant_tcp_speed_parameterization_profiles.cpp)
 add_library(tesseract::time_parameterization_kdl ALIAS time_parameterization_kdl)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(time_parameterization_kdl PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(time_parameterization_kdl PROPERTIES OUTPUT_NAME tesseract_time_parameterization_kdl)

--- a/time_parameterization/kdl/include/tesseract/time_parameterization/kdl/cereal_serialization.h
+++ b/time_parameterization/kdl/include/tesseract/time_parameterization/kdl/cereal_serialization.h
@@ -24,6 +24,12 @@ void serialize(Archive& ar, ConstantTCPSpeedParameterizationCompositeProfile& ob
 
 }  // namespace tesseract::time_parameterization
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/time_parameterization/kdl/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_kdl_cereal)
+#endif
 
 #endif  // TESSERACT_TIME_PARAMETERIZATION_CONSTANT_TCP_SPEED_PARAMETERIZATION_CEREAL_SERIALIZATION_H

--- a/time_parameterization/kdl/include/tesseract/time_parameterization/kdl/cereal_serialization.h
+++ b/time_parameterization/kdl/include/tesseract/time_parameterization/kdl/cereal_serialization.h
@@ -24,9 +24,9 @@ void serialize(Archive& ar, ConstantTCPSpeedParameterizationCompositeProfile& ob
 
 }  // namespace tesseract::time_parameterization
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/time_parameterization/kdl/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_kdl_cereal)

--- a/time_parameterization/kdl/src/cereal_serialization.cpp
+++ b/time_parameterization/kdl/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/time_parameterization/kdl/cereal_serialization.h>
+#include <tesseract/time_parameterization/kdl/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_time_parameterization_kdl_cereal)

--- a/time_parameterization/ruckig/CMakeLists.txt
+++ b/time_parameterization/ruckig/CMakeLists.txt
@@ -3,6 +3,10 @@ find_package(ruckig REQUIRED)
 add_library(time_parameterization_ruckig src/ruckig_trajectory_smoothing.cpp
                                          src/ruckig_trajectory_smoothing_profiles.cpp)
 add_library(tesseract::time_parameterization_ruckig ALIAS time_parameterization_ruckig)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(time_parameterization_ruckig PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(time_parameterization_ruckig PROPERTIES OUTPUT_NAME tesseract_time_parameterization_ruckig)
 target_link_libraries(time_parameterization_ruckig PUBLIC tesseract::time_parameterization ruckig::ruckig
                                                           cereal::cereal)

--- a/time_parameterization/ruckig/CMakeLists.txt
+++ b/time_parameterization/ruckig/CMakeLists.txt
@@ -3,8 +3,8 @@ find_package(ruckig REQUIRED)
 add_library(time_parameterization_ruckig src/ruckig_trajectory_smoothing.cpp
                                          src/ruckig_trajectory_smoothing_profiles.cpp)
 add_library(tesseract::time_parameterization_ruckig ALIAS time_parameterization_ruckig)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(time_parameterization_ruckig PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(time_parameterization_ruckig PROPERTIES OUTPUT_NAME tesseract_time_parameterization_ruckig)

--- a/time_parameterization/ruckig/include/tesseract/time_parameterization/ruckig/cereal_serialization.h
+++ b/time_parameterization/ruckig/include/tesseract/time_parameterization/ruckig/cereal_serialization.h
@@ -23,6 +23,12 @@ void serialize(Archive& ar, RuckigTrajectorySmoothingCompositeProfile& obj)
 }
 }  // namespace tesseract::time_parameterization
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/time_parameterization/ruckig/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_ruckig_cereal)
+#endif
 
 #endif  // TESSERACT_TIME_PARAMETERIZATION_RUCKIG_TRAJECTORY_SMOOTHING_CEREAL_SERIALIZATION_H

--- a/time_parameterization/ruckig/include/tesseract/time_parameterization/ruckig/cereal_serialization.h
+++ b/time_parameterization/ruckig/include/tesseract/time_parameterization/ruckig/cereal_serialization.h
@@ -23,9 +23,9 @@ void serialize(Archive& ar, RuckigTrajectorySmoothingCompositeProfile& obj)
 }
 }  // namespace tesseract::time_parameterization
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/time_parameterization/ruckig/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_ruckig_cereal)

--- a/time_parameterization/ruckig/src/cereal_serialization.cpp
+++ b/time_parameterization/ruckig/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/time_parameterization/ruckig/cereal_serialization.h>
+#include <tesseract/time_parameterization/ruckig/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_time_parameterization_ruckig_cereal)

--- a/time_parameterization/totg/CMakeLists.txt
+++ b/time_parameterization/totg/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_library(time_parameterization_totg src/time_optimal_trajectory_generation.cpp
                                        src/time_optimal_trajectory_generation_profiles.cpp)
 add_library(tesseract::time_parameterization_totg ALIAS time_parameterization_totg)
+if(NOT WIN32)
+  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+  target_sources(time_parameterization_totg PRIVATE src/cereal_serialization.cpp)
+endif()
 set_target_properties(time_parameterization_totg PROPERTIES OUTPUT_NAME tesseract_time_parameterization_totg)
 target_link_libraries(time_parameterization_totg PUBLIC tesseract::time_parameterization cereal::cereal)
 target_include_directories(time_parameterization_totg PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"

--- a/time_parameterization/totg/CMakeLists.txt
+++ b/time_parameterization/totg/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(time_parameterization_totg src/time_optimal_trajectory_generation.cpp
                                        src/time_optimal_trajectory_generation_profiles.cpp)
 add_library(tesseract::time_parameterization_totg ALIAS time_parameterization_totg)
-if(NOT WIN32)
-  # Compile the cereal polymorphic-type registration. On Windows it is registered in the header instead.
+if(NOT WIN32 AND NOT APPLE)
+  # Compile the cereal polymorphic-type registration. On Windows and macOS it is registered in the header instead.
   target_sources(time_parameterization_totg PRIVATE src/cereal_serialization.cpp)
 endif()
 set_target_properties(time_parameterization_totg PROPERTIES OUTPUT_NAME tesseract_time_parameterization_totg)

--- a/time_parameterization/totg/include/tesseract/time_parameterization/totg/cereal_serialization.h
+++ b/time_parameterization/totg/include/tesseract/time_parameterization/totg/cereal_serialization.h
@@ -25,9 +25,9 @@ void serialize(Archive& ar, TimeOptimalTrajectoryGenerationCompositeProfile& obj
 
 }  // namespace tesseract::time_parameterization
 
-// On Windows the cereal polymorphic-type registration must be in the header,
+// On Windows and macOS the cereal polymorphic-type registration must be in the header,
 // for other platforms registration is in the cpp.
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <tesseract/time_parameterization/totg/cereal_serialization_impl.hpp>
 #else
 CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_totg_cereal)

--- a/time_parameterization/totg/include/tesseract/time_parameterization/totg/cereal_serialization.h
+++ b/time_parameterization/totg/include/tesseract/time_parameterization/totg/cereal_serialization.h
@@ -25,6 +25,12 @@ void serialize(Archive& ar, TimeOptimalTrajectoryGenerationCompositeProfile& obj
 
 }  // namespace tesseract::time_parameterization
 
+// On Windows the cereal polymorphic-type registration must be in the header,
+// for other platforms registration is in the cpp.
+#ifdef _WIN32
 #include <tesseract/time_parameterization/totg/cereal_serialization_impl.hpp>
+#else
+CEREAL_FORCE_DYNAMIC_INIT(tesseract_time_parameterization_totg_cereal)
+#endif
 
 #endif  // TESSERACT_TIME_PARAMETERIZATION_TIME_OPTIMAL_TRAJECTORY_GENERATION_CEREAL_SERIALIZATION_H

--- a/time_parameterization/totg/src/cereal_serialization.cpp
+++ b/time_parameterization/totg/src/cereal_serialization.cpp
@@ -1,0 +1,4 @@
+#include <tesseract/time_parameterization/totg/cereal_serialization.h>
+#include <tesseract/time_parameterization/totg/cereal_serialization_impl.hpp>
+
+CEREAL_REGISTER_DYNAMIC_INIT(tesseract_time_parameterization_totg_cereal)


### PR DESCRIPTION
… via _impl headers for non-Windows builds.

See also https://github.com/tesseract-robotics/tesseract/pull/1305

PR https://github.com/tesseract-robotics/tesseract_planning/pull/742 caused a regression in build memory usage and build times. Reason was the heavy Cereal template instantiation whenever these headers were included. This PR reverts the template registration to cpp files for non-Windows builds.

This also adds [CEREAL_FORCE_DYNAMIC_INIT](https://uscilab.github.io/cereal/assets/doxygen/polymorphic_8hpp.html#a8e0d5df9830c0ed7c60451cf2f873ff5) in the header (non-Windows) to match CEREAL_REGISTER_DYNAMIC_INIT in the cpp.

Windows builds are not affected, the fix of the mentioned PR is still in place for that platform.