### PR TITLE
Fix joint limit enforcement discarded in OMPL JointWaypoint start/goal registration

### DIFF
--- a/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
+++ b/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
@@ -335,7 +335,7 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
 
   ompl::base::ScopedState<> goal_state(simple_setup.getStateSpace());
   for (unsigned i = 0; i < dof; ++i)
-    goal_state[i] = joint_waypoint[i];
+    goal_state[i] = solution[static_cast<Eigen::Index>(i)];
 
   simple_setup.setGoalState(goal_state);
 }
@@ -444,7 +444,7 @@ void OMPLRealVectorMoveProfile::applyStartStates(ompl::geometric::SimpleSetup& s
 
   ompl::base::ScopedState<> start_state(simple_setup.getStateSpace());
   for (unsigned i = 0; i < dof; ++i)
-    start_state[i] = joint_waypoint[i];
+    start_state[i] = solution[static_cast<Eigen::Index>(i)];
 
   simple_setup.addStartState(start_state);
 }


### PR DESCRIPTION
## Summary

- `applyGoalStates` and `applyStartStates` (JointGroup overloads) compute a limit-enforced copy of the waypoint (`solution`) via `satisfiesLimits`/`enforceLimits`, but then populate the OMPL state from the original `joint_waypoint` vector thereby discarding the clamped values.
- A joint value marginally outside the state space bounds (within the `1e-6` satisfiesLimits tolerance) would pass through unclamped into OMPL, producing an out-of-bounds start or goal state.
- The IK overloads of both functions already index `solution[j]` correctly  this aligns the JointWaypoint overloads with that established pattern.
