### PR TITLE
Fix rosdep key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,9 +18,11 @@
   <build_export_depend>eigen</build_export_depend>
 
   <!-- Core dependencies -->
-  <depend>libconsole-bridge-dev</depend>
+  <build_depend>libconsole-bridge-dev</build_depend>
+  <exec_depend>libconsole-bridge</exec_depend>
   <depend>tesseract</depend>
-  <depend>cereal</depend>
+  <build_depend>cereal</build_depend>
+  <build_export_depend>cereal</build_export_depend>
   <depend>yaml-cpp</depend>
   <depend>boost_plugin_loader</depend>
 

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>ros_industrial_cmake_boilerplate</build_depend>
 
+  <build_depend>libtaskflow-cpp-dev</build_depend>
   <build_depend>eigen</build_depend>
   <build_export_depend>eigen</build_export_depend>
 
@@ -33,9 +34,6 @@
 
   <!-- Time parameterization -->
   <depend>ruckig</depend>
-
-  <!-- Task composer -->
-  <depend>taskflow</depend>
 
   <!-- Test dependencies -->
   <test_depend>gtest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
 
   <!-- Core dependencies -->
   <build_depend>libconsole-bridge-dev</build_depend>
-  <exec_depend>libconsole-bridge</exec_depend>
+  <exec_depend>libconsole-bridge-dev</exec_depend>
   <depend>tesseract</depend>
   <build_depend>cereal</build_depend>
   <build_export_depend>cereal</build_export_depend>


### PR DESCRIPTION
Fix rosdep key for TaskFlow. Key is available on [some](https://index.ros.org/d/libtaskflow-cpp-dev/) Ubuntu distributions. 

Additionally, make cereal and taskflow `build_depend` only since they are header-only. 

`libconsole-bridge-dev` has no `libconsole-bridge` rosdep key so use the `-dev` for both build and exec.

This reduces unnecessary runtime dependencies, resulting in smaller docker images.