### PR TITLE
Fix CartesianWaypoint::print() to include rotation

### DIFF
--- a/command_language/src/cartesian_waypoint.cpp
+++ b/command_language/src/cartesian_waypoint.cpp
@@ -27,10 +27,10 @@ void CartesianWaypoint::print(const std::string& prefix) const
 {
   const Eigen::Quaterniond q(transform_.rotation());
   std::cout << prefix << "Cart WP: xyz=" << transform_.translation().x() << ", " << transform_.translation().y()
-            << ", "                                                                             // NOLINT
-            << transform_.translation().z()                                                    // NOLINT
-            << " xyzw=" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w()          // NOLINT
-            << std::endl;                                                                       // NOLINT
+            << ", "                                                                  // NOLINT
+            << transform_.translation().z()                                          // NOLINT
+            << " xyzw=" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w()  // NOLINT
+            << std::endl;                                                            // NOLINT
 }
 
 std::unique_ptr<CartesianWaypointInterface> CartesianWaypoint::clone() const

--- a/command_language/src/cartesian_waypoint.cpp
+++ b/command_language/src/cartesian_waypoint.cpp
@@ -25,10 +25,12 @@ void CartesianWaypoint::setName(const std::string& name) { name_ = name; }
 const std::string& CartesianWaypoint::getName() const { return name_; }
 void CartesianWaypoint::print(const std::string& prefix) const
 {
+  const Eigen::Quaterniond q(transform_.rotation());
   std::cout << prefix << "Cart WP: xyz=" << transform_.translation().x() << ", " << transform_.translation().y()
-            << ", "                                        // NOLINT
-            << transform_.translation().z() << std::endl;  // NOLINT
-  // TODO: Add rotation
+            << ", "                                                                             // NOLINT
+            << transform_.translation().z()                                                    // NOLINT
+            << " xyzw=" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w()          // NOLINT
+            << std::endl;                                                                       // NOLINT
 }
 
 std::unique_ptr<CartesianWaypointInterface> CartesianWaypoint::clone() const


### PR DESCRIPTION
## Summary

`CartesianWaypoint::print()` only printed the XYZ translation and had a `// TODO: Add rotation` comment. This PR completes it by printing the rotation as a quaternion (xyzw).

## Change

```cpp
const Eigen::Quaterniond q(transform_.rotation());
std::cout << prefix << "Cart WP: xyz=..." << " xyzw=" << q.x() << ", " << q.y() << ", " << q.z() << ", " << q.w() << std::endl;
```
### Test

Verified with basic_cartesian_example in debug mode output now shows:
```
Cart WP: xyz=0.5, -0.2, 0.62 xyzw=0, 1, 0, 0
```
Note: This is a trivial fix but a deliberate first contribution to get familiar with the codebase and contribution workflow.