### PR TITLE
feat(ompl): add time bounding to simplifcation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package tesseract_planning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Unreleased
+----------
+* Add ``simplify_time`` to ``OMPLSolverConfig`` to time-bound OMPL path simplification (``simplifySolution(double)``); defaults to 0.0 which preserves the existing unbounded ``simplifyMax`` behavior
+
 0.35.0 (2026-05-28)
 -------------------
 * Update descartes tag

--- a/motion_planners/ompl/include/tesseract/motion_planners/ompl/cereal_serialization.h
+++ b/motion_planners/ompl/include/tesseract/motion_planners/ompl/cereal_serialization.h
@@ -147,6 +147,7 @@ void serialize(Archive& ar, OMPLSolverConfig& obj)
   ar(cereal::make_nvp("planning_time", obj.planning_time));
   ar(cereal::make_nvp("max_solutions", obj.max_solutions));
   ar(cereal::make_nvp("simplify", obj.simplify));
+  ar(cereal::make_nvp("simplify_time", obj.simplify_time));
   ar(cereal::make_nvp("optimize", obj.optimize));
   ar(cereal::make_nvp("planners", obj.planners));
 }

--- a/motion_planners/ompl/include/tesseract/motion_planners/ompl/ompl_solver_config.h
+++ b/motion_planners/ompl/include/tesseract/motion_planners/ompl/ompl_solver_config.h
@@ -54,6 +54,18 @@ struct OMPLSolverConfig
   bool simplify = false;
 
   /**
+   * @brief Maximum time in seconds to spend simplifying the solution path.
+   *
+   * Only used when @ref simplify is true.
+   *   - If <= 0 (default) the simplification runs to completion
+   *     (ompl::geometric::SimpleSetup::simplifySolution() -> PathSimplifier::simplifyMax), applying every
+   *     simplification step until done. This yields the most simplified path but is unbounded in time.
+   *   - If > 0 the simplification is time bounded (ompl::geometric::SimpleSetup::simplifySolution(double)),
+   *     trading some path quality for a predictable upper bound on simplification time.
+   */
+  double simplify_time = 0.0;
+
+  /**
    * @brief This uses all available planning time to create the most optimized trajectory given the objective function.
    *
    * This is required because not all OMPL planners are optimize graph planners. If the planner you choose is an

--- a/motion_planners/ompl/include/tesseract/motion_planners/ompl/yaml_extensions.h
+++ b/motion_planners/ompl/include/tesseract/motion_planners/ompl/yaml_extensions.h
@@ -605,6 +605,7 @@ struct convert<tesseract::motion_planners::OMPLSolverConfig>
     node["planning_time"] = rhs.planning_time;
     node["max_solutions"] = rhs.max_solutions;
     node["simplify"] = rhs.simplify;
+    node["simplify_time"] = rhs.simplify_time;
     node["optimize"] = rhs.optimize;
     node["planners"] = rhs.planners;
 
@@ -620,6 +621,8 @@ struct convert<tesseract::motion_planners::OMPLSolverConfig>
       rhs.max_solutions = n.as<int>();
     if (const YAML::Node& n = node["simplify"])
       rhs.simplify = n.as<bool>();
+    if (const YAML::Node& n = node["simplify_time"])
+      rhs.simplify_time = n.as<double>();
     if (const YAML::Node& n = node["optimize"])
       rhs.optimize = n.as<bool>();
     if (const YAML::Node& n = node["planners"])

--- a/motion_planners/ompl/src/ompl_motion_planner.cpp
+++ b/motion_planners/ompl/src/ompl_motion_planner.cpp
@@ -184,7 +184,11 @@ std::pair<bool, std::string> parallelPlan(ompl::geometric::SimpleSetup& simple_s
     return std::make_pair(false, std::string(ERROR_FAILED_TO_FIND_VALID_SOLUTION) + reason);
 
   if (solver_config.simplify)
-    simple_setup.simplifySolution();
+  {
+    // A positive simplify_time bounds the simplification routine; OMPL treats <= 0 (the default) as the
+    // unbounded simplifyMax which runs every simplification step to completion.
+    simple_setup.simplifySolution(solver_config.simplify_time);
+  }
 
   // Interpolate the path if there are currently fewer states than requested
   if (simple_setup.getSolutionPath().getStateCount() < num_output_states)

--- a/motion_planners/ompl/src/ompl_solver_config.cpp
+++ b/motion_planners/ompl/src/ompl_solver_config.cpp
@@ -35,6 +35,7 @@ bool OMPLSolverConfig::operator==(const OMPLSolverConfig& rhs) const
   equal &= tesseract::common::almostEqualRelativeAndAbs(planning_time, rhs.planning_time, max_diff);
   equal &= (max_solutions == rhs.max_solutions);
   equal &= (simplify == rhs.simplify);
+  equal &= tesseract::common::almostEqualRelativeAndAbs(simplify_time, rhs.simplify_time, max_diff);
   equal &= (optimize == rhs.optimize);
   equal &= (planners.size() == rhs.planners.size());
 

--- a/motion_planners/ompl/test/ompl_yaml_conversions_tests.cpp
+++ b/motion_planners/ompl/test/ompl_yaml_conversions_tests.cpp
@@ -569,6 +569,7 @@ TEST(OMPLYAMLTestFixture, OMPLYAMLOMPLSolverConfigConversionsUnit)  // NOLINT
     EXPECT_NEAR(configurator.planning_time, 5.0, 1e-6);
     EXPECT_EQ(configurator.max_solutions, 10);
     EXPECT_EQ(configurator.simplify, false);
+    EXPECT_NEAR(configurator.simplify_time, 0.0, 1e-6);
     EXPECT_EQ(configurator.optimize, true);
     EXPECT_EQ(configurator.planners.size(), 0);
   }
@@ -577,6 +578,7 @@ TEST(OMPLYAMLTestFixture, OMPLYAMLOMPLSolverConfigConversionsUnit)  // NOLINT
                                      planning_time: 2.0
                                      max_solutions: 4
                                      simplify: true
+                                     simplify_time: 0.5
                                      optimize: false
                                      planners:
                                        - SBLConfigurator: {}
@@ -601,6 +603,7 @@ TEST(OMPLYAMLTestFixture, OMPLYAMLOMPLSolverConfigConversionsUnit)  // NOLINT
     EXPECT_NEAR(configurator.planning_time, 2.0, 1e-6);
     EXPECT_EQ(configurator.max_solutions, 4);
     EXPECT_EQ(configurator.simplify, true);
+    EXPECT_NEAR(configurator.simplify_time, 0.5, 1e-6);
     EXPECT_EQ(configurator.optimize, false);
     EXPECT_EQ(containsType(OMPLPlannerType::SBL, configurator.planners), true);
     EXPECT_EQ(containsType(OMPLPlannerType::EST, configurator.planners), true);
@@ -623,6 +626,7 @@ TEST(OMPLYAMLTestFixture, OMPLYAMLOMPLSolverConfigConversionsUnit)  // NOLINT
     configurator.planning_time = 2.0;
     configurator.max_solutions = 4;
     configurator.simplify = true;
+    configurator.simplify_time = 0.5;
     configurator.optimize = false;
     configurator.planners.push_back(
         std::static_pointer_cast<const OMPLPlannerConfigurator>(std::make_shared<SBLConfigurator>()));
@@ -657,6 +661,7 @@ TEST(OMPLYAMLTestFixture, OMPLYAMLOMPLSolverConfigConversionsUnit)  // NOLINT
     EXPECT_NEAR(output_n["planning_time"].as<double>(), 2.0, 1e-6);
     EXPECT_EQ(output_n["max_solutions"].as<int>(), 4);
     EXPECT_EQ(output_n["simplify"].as<bool>(), true);
+    EXPECT_NEAR(output_n["simplify_time"].as<double>(), 0.5, 1e-6);
     EXPECT_EQ(output_n["optimize"].as<bool>(), false);
     EXPECT_TRUE(containsPlanner("SBLConfigurator", output_n["planners"]));
     EXPECT_TRUE(containsPlanner("ESTConfigurator", output_n["planners"]));


### PR DESCRIPTION
By default `simplifySolution()` → OMPL's `simplifyMax()`, which runs the full pipeline to completion: reduceVertices → collapseCloseVertices → shortcutPath (multiple rounds) → smoothBSpline. 

For most cases, any RRT detour removal almost entirely happens in `shortcutPath`, and it converges fast (within a second). This should get the path to be good enough for trajopt to optimise further (if desired)