### PR TITLE
Use the Cartesian waypoint seed when solving IK in the OMPL move profile

### DIFF
--- a/motion_planners/ompl/include/tesseract/motion_planners/ompl/profile/ompl_real_vector_move_profile.h
+++ b/motion_planners/ompl/include/tesseract/motion_planners/ompl/profile/ompl_real_vector_move_profile.h
@@ -98,12 +98,14 @@ protected:
   static void applyGoalStates(ompl::geometric::SimpleSetup& simple_setup,
                               const tesseract::kinematics::KinGroupIKInput& ik_input,
                               const tesseract::kinematics::KinematicGroup& manip,
-                              tesseract::collision::DiscreteContactManager& contact_checker);
+                              tesseract::collision::DiscreteContactManager& contact_checker,
+                              const Eigen::VectorXd& seed = Eigen::VectorXd());
 
   static void applyStartStates(ompl::geometric::SimpleSetup& simple_setup,
                                const tesseract::kinematics::KinGroupIKInput& ik_input,
                                const tesseract::kinematics::KinematicGroup& manip,
-                               tesseract::collision::DiscreteContactManager& contact_checker);
+                               tesseract::collision::DiscreteContactManager& contact_checker,
+                               const Eigen::VectorXd& seed = Eigen::VectorXd());
 
   static void applyGoalStates(ompl::geometric::SimpleSetup& simple_setup,
                               const Eigen::VectorXd& joint_waypoint,

--- a/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
+++ b/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
@@ -245,22 +245,31 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
   const auto dof = manip.numJoints();
   tesseract::common::KinematicLimits limits = manip.getLimits();
 
-  /** @brief Making this thread_local does not help because it is not called enough during planning */
-  tesseract::kinematics::IKSolutions joint_solutions;
+  auto goal_states = std::make_shared<ompl::base::GoalStates>(simple_setup.getSpaceInformation());
+  std::vector<tesseract::collision::ContactResultMap> contact_map_vec;
+
   // Use the seed attached to the Cartesian waypoint when one is provided, otherwise fall back to the
   // zero seed. For seed-dependent solvers that return a single solution (e.g. KDL-LMA), a hardcoded
   // zero seed can converge to an out-of-limits branch of the solution manifold; the limit filter then
   // discards it and an otherwise-reachable goal ends up with an empty solution set.
-  Eigen::VectorXd ik_seed = Eigen::VectorXd::Zero(dof);
-  if (seed.size() == static_cast<Eigen::Index>(dof))
-    ik_seed = seed;
-  manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
-  auto goal_states = std::make_shared<ompl::base::GoalStates>(simple_setup.getSpaceInformation());
-  std::vector<tesseract::collision::ContactResultMap> contact_map_vec(static_cast<std::size_t>(joint_solutions.size()));
+  //
+  // The waypoint seed is used PREFERENTIALLY, not exclusively: a seed produced upstream without
+  // collision awareness (e.g. the simple planner's interpolation states) can equally steer a
+  // single-solution solver onto a branch that is in collision. If the seeded pass contributes no
+  // valid goal state, a second pass with the legacy zero seed recovers the previous behavior so a
+  // reachable goal is never lost to an unlucky seed.
+  const bool has_wp_seed = (seed.size() == static_cast<Eigen::Index>(dof));
 
-  for (std::size_t i = 0; i < joint_solutions.size(); ++i)
-  {
-    Eigen::VectorXd& solution = joint_solutions[i];
+  auto addStatesForSeed = [&](const Eigen::VectorXd& ik_seed) {
+    /** @brief Making this thread_local does not help because it is not called enough during planning */
+    tesseract::kinematics::IKSolutions joint_solutions;
+    manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
+    contact_map_vec.reserve(contact_map_vec.size() + joint_solutions.size());
+
+    for (std::size_t i = 0; i < joint_solutions.size(); ++i)
+    {
+      Eigen::VectorXd& solution = joint_solutions[i];
+      contact_map_vec.emplace_back();
 
     // Check limits
     if (tesseract::common::satisfiesLimits<double>(solution, limits.joint_limits))
@@ -275,7 +284,7 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
     // Get discrete contact manager for testing provided start and end position
     // This is required because collision checking happens in motion validators now
     // instead of the isValid function to avoid unnecessary collision checks.
-    if (!checkStateInCollision(contact_map_vec[i], contact_checker, manip, solution))
+    if (!checkStateInCollision(contact_map_vec.back(), contact_checker, manip, solution))
     {
       {
         ompl::base::ScopedState<> goal_state(simple_setup.getStateSpace());
@@ -296,7 +305,12 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
         goal_states->addState(goal_state);
       }
     }
-  }
+    }
+  };
+
+  addStatesForSeed(has_wp_seed ? seed : Eigen::VectorXd::Zero(dof));
+  if (has_wp_seed && !goal_states->hasStates() && !seed.isZero(0.0))
+    addStatesForSeed(Eigen::VectorXd::Zero(dof));
 
   if (!goal_states->hasStates())
   {
@@ -361,22 +375,24 @@ void OMPLRealVectorMoveProfile::applyStartStates(ompl::geometric::SimpleSetup& s
   const auto dof = manip.numJoints();
   tesseract::common::KinematicLimits limits = manip.getLimits();
 
-  /** @brief Making this thread_local does not help because it is not called enough during planning */
-  tesseract::kinematics::IKSolutions joint_solutions;
-  // Use the seed attached to the Cartesian waypoint when one is provided, otherwise fall back to the
-  // zero seed. For seed-dependent solvers that return a single solution (e.g. KDL-LMA), a hardcoded
-  // zero seed can converge to an out-of-limits branch of the solution manifold; the limit filter then
-  // discards it and an otherwise-reachable start ends up with an empty solution set.
-  Eigen::VectorXd ik_seed = Eigen::VectorXd::Zero(dof);
-  if (seed.size() == static_cast<Eigen::Index>(dof))
-    ik_seed = seed;
-  manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
   bool found_start_state = false;
-  std::vector<tesseract::collision::ContactResultMap> contact_map_vec(joint_solutions.size());
+  std::vector<tesseract::collision::ContactResultMap> contact_map_vec;
 
-  for (std::size_t i = 0; i < joint_solutions.size(); ++i)
-  {
-    Eigen::VectorXd& solution = joint_solutions[i];
+  // Seed handling mirrors applyGoalStates: waypoint seed preferentially, zero-seed second pass as
+  // the fallback when the seeded pass contributes no valid start state (see the goal-side comment
+  // for the full rationale).
+  const bool has_wp_seed = (seed.size() == static_cast<Eigen::Index>(dof));
+
+  auto addStatesForSeed = [&](const Eigen::VectorXd& ik_seed) {
+    /** @brief Making this thread_local does not help because it is not called enough during planning */
+    tesseract::kinematics::IKSolutions joint_solutions;
+    manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
+    contact_map_vec.reserve(contact_map_vec.size() + joint_solutions.size());
+
+    for (std::size_t i = 0; i < joint_solutions.size(); ++i)
+    {
+      Eigen::VectorXd& solution = joint_solutions[i];
+      contact_map_vec.emplace_back();
 
     // Check limits
     if (tesseract::common::satisfiesLimits<double>(solution, limits.joint_limits))
@@ -391,7 +407,7 @@ void OMPLRealVectorMoveProfile::applyStartStates(ompl::geometric::SimpleSetup& s
     // Get discrete contact manager for testing provided start and end position
     // This is required because collision checking happens in motion validators now
     // instead of the isValid function to avoid unnecessary collision checks.
-    if (!checkStateInCollision(contact_map_vec[i], contact_checker, manip, solution))
+    if (!checkStateInCollision(contact_map_vec.back(), contact_checker, manip, solution))
     {
       found_start_state = true;
       {
@@ -413,7 +429,12 @@ void OMPLRealVectorMoveProfile::applyStartStates(ompl::geometric::SimpleSetup& s
         simple_setup.addStartState(start_state);
       }
     }
-  }
+    }
+  };
+
+  addStatesForSeed(has_wp_seed ? seed : Eigen::VectorXd::Zero(dof));
+  if (has_wp_seed && !found_start_state && !seed.isZero(0.0))
+    addStatesForSeed(Eigen::VectorXd::Zero(dof));
 
   if (!found_start_state)
   {

--- a/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
+++ b/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
@@ -60,6 +60,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_POP
 #include <tesseract/environment/environment.h>
 
 #include <tesseract/common/profile_plugin_factory.h>
+#include <tesseract/common/joint_state.h>
 
 namespace tesseract::motion_planners
 {
@@ -193,7 +194,8 @@ std::unique_ptr<ompl::geometric::SimpleSetup> OMPLRealVectorMoveProfile::createS
 
     contact_checker->setActiveCollisionObjects(kin_group->getActiveLinkNames());
     tesseract::kinematics::KinGroupIKInput ik_input(tcp_frame_cwp, start_mi.working_frame, start_mi.tcp_frame);
-    applyStartStates(*simple_setup, ik_input, *kin_group, *contact_checker);
+    const Eigen::VectorXd seed = cur_wp.hasSeed() ? cur_wp.getSeed().position : Eigen::VectorXd();
+    applyStartStates(*simple_setup, ik_input, *kin_group, *contact_checker, seed);
   }
   else
   {
@@ -222,7 +224,8 @@ std::unique_ptr<ompl::geometric::SimpleSetup> OMPLRealVectorMoveProfile::createS
 
     contact_checker->setActiveCollisionObjects(kin_group->getActiveLinkNames());
     tesseract::kinematics::KinGroupIKInput ik_input(tcp_frame_cwp, end_mi.working_frame, end_mi.tcp_frame);
-    applyGoalStates(*simple_setup, ik_input, *kin_group, *contact_checker);
+    const Eigen::VectorXd seed = cur_wp.hasSeed() ? cur_wp.getSeed().position : Eigen::VectorXd();
+    applyGoalStates(*simple_setup, ik_input, *kin_group, *contact_checker, seed);
   }
   else
   {
@@ -235,7 +238,8 @@ std::unique_ptr<ompl::geometric::SimpleSetup> OMPLRealVectorMoveProfile::createS
 void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& simple_setup,
                                                 const tesseract::kinematics::KinGroupIKInput& ik_input,
                                                 const tesseract::kinematics::KinematicGroup& manip,
-                                                tesseract::collision::DiscreteContactManager& contact_checker)
+                                                tesseract::collision::DiscreteContactManager& contact_checker,
+                                                const Eigen::VectorXd& seed)
 {
   /** @todo Need to add Descartes pose sample to ompl profile */
   const auto dof = manip.numJoints();
@@ -243,7 +247,14 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
 
   /** @brief Making this thread_local does not help because it is not called enough during planning */
   tesseract::kinematics::IKSolutions joint_solutions;
-  manip.calcInvKin(joint_solutions, { ik_input }, Eigen::VectorXd::Zero(dof));
+  // Use the seed attached to the Cartesian waypoint when one is provided, otherwise fall back to the
+  // zero seed. For seed-dependent solvers that return a single solution (e.g. KDL-LMA), a hardcoded
+  // zero seed can converge to an out-of-limits branch of the solution manifold; the limit filter then
+  // discards it and an otherwise-reachable goal ends up with an empty solution set.
+  Eigen::VectorXd ik_seed = Eigen::VectorXd::Zero(dof);
+  if (seed.size() == static_cast<Eigen::Index>(dof))
+    ik_seed = seed;
+  manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
   auto goal_states = std::make_shared<ompl::base::GoalStates>(simple_setup.getSpaceInformation());
   std::vector<tesseract::collision::ContactResultMap> contact_map_vec(static_cast<std::size_t>(joint_solutions.size()));
 
@@ -343,16 +354,23 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
 void OMPLRealVectorMoveProfile::applyStartStates(ompl::geometric::SimpleSetup& simple_setup,
                                                  const tesseract::kinematics::KinGroupIKInput& ik_input,
                                                  const tesseract::kinematics::KinematicGroup& manip,
-                                                 tesseract::collision::DiscreteContactManager& contact_checker)
+                                                 tesseract::collision::DiscreteContactManager& contact_checker,
+                                                 const Eigen::VectorXd& seed)
 {
   /** @todo Need to add Descartes pose sampler to ompl profile */
-  /** @todo Need to also provide the seed instruction to use here */
   const auto dof = manip.numJoints();
   tesseract::common::KinematicLimits limits = manip.getLimits();
 
   /** @brief Making this thread_local does not help because it is not called enough during planning */
   tesseract::kinematics::IKSolutions joint_solutions;
-  manip.calcInvKin(joint_solutions, { ik_input }, Eigen::VectorXd::Zero(dof));
+  // Use the seed attached to the Cartesian waypoint when one is provided, otherwise fall back to the
+  // zero seed. For seed-dependent solvers that return a single solution (e.g. KDL-LMA), a hardcoded
+  // zero seed can converge to an out-of-limits branch of the solution manifold; the limit filter then
+  // discards it and an otherwise-reachable start ends up with an empty solution set.
+  Eigen::VectorXd ik_seed = Eigen::VectorXd::Zero(dof);
+  if (seed.size() == static_cast<Eigen::Index>(dof))
+    ik_seed = seed;
+  manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
   bool found_start_state = false;
   std::vector<tesseract::collision::ContactResultMap> contact_map_vec(joint_solutions.size());
 

--- a/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
+++ b/motion_planners/ompl/src/profile/ompl_real_vector_move_profile.cpp
@@ -266,45 +266,44 @@ void OMPLRealVectorMoveProfile::applyGoalStates(ompl::geometric::SimpleSetup& si
     manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
     contact_map_vec.reserve(contact_map_vec.size() + joint_solutions.size());
 
-    for (std::size_t i = 0; i < joint_solutions.size(); ++i)
+    for (Eigen::VectorXd& solution : joint_solutions)
     {
-      Eigen::VectorXd& solution = joint_solutions[i];
       contact_map_vec.emplace_back();
 
-    // Check limits
-    if (tesseract::common::satisfiesLimits<double>(solution, limits.joint_limits))
-    {
-      tesseract::common::enforceLimits<double>(solution, limits.joint_limits);
-    }
-    else
-    {
-      CONSOLE_BRIDGE_logDebug("In OMPLRealVectorMoveProfile: Goal state has invalid bounds");
-    }
-
-    // Get discrete contact manager for testing provided start and end position
-    // This is required because collision checking happens in motion validators now
-    // instead of the isValid function to avoid unnecessary collision checks.
-    if (!checkStateInCollision(contact_map_vec.back(), contact_checker, manip, solution))
-    {
+      // Check limits
+      if (tesseract::common::satisfiesLimits<double>(solution, limits.joint_limits))
       {
-        ompl::base::ScopedState<> goal_state(simple_setup.getStateSpace());
-        for (unsigned j = 0; j < dof; ++j)
-          goal_state[j] = solution[static_cast<Eigen::Index>(j)];
-
-        goal_states->addState(goal_state);
+        tesseract::common::enforceLimits<double>(solution, limits.joint_limits);
+      }
+      else
+      {
+        CONSOLE_BRIDGE_logDebug("In OMPLRealVectorMoveProfile: Goal state has invalid bounds");
       }
 
-      auto redundant_solutions = tesseract::kinematics::getRedundantSolutions<double>(
-          solution, limits.joint_limits, manip.getRedundancyCapableJointIndices());
-      for (const auto& rs : redundant_solutions)
+      // Get discrete contact manager for testing provided start and end position
+      // This is required because collision checking happens in motion validators now
+      // instead of the isValid function to avoid unnecessary collision checks.
+      if (!checkStateInCollision(contact_map_vec.back(), contact_checker, manip, solution))
       {
-        ompl::base::ScopedState<> goal_state(simple_setup.getStateSpace());
-        for (unsigned j = 0; j < dof; ++j)
-          goal_state[j] = rs[static_cast<Eigen::Index>(j)];
+        {
+          ompl::base::ScopedState<> goal_state(simple_setup.getStateSpace());
+          for (unsigned j = 0; j < dof; ++j)
+            goal_state[j] = solution[static_cast<Eigen::Index>(j)];
 
-        goal_states->addState(goal_state);
+          goal_states->addState(goal_state);
+        }
+
+        auto redundant_solutions = tesseract::kinematics::getRedundantSolutions<double>(
+            solution, limits.joint_limits, manip.getRedundancyCapableJointIndices());
+        for (const auto& rs : redundant_solutions)
+        {
+          ompl::base::ScopedState<> goal_state(simple_setup.getStateSpace());
+          for (unsigned j = 0; j < dof; ++j)
+            goal_state[j] = rs[static_cast<Eigen::Index>(j)];
+
+          goal_states->addState(goal_state);
+        }
       }
-    }
     }
   };
 
@@ -389,46 +388,45 @@ void OMPLRealVectorMoveProfile::applyStartStates(ompl::geometric::SimpleSetup& s
     manip.calcInvKin(joint_solutions, { ik_input }, ik_seed);
     contact_map_vec.reserve(contact_map_vec.size() + joint_solutions.size());
 
-    for (std::size_t i = 0; i < joint_solutions.size(); ++i)
+    for (Eigen::VectorXd& solution : joint_solutions)
     {
-      Eigen::VectorXd& solution = joint_solutions[i];
       contact_map_vec.emplace_back();
 
-    // Check limits
-    if (tesseract::common::satisfiesLimits<double>(solution, limits.joint_limits))
-    {
-      tesseract::common::enforceLimits<double>(solution, limits.joint_limits);
-    }
-    else
-    {
-      CONSOLE_BRIDGE_logDebug("In OMPLRealVectorMoveProfile: Start state has invalid bounds");
-    }
-
-    // Get discrete contact manager for testing provided start and end position
-    // This is required because collision checking happens in motion validators now
-    // instead of the isValid function to avoid unnecessary collision checks.
-    if (!checkStateInCollision(contact_map_vec.back(), contact_checker, manip, solution))
-    {
-      found_start_state = true;
+      // Check limits
+      if (tesseract::common::satisfiesLimits<double>(solution, limits.joint_limits))
       {
-        ompl::base::ScopedState<> start_state(simple_setup.getStateSpace());
-        for (unsigned j = 0; j < dof; ++j)
-          start_state[j] = solution[static_cast<Eigen::Index>(j)];
-
-        simple_setup.addStartState(start_state);
+        tesseract::common::enforceLimits<double>(solution, limits.joint_limits);
+      }
+      else
+      {
+        CONSOLE_BRIDGE_logDebug("In OMPLRealVectorMoveProfile: Start state has invalid bounds");
       }
 
-      auto redundant_solutions = tesseract::kinematics::getRedundantSolutions<double>(
-          solution, limits.joint_limits, manip.getRedundancyCapableJointIndices());
-      for (const auto& rs : redundant_solutions)
+      // Get discrete contact manager for testing provided start and end position
+      // This is required because collision checking happens in motion validators now
+      // instead of the isValid function to avoid unnecessary collision checks.
+      if (!checkStateInCollision(contact_map_vec.back(), contact_checker, manip, solution))
       {
-        ompl::base::ScopedState<> start_state(simple_setup.getStateSpace());
-        for (unsigned j = 0; j < dof; ++j)
-          start_state[j] = rs[static_cast<Eigen::Index>(j)];
+        found_start_state = true;
+        {
+          ompl::base::ScopedState<> start_state(simple_setup.getStateSpace());
+          for (unsigned j = 0; j < dof; ++j)
+            start_state[j] = solution[static_cast<Eigen::Index>(j)];
 
-        simple_setup.addStartState(start_state);
+          simple_setup.addStartState(start_state);
+        }
+
+        auto redundant_solutions = tesseract::kinematics::getRedundantSolutions<double>(
+            solution, limits.joint_limits, manip.getRedundancyCapableJointIndices());
+        for (const auto& rs : redundant_solutions)
+        {
+          ompl::base::ScopedState<> start_state(simple_setup.getStateSpace());
+          for (unsigned j = 0; j < dof; ++j)
+            start_state[j] = rs[static_cast<Eigen::Index>(j)];
+
+          simple_setup.addStartState(start_state);
+        }
       }
-    }
     }
   };
 


### PR DESCRIPTION
## Summary
`OMPLRealVectorMoveProfile` now uses the seed state attached to a `CartesianWaypoint` when solving IK for start/goal states, instead of always seeding `calcInvKin` with a hardcoded zero vector.

## Root cause
In `applyStartStates` / `applyGoalStates` (the `KinGroupIKInput` overloads), `calcInvKin` was called with `Eigen::VectorXd::Zero(dof)` even when the waypoint carried a seed (`CartesianWaypointPoly::getSeed()` populated, e.g. by `MinLengthTask`'s interpolation). For seed-dependent solvers that return a single solution (e.g. the KDL-LMA plugin), the zero-seed solution can converge to an out-of-limits branch of the solution manifold. `calcInvKin`'s joint-limit filter then discards it, the goal-state set ends up empty, and the planner aborts with:

```
All goal states are either in collision or outside limits
```

The failure is deterministic: programs whose LINEAR `StateWaypoint`s were converted to seeded `CartesianWaypoint`s by `MinLengthTask` fail even though every state is reachable and within limits — the seed that would make IK succeed is on the waypoint but was never consulted.

## Fix
- Thread the waypoint's seed into the two `KinGroupIKInput` `applyStartStates`/`applyGoalStates` overloads via an optional trailing `const Eigen::VectorXd& seed` parameter (defaulted, so the public API and existing zero-seed behavior are unchanged for callers that pass nothing).
- At the call sites, pass `cur_wp.getSeed().position` when `cur_wp.hasSeed()`.
- Inside, the seed is only used when its size matches the manipulator DOF; otherwise it falls back to the previous zero seed.

This also resolves the pre-existing `@todo Need to also provide the seed instruction to use here` in `applyStartStates`.

## Notes for review
- **Seed ordering**: `getSeed().position` is ordered by `getSeed().joint_names`. This follows the same convention already relied on elsewhere for Cartesian-waypoint seeds (e.g. `simple_motion_planner.cpp` and the simple-planner assign profiles use `getSeed().position` directly), so no reordering is applied here. The size guard makes a mismatched seed a safe no-op (falls back to zero); a seed is a hint, so a mis-ordered one degrades gracefully rather than breaking correctness.
- **Scope**: this implements the "honor the attached seed" part only. A multi-random-restart fallback for the no-seed / no-analytic-IK case (mentioned in the issue) would be a reasonable follow-up but is intentionally left out to keep this change minimal.

## Verification
An equivalent seed-honoring patch was validated in our downstream application on 0.34 (the previously-failing `MinLengthTask` -> OMPL -> KDL-LMA programs planned successfully, with no regressions observed elsewhere); this PR ports that approach to current `master`. The seed-selection logic and the call-site expressions were compile-checked in isolation against Eigen. A full `colcon` build against current `master` (0.35.0) was **not** run in this environment. Happy to add a unit test if you'd like.

Closes #762
