### PR TITLE
Move ccache setup into colcon-action@v15

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -8,6 +8,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   deploy_documentation:
     runs-on: ubuntu-18.04

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   clang_format:
     runs-on: ubuntu-24.04

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cmake_format:
     runs-on: ubuntu-22.04

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -28,14 +28,13 @@ jobs:
         include:
           - job_type: clang-tidy
             env:
-              TARGET_CMAKE_ARGS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CLANG_TIDY=ON -DTESSERACT_ENABLE_TESTING=ON -DCLANG_TIDY_NAMES=clang-tidy-17"
+              TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CLANG_TIDY=ON -DTESSERACT_ENABLE_TESTING=ON -DCLANG_TIDY_NAMES=clang-tidy-17"
           - job_type: codecov
             env:
-              TARGET_CMAKE_ARGS: "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
+              TARGET_CMAKE_ARGS: "-DCMAKE_BUILD_TYPE=Debug -DTESSERACT_ENABLE_CODE_COVERAGE=ON -DTESSERACT_WARNINGS_AS_ERRORS=OFF"
     container:
       image: ghcr.io/tesseract-robotics/trajopt:jammy-master
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.job_type }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -58,7 +57,7 @@ jobs:
           apt install -y clang-tidy-17 libomp-17-dev libompl-dev taskflow
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/trajopt/install/setup.bash
           ccache-prefix: ${{ matrix.job_type }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -17,6 +17,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.job_type }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -10,6 +10,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   conda-win:
     runs-on: windows-2022

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
   
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -20,6 +20,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   VCPKG_PKGS: >- 
     boost-dll boost-program-options boost-stacktrace

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -78,9 +78,9 @@ jobs:
         echo "DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}/lib" >> "$GITHUB_ENV"
         echo "CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$GITHUB_WORKSPACE/vcpkg/installed/${{ matrix.config.vcpkg_triplet }}" >> "$GITHUB_ENV"
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v14
+      uses: tesseract-robotics/colcon-action@v15
       with:
-        ccache-prefix: ci-mac-build-${{ matrix.config.name }}
+        ccache-prefix: ci-mac-build-${{ matrix.config.arch }}
         vcs-file: .github/workflows/windows_dependencies.repos
         rosdep-enabled: false
         upstream-args: >-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/trajopt:${{ matrix.distro }}
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -50,10 +49,10 @@ jobs:
           apt install -y libtaskflow-cpp-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/trajopt/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: nightly-${{ matrix.distro }}
           vcs-file: dependencies.repos
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     if: contains(github.event.pull_request.labels.*.name, 'check-tesseract-ros') || github.event.schedule == true

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -8,6 +8,11 @@ on:
   # allow manually starting this workflow
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-tag:
     # Pre-job to fetch the latest tag

--- a/.github/workflows/package_debian.yml
+++ b/.github/workflows/package_debian.yml
@@ -76,7 +76,7 @@ jobs:
           apt install -y libtaskflow-cpp-dev
 
       - name: Build and test
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/trajopt/install/setup.bash
           ccache-enabled: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,6 +20,11 @@ on:
     types:
       - released
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   get-tag:
     # Pre-job to fetch the latest tag

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,7 +58,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/trajopt:${{ matrix.distro }}-${{ needs.get-tag.outputs.major }}.${{ needs.get-tag.outputs.minor }}
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -87,10 +86,10 @@ jobs:
           apt install -y libtaskflow-cpp-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/trajopt/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: ubuntu-${{ matrix.distro }}
           vcs-file: dependencies.repos
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -32,7 +32,6 @@ jobs:
     container:
       image: ghcr.io/tesseract-robotics/trajopt:${{ matrix.distro }}-master
       env:
-        CCACHE_DIR: "$GITHUB_WORKSPACE/${{ matrix.distro }}/.ccache"
         DEBIAN_FRONTEND: noninteractive
         TZ: Etc/UTC
     steps:
@@ -61,10 +60,10 @@ jobs:
           apt install -y libtaskflow-cpp-dev
 
       - name: Build and Tests
-        uses: tesseract-robotics/colcon-action@v14
+        uses: tesseract-robotics/colcon-action@v15
         with:
           before-script: source /opt/tesseract/install/setup.bash && source /opt/trajopt/install/setup.bash
-          ccache-prefix: ${{ matrix.distro }}
+          ccache-prefix: unstable-${{ matrix.distro }}
           vcs-file: dependencies_unstable.repos
           upstream-args: --cmake-args -DCMAKE_BUILD_TYPE=Release
           target-path: target_ws/src

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -21,6 +21,11 @@ on:
       - released
   workflow_dispatch:
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.distro }}-unstable

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,9 +56,9 @@ jobs:
         echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE\vcpkg\installed\x64-windows-release" >> "$GITHUB_ENV"
 
     - name: Build and Tests
-      uses: tesseract-robotics/colcon-action@v14
+      uses: tesseract-robotics/colcon-action@v15
       with:
-        ccache-prefix: ${{ matrix.distro }}
+        ccache-prefix: ${{ matrix.os }}
         vcs-file: .github/workflows/windows_dependencies.repos
         upstream-args: --cmake-args -G "Ninja" -DVCPKG_TARGET_TRIPLET=x64-windows-release -DCMAKE_BUILD_TYPE=Release -DBUILD_IPOPT=OFF -DBUILD_SNOPT=OFF -DTESSERACT_BUILD_TRAJOPT_IFOPT=ON -DVCPKG_APPLOCAL_DEPS=OFF
         target-path: target_ws/src

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ on:
       - 'motion_planners/**'
       - 'time_parameterization/**'
       - 'task_composer/**'
-      - ".github/workflows/unstable.yml"
+      - ".github/workflows/windows.yml"
       - "**.repos"
   schedule:
     - cron: '0 5 * * *'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,11 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Supersede in-progress pull-request runs; queue everything else so two runs on one ref never race.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: ${{ matrix.os }}


### PR DESCRIPTION
Second in the series that moves ccache wiring out of the workflows and into
[colcon-action](https://github.com/tesseract-robotics/colcon-action); tesseract#1351 was the first.
Fixes tesseract#1345 and tesseract#1346 for this repo.

### What was wrong

**`CCACHE_DIR` pointed where nothing was cached.** Four workflows set it in the container `env:` map
as a literal `$GITHUB_WORKSPACE/...`. GitHub never runs a shell over that map, so the variable stayed
unexpanded. On noble ccache expands `$VAR` in its own config (4.9+) and it happened to work; on jammy
(4.5.1) it did not, and the directory handed to `actions/cache` was not the directory ccache filled.
`@v15` resolves the path by asking ccache, so the line is deleted rather than corrected.

**Two `ccache-prefix` values named a matrix key their matrix does not define.** An undefined
`matrix.x` is not an error in Actions — it expands to the empty string:

| file | prefix | matrix defines | effect |
| --- | --- | --- | --- |
| `mac.yml` | `ci-mac-build-${{ matrix.config.name }}` | `config.arch`, not `config.name` | **live**: `x64` and `arm64` shared one entry and evicted each other every run |
| `windows.yml` | `${{ matrix.distro }}` | `os`, not `distro` | latent: one leg, so nothing to collide with yet |

**Three workflows shared one restore namespace.** `@v15`'s restore key is
`<prefix>-<runner.os>-ccache-<github.job>-`, and the job id is `ci` in `ubuntu`, `unstable` and
`nightly` alike, so an identical `${{ matrix.distro }}` prefix put three different build
configurations in one `ccache-maxsize` cap. They are now `ubuntu-`, `unstable-` and `nightly-`
prefixed. `code_quality.yml` keeps `${{ matrix.job_type }}`, which was already distinct.

**The compiler launcher in `code_quality.yml`'s `TARGET_CMAKE_ARGS`** is now redundant — `@v15`
exports both `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER` into the environment,
where colcon's last-wins `--cmake-args` cannot drop them.

**`windows.yml` never ran on its own changes.** Its `pull_request: paths:` list named
`.github/workflows/unstable.yml`, evidently a copy-paste, so a change confined to `windows.yml` did
not trigger the workflow it belongs to. Fixed in its own commit.

`package_debian.yml` is bumped in its own commit. `ccache-enabled: false` opts out of ccache, not out
of the action, and v14→v15 also carries `$SUDO` handling and `action_repository` changes.

### Every workflow is cold exactly once

`@v14`'s restore key used lowercase `linux`; `@v15` uses `${{ runner.os }}`, which is `Linux`. No
`@v14` entry can prefix-match a `@v15` restore key, so every workflow here is cold on its first run
after this merges regardless of the prefix renames. One cold run, then normal.

### Measured

Two consecutive runs on this branch, cold then warm. `Nightly` was measured out-of-band (see below).

| leg | cold | warm | warm hit rate |
| --- | --- | --- | --- |
| unstable jammy / noble | 16.2 / 15.8 m | **9.8 / 9.2 m** | 512/512 (100%) · 245/255 (96.1%) |
| nightly jammy / noble | 16.8 / 15.7 m | **9.6 / 7.7 m** | 512/512 (100%) · 245/255 (96.1%) |
| code_quality clang-tidy | 37.6 m | **31.7 m** | 512/512 (100%) |
| code_quality codecov | 8.6 m | **1.6 m** | 512/512 (100%) |
| mac x64 / arm64 | 52.0 / 43.4 m | **14.7 / 9.2 m** | 627/656 (95.6%) both legs |
| windows | 41.8 m | **7.7 m** | 525/525 (100%) |

clang-tidy gains least because ccache caches compilation, not the analyzer pass, which is the bulk of
that job. Windows gains most because `@v14`'s `windows/action.yml` had no ccache at all — that 34
minutes is new, and it is ccache's alone: the vcpkg cache key was byte-identical across both runs.

A warm hit rate below 100% is expected on noble and macOS and is not a defect. Newer CMake runs its
`try_compile` probes from `CMakeFiles/CMakeScratch/TryCompile-<random>/`, and a randomised path is
part of ccache's hash, so those calls can never hit. jammy reads 100% only because cmake 3.22 uses a
stable path. The shortfall is identical on cold and warm runs — 10 calls on noble, 29 on macOS — which
is how you tell it from a real miss. Likewise Windows' `Uncacheable calls: 89 / 614` is invariant to
cache state: those are link steps.

`Cache size (GB)` peaked at 0.25 / 1.00, so the `1G` cap has ample headroom on this repo despite it
being the heaviest build in the series.

### Pre-existing failures, none of them caused by this PR

Censused on `master` at 6ba9f46 before the first edit:

- **`Ubuntu` is red on `master` itself.** It pins the released image tag
  `trajopt:<distro>-<major>.<minor>`, which still ships pre-#734 tesseract, and master now uses
  `JointState::joint_ids`. It fails at `cartesian_waypoint_poly.cpp` until a new tesseract release is
  tagged. `Nightly` and `Package-Debian-Build` pin release tags too and will fail the same way.
  Everything up to the compile error still exercises the cache, so the restore/save signals are
  readable; the build-time comparison is not.
- **`Nightly` cannot run at all, by any route.** Its schedule condition compares
  `github.event.schedule == true`; GitHub coerces the mismatched types to number, a non-numeric
  string becomes `NaN`, so that branch is always false. The `check-tesseract-ros` label its other
  branch tests does not exist in this repository. The same condition also gates out
  `workflow_dispatch`. And its container image, `trajopt:${{ matrix.distro }}`, has never been
  published — every tag is `<distro>-master` or `<distro>-<version>`, so a run that did start would
  fail at `Initialize containers` with `manifest unknown`. Reverting any one of those four leaves the
  other three. Reported, not fixed here: reviving it is a separate change with its own risk, and a
  nightly that suddenly starts running against a release image would fail exactly as `Ubuntu` does
  today. Its ccache configuration was verified out-of-band on a throwaway fork branch instead.
- **`Deploy Documentation` (`api_docs.yml`) is dead.** `runs-on: ubuntu-18.04`, a label retired in
  2022, so every run queues until GitHub cancels it — 106 runs, none successful. Untouched here.

### Verification

Worked in two phases, because the two changes in this PR are verified by opposite actions — ccache
needs two runs that both complete, cancellation needs a push that interrupts one.

**Phase A — ccache.** Two consecutive runs, cold then warm. On every workflow: `CCACHE_DIR` resolved
by the action to a real path, `Statistics zeroed` after the restore, both `CMAKE_C_` and
`CMAKE_CXX_COMPILER_LAUNCHER` exported, a real `Cache saved with key:`, then on the second run
`Cache restored from key:` naming the first run's key. Zero `::warning::` from the action anywhere,
and no `Path Validation Error` in any post-job cleanup.

The renamed prefixes are visible in the keys and confirm the fixes did what they claim:
`ci-mac-build-arm64-…` and `ci-mac-build-x64-…` now restore separately where they previously shared
one entry, and `ubuntu-`, `unstable-` and `nightly-` no longer collide.

Two things `@v15` promises that a normal run does not exercise were confirmed incidentally, because
`Ubuntu` fails: **the cache is saved after a failed build** (`Cache saved with key:` on both legs of a
run whose build step failed), and it is restored again on the next run.

**Phase B — concurrency.** Pushed, waited for the matrix to go live, pushed again. Both times **7 of 7
in-flight runs cancelled**, while runs that had already completed stayed `success` — cancellation
supersedes only what is still live. Repeated on the force-push that dropped the throwaway commit, so
the observation was taken twice.

`nightly.yml`'s concurrency lines ship unexercised, because nothing in this repository can trigger
that workflow. See above.

**`package_debian.yml`** was verified by `workflow_dispatch` on a fork, since no pull request can
trigger a tag-push workflow. The action's `Configure ccache` step correctly reports
`outcome=skipped` under `ccache-enabled: false`, with no warnings; the run then fails at the same
pre-existing `JointState` error as `Ubuntu`.

**`nightly.yml`** was verified on a throwaway fork branch carrying two commits that are not part of
this PR — the gating `if:` removed and the image pointed at a tag that exists — since neither of
those is what this PR changes. What it exercises is nightly's ccache configuration, and that came
back cold-then-warm at 100% / 96.1% with keys correctly distinct from `ubuntu-`.
